### PR TITLE
perf(core): optimize primary evaluation loops by caching propagated states (fixes #3)

### DIFF
--- a/backend/app/services/collision_engine.py
+++ b/backend/app/services/collision_engine.py
@@ -34,14 +34,25 @@ class CollisionEngine:
         predictions = []
         now = datetime.datetime.utcnow()
 
-        for i in range(len(objects)):
-            for j in range(i + 1, len(objects)):
-                obj_a = objects[i]
-                obj_b = objects[j]
-                try:
-                    r_a, v_a = orbit_engine.propagate_state(obj_a.tle_line1, obj_a.tle_line2, now)
-                    r_b, v_b = orbit_engine.propagate_state(obj_b.tle_line1, obj_b.tle_line2, now)
+        # Batch process / memoize states to prevent redundant O(N^2) propagation calls
+        propagated_states = []
+        for obj in objects:
+            try:
+                r, v = orbit_engine.propagate_state(obj.tle_line1, obj.tle_line2, now)
+                propagated_states.append((obj, r, v))
+            except Exception as e:
+                logger.warning(f"Failed to propagate state for {obj.catalog_number}: {e}")
+                propagated_states.append((obj, None, None))
 
+        for i in range(len(propagated_states)):
+            obj_a, r_a, v_a = propagated_states[i]
+            if r_a is None:
+                continue
+            for j in range(i + 1, len(propagated_states)):
+                obj_b, r_b, v_b = propagated_states[j]
+                if r_b is None:
+                    continue
+                try:
                     distance_km = orbit_engine.calculate_distance(r_a, r_b)
 
                     if distance_km < 15.0:


### PR DESCRIPTION
### Summary
This PR optimizes the primary evaluation loop in `predict_collisions` by converting O(N²) repetitive orbital state propagations into an O(N) batch computation structure with O(1) pairwise lookups.

### Motivation
Closes #3
When running the daily collision predictions over the active TLE catalog, the engine was calling `orbit_engine.propagate_state()` inside the nested `i` and `j` comparison loop. This means for `N` orbital objects, the CPU was performing an intensive state calculation `N * (N - 1)` times instead of just `N` times, leading to severe computational bottleneck and slow scanning rates.

### Changes
- Refactored `backend/app/services/collision_engine.py` to memoize the propagated states.
- Iterated through the list of spatial objects once to propagate and cache all coordinates and velocities in an array.
- Adjusted the pairwise inner loop to cross-reference the pre-cached distances rather than recalculating them dynamically.
- Handled invalid/un-propagated objects gracefully.

### Impact & Side Effects
- CPU usage and evaluation time is reduced exponentially. O(N²) state evaluations become O(N) state evaluations followed by fast O(N²) arithmetic distance comparisons.
- Memory footprint increases trivially since `(r, v)` tuples are now cached for the iteration.
- No behavioral changes or regressions in prediction outcomes.

### How to Test
1. Make a POST request to `/api/v1/collisions/evaluate`.
2. Notice the response time returning significantly faster while finding the exact same number of predictions as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision prediction reliability by safely handling objects whose movement data cannot be propagated.
  * Preserved existing distance, probability, and risk calculations while improving processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->