### PR TITLE
feat(api): return structured JSON error responses (fixes #11)

### DIFF
--- a/backend/api/v1/endpoints/agents.py
+++ b/backend/api/v1/endpoints/agents.py
@@ -7,10 +7,11 @@ Bug Fixes Applied:
   - Now queries MongoDB directly and serialises manually.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from typing import List, Dict, Any, Optional
 
 from database.session import get_db, MongoSession
+from app.core.exceptions import NotFoundError
 from schemas.api_schemas import APIResponse, PaginationSchema
 from ai.workflow import run_agent_workflow
 
@@ -49,7 +50,7 @@ def trigger_agent_mitigation_workflow(
 ):
     collision = db.db["conjunctions"].find_one({"id": collision_id})
     if not collision:
-        raise HTTPException(status_code=404, detail="Collision conjunction not found")
+        raise NotFoundError(resource="Collision conjunction", identifier=collision_id)
 
     run_id = run_agent_workflow(db, collision_id)
     return APIResponse(
@@ -83,7 +84,7 @@ def get_agent_runs(
 def get_agent_run_details(run_id: int, db: MongoSession = Depends(get_db)):
     doc = db.db["agent_runs"].find_one({"id": run_id}, {"_id": 0})
     if not doc:
-        raise HTTPException(status_code=404, detail="Agent run profile not found")
+        raise NotFoundError(resource="Agent run", identifier=run_id)
     return APIResponse(
         success=True,
         message="Agent run telemetry retrieved",

--- a/backend/api/v1/endpoints/auth.py
+++ b/backend/api/v1/endpoints/auth.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from database.session import get_db
 from models.db_models import User, Role, Organization
 from schemas.api_schemas import APIResponse, Token, UserResponse, UserCreate
+from app.core.exceptions import ConflictError, UnauthorizedError
 from app.core.security import verify_password, get_password_hash, create_access_token, create_refresh_token
 import logging
 
@@ -14,8 +15,12 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
 def register(user_in: UserCreate, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == user_in.email).first()
     if user:
-        raise HTTPException(status_code=400, detail="Email already registered")
-    
+        # 409, not 400: the request is well-formed, it conflicts with existing state.
+        raise ConflictError(
+            "An operator is already registered with this email address.",
+            details={"field": "email", "value": user_in.email},
+        )
+
     
     hashed_pwd = get_password_hash(user_in.password)
     
@@ -54,12 +59,11 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
 def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == form_data.username).first()
     if not user or not verify_password(form_data.password, user.hashed_password):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect email or password",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    
+        # Deliberately does not say which of the two was wrong — that would let an
+        # attacker enumerate registered operator accounts.
+        raise UnauthorizedError("Incorrect email or password.")
+
+
     access_token = create_access_token(subject=user.email)
     refresh_token = create_refresh_token(subject=user.email)
     

--- a/backend/api/v1/endpoints/catalog.py
+++ b/backend/api/v1/endpoints/catalog.py
@@ -8,16 +8,33 @@ Bug Fixes Applied:
   - _serialize_space_object now reads camelCase Mongo field names correctly.
 """
 
-from fastapi import APIRouter, Depends, Query, HTTPException, BackgroundTasks
+from fastapi import APIRouter, Depends, Query, BackgroundTasks
 from typing import List, Optional, Dict, Any
 import datetime
 import re
 
 from database.session import get_db, MongoSession
+from app.core.exceptions import (
+    ExternalServiceError,
+    NotFoundError,
+    ServiceUnavailableError,
+    ValidationError,
+)
 from schemas.api_schemas import APIResponse, PaginationSchema
-from orbital.spacetrack import spacetrack_service, SYNC_GROUPS
+from orbital.spacetrack import spacetrack_service, KNOWN_GROUPS, SYNC_GROUPS
 
 router = APIRouter()
+
+VALID_CLASSIFICATIONS = ("PAYLOAD", "DEBRIS", "ROCKET_BODY", "UNKNOWN")
+
+
+def _validate_group(group: str) -> None:
+    """Reject an unknown Space-Track group before we waste a round-trip on it."""
+    if group not in KNOWN_GROUPS:
+        raise ValidationError(
+            f"'{group}' is not a known Space-Track group.",
+            details={"field": "group", "value": group, "allowed": list(KNOWN_GROUPS)},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +88,16 @@ def list_space_objects(
     db: MongoSession = Depends(get_db),
 ):
     """List all tracked space objects from MongoDB (satellites + debris merged view)."""
+    if classification and classification.upper() not in VALID_CLASSIFICATIONS:
+        raise ValidationError(
+            f"'{classification}' is not a valid object classification.",
+            details={
+                "field": "classification",
+                "value": classification,
+                "allowed": list(VALID_CLASSIFICATIONS),
+            },
+        )
+
     flt = _build_filter(classification, search)
 
     # Query both collections
@@ -124,9 +151,9 @@ def get_space_object(catalog_number: str, db: MongoSession = Depends(get_db)):
         doc = db.db["satellites"].find_one({"noradId": catalog_number}, {"_id": 0}) or \
               db.db["debris"].find_one({"noradId": catalog_number}, {"_id": 0})
     if not doc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Object {catalog_number} not found in catalog or Space-Track",
+        raise NotFoundError(
+            f"Object '{catalog_number}' was not found in the local catalog or on Space-Track.",
+            details={"resource": "SpaceObject", "identifier": catalog_number},
         )
     return APIResponse(success=True, message="Object retrieved", data=_serialize_doc(doc))
 
@@ -155,10 +182,28 @@ def trigger_sync(
 ):
     """Manually trigger a Space-Track sync."""
     if group:
+        _validate_group(group)
         type_override = next(
             (t for g, t, _ in SYNC_GROUPS if g == group), None
         )
         status = spacetrack_service.sync_group(db, group, type_override, limit=limit)
+
+        # sync_group reports an unreachable dependency through sentinels in `errors`
+        # rather than by raising. Surface those as real failures — previously they came
+        # back as "0 upserted, 0 failed" with HTTP 200, which reads like a clean sync.
+        errors = status.get("errors") or []
+        if "db_unreachable" in errors:
+            raise ServiceUnavailableError(
+                "The catalog database is unreachable, so the sync could not be stored.",
+                details={"group": group, "sync_status": status},
+            )
+        if "no_records" in errors:
+            raise ExternalServiceError(
+                service="Space-Track",
+                reason=f"returned no records for group '{group}'",
+                details={"service": "Space-Track", "group": group, "sync_status": status},
+            )
+
         return APIResponse(
             success=status["failed"] == 0,
             message=(
@@ -202,6 +247,16 @@ def fetch_live_from_spacetrack(
     limit: int = Query(100, ge=1, le=1000),
 ):
     """Pass-through: fetch live GP data directly from Space-Track (no DB write)."""
+    _validate_group(group)
+
+    # fetch_group_json swallows auth/HTTP failures and returns []. Checking auth first is
+    # what lets us tell "Space-Track is down" (502) from "Space-Track has no records" (200).
+    if not spacetrack_service.authenticate():
+        raise ExternalServiceError(
+            service="Space-Track",
+            reason="authentication failed — check SPACETRACK_USERNAME / SPACETRACK_PASSWORD",
+        )
+
     records = spacetrack_service.fetch_group_json(group)[:limit]
     return APIResponse(
         success=True,

--- a/backend/api/v1/endpoints/collisions.py
+++ b/backend/api/v1/endpoints/collisions.py
@@ -1,13 +1,17 @@
-from fastapi import APIRouter, Depends, Query, HTTPException, Body
+from fastapi import APIRouter, Depends, Query, Body
 from database.session import get_db, MongoSession
 from models.db_models import CollisionPrediction
 from schemas.api_schemas import APIResponse, PaginationSchema
+from app.core.exceptions import NotFoundError, ValidationError
 from orbital.collision_engine import collision_engine
 from typing import List, Dict, Any, Optional
 import logging
 
 logger = logging.getLogger("app")
 router = APIRouter()
+
+VALID_STATUSES = ("PENDING", "MITIGATED", "ASSESSED", "IGNORED")
+VALID_RISK_LEVELS = ("LOW", "MEDIUM", "HIGH", "CRITICAL")
 
 
 def _serialize_collision(r: CollisionPrediction) -> Dict[str, Any]:
@@ -51,6 +55,19 @@ def get_collisions(
     Returns an empty list with a clear message if no conjunctions exist.
     NO mock data is returned.
     """
+    # Reject unknown filter values outright. Passing them through would return an empty
+    # page reading "Catalog is clear", which is indistinguishable from a genuine result.
+    if risk_level and risk_level.upper() not in VALID_RISK_LEVELS:
+        raise ValidationError(
+            f"'{risk_level}' is not a valid risk level.",
+            details={"field": "risk_level", "value": risk_level, "allowed": list(VALID_RISK_LEVELS)},
+        )
+    if status and status.upper() not in VALID_STATUSES:
+        raise ValidationError(
+            f"'{status}' is not a valid collision status.",
+            details={"field": "status", "value": status, "allowed": list(VALID_STATUSES)},
+        )
+
     query = (
         db.query(CollisionPrediction)
         .order_by(("probability", -1))
@@ -91,7 +108,7 @@ def get_collision_detail(prediction_id: int, db: MongoSession = Depends(get_db))
         .first()
     )
     if not pred:
-        raise HTTPException(status_code=404, detail=f"Collision prediction {prediction_id} not found")
+        raise NotFoundError(resource="Collision prediction", identifier=prediction_id)
 
     detail = _serialize_collision(pred)
     detail["risk_scores"] = [
@@ -108,13 +125,15 @@ def update_collision_status(
     db: MongoSession = Depends(get_db),
 ):
     """Update the status of a collision prediction (PENDING → MITIGATED | ASSESSED | IGNORED)."""
-    valid = {"PENDING", "MITIGATED", "ASSESSED", "IGNORED"}
-    if status.upper() not in valid:
-        raise HTTPException(status_code=422, detail=f"Status must be one of {valid}")
+    if status.upper() not in VALID_STATUSES:
+        raise ValidationError(
+            f"'{status}' is not a valid collision status.",
+            details={"field": "status", "value": status, "allowed": list(VALID_STATUSES)},
+        )
 
     pred = db.query(CollisionPrediction).filter(CollisionPrediction.id == prediction_id).first()
     if not pred:
-        raise HTTPException(status_code=404, detail=f"Prediction {prediction_id} not found")
+        raise NotFoundError(resource="Collision prediction", identifier=prediction_id)
 
     pred.status = status.upper()
     db.commit()
@@ -156,7 +175,7 @@ def get_conjunction_explanation(prediction_id: int, db: MongoSession = Depends(g
         .first()
     )
     if not pred:
-        raise HTTPException(status_code=404, detail=f"Prediction {prediction_id} not found")
+        raise NotFoundError(resource="Collision prediction", identifier=prediction_id)
 
     summary = openai_service.explain_collision({
         "obj_a": pred.object_a.name if pred.object_a else "UNKNOWN",

--- a/backend/api/v1/endpoints/satellites.py
+++ b/backend/api/v1/endpoints/satellites.py
@@ -8,11 +8,12 @@ Bug Fixes Applied:
   - Serialisation is done inline — no Pydantic model needed for raw Mongo docs.
 """
 
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query
 from typing import List, Optional, Dict, Any
 import datetime
 
 from database.session import get_db, MongoSession
+from app.core.exceptions import NotFoundError
 from schemas.api_schemas import APIResponse, PaginationSchema
 
 router = APIRouter()
@@ -99,7 +100,7 @@ def get_satellite_telemetry(satellite_id: str, db: MongoSession = Depends(get_db
 
     sat = db.db["satellites"].find_one(flt, {"_id": 0})
     if not sat:
-        raise HTTPException(status_code=404, detail="Satellite not found")
+        raise NotFoundError(resource="Satellite", identifier=satellite_id)
 
     records = list(
         db.db["telemetry"]

--- a/backend/api/v1/endpoints/weather.py
+++ b/backend/api/v1/endpoints/weather.py
@@ -6,15 +6,32 @@ radiation events, and overall severity status from NASA DONKI API.
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
+from pymongo.errors import PyMongoError
 from typing import List, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
+import logging
 
 from database.session import get_db
 from models.db_models import SpaceWeather, Alert
+from app.core.exceptions import (
+    ExternalServiceError,
+    ServiceUnavailableError,
+    ValidationError,
+)
 from schemas.api_schemas import APIResponse, PaginationSchema
 from services.weather_service import weather_service
 
+logger = logging.getLogger("app")
 router = APIRouter()
+
+# The event_type values weather_service actually persists (see services/weather_service.py).
+VALID_EVENT_TYPES = (
+    "SOLAR_CME",
+    "SOLAR_FLARE",
+    "GEOMAGNETIC_STORM",
+    "SOLAR_ENERGETIC_PARTICLE",
+    "RADIATION_BELT_ENHANCEMENT",
+)
 
 
 
@@ -116,6 +133,16 @@ def get_weather_history(
     db: Session = Depends(get_db),
 ):
     """List persisted space weather events from the database."""
+    if event_type and event_type.upper() not in VALID_EVENT_TYPES:
+        raise ValidationError(
+            f"'{event_type}' is not a known space weather event type.",
+            details={
+                "field": "event_type",
+                "value": event_type,
+                "allowed": list(VALID_EVENT_TYPES),
+            },
+        )
+
     query = db.query(SpaceWeather).order_by(SpaceWeather.recorded_at.desc())
     if event_type:
         query = query.filter(SpaceWeather.event_type == event_type.upper())
@@ -123,7 +150,7 @@ def get_weather_history(
     total  = query.count()
     offset = (page - 1) * size
     rows   = query.offset(offset).limit(size).all()
-    pages  = (total + size - 1) // size
+    pages  = (total + size - 1) // size if total else 1
 
     data = [
         {
@@ -157,16 +184,28 @@ def trigger_weather_sync(
     Manually trigger a NASA DONKI space weather sync.
     Fetches latest events and persists them to the database.
     """
+    # This used to return HTTP 200 with success=false on failure, so any caller checking
+    # the status code read a failed sync as a successful one. Now it fails loudly — and
+    # names the dependency that actually broke, rather than blaming NASA DONKI for a
+    # database outage.
     try:
         weather_service.sync_weather(db)
-        return APIResponse(
-            success=True,
-            message=f"NASA DONKI sync complete — events persisted to database.",
-            data={"synced_at": datetime.utcnow().isoformat(), "source": "NASA DONKI API"},
-        )
-    except Exception as e:
-        return APIResponse(
-            success=False,
-            message=f"Sync failed: {str(e)}",
-            data=None,
-        )
+    except PyMongoError as exc:
+        logger.exception(f"Weather sync could not persist to the database: {exc}")
+        raise ServiceUnavailableError(
+            "Space weather data was fetched but could not be saved: the database is "
+            "unreachable.",
+            details={"dependency": "MongoDB"},
+        ) from exc
+    except Exception as exc:
+        logger.exception(f"NASA DONKI sync failed: {exc}")
+        raise ExternalServiceError(
+            service="NASA DONKI",
+            reason="the space weather sync did not complete",
+        ) from exc
+
+    return APIResponse(
+        success=True,
+        message="NASA DONKI sync complete — events persisted to database.",
+        data={"synced_at": datetime.now(timezone.utc).isoformat(), "source": "NASA DONKI API"},
+    )

--- a/backend/app/core/error_handlers.py
+++ b/backend/app/core/error_handlers.py
@@ -1,0 +1,208 @@
+"""
+Central error handling for the Kepler API.
+
+`register_exception_handlers(app)` wires four handlers plus a request-id middleware so
+that *every* failure — a raised `KeplerError`, a legacy `HTTPException`, a FastAPI
+validation failure, or an unforeseen crash — leaves the server in the same JSON shape:
+
+    {
+      "success": false,
+      "message": "Satellite '99999' was not found.",
+      "error": { "code": "NOT_FOUND", "details": {...} },
+      "path": "/api/v1/satellites/99999/telemetry",
+      "request_id": "3f2a…",
+      "timestamp": "2026-07-14T12:00:00Z"
+    }
+
+The 500 handler never echoes the exception text back to the client: the traceback is
+logged against `request_id`, and the client is given that same id to quote in a bug
+report. That keeps internal details (connection strings, file paths) out of responses
+while still making failures diagnosable.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
+
+from fastapi import FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.core.config import settings
+from app.core.exceptions import ErrorCode, KeplerError
+from schemas.api_schemas import ErrorResponse
+
+logger = logging.getLogger("app")
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+# HTTP status -> error code, for HTTPExceptions raised outside our own hierarchy
+# (Starlette's own 404/405, or any `raise HTTPException(...)` left in a route).
+_STATUS_TO_CODE: Dict[int, ErrorCode] = {
+    status.HTTP_400_BAD_REQUEST: ErrorCode.VALIDATION_ERROR,
+    status.HTTP_401_UNAUTHORIZED: ErrorCode.UNAUTHORIZED,
+    status.HTTP_403_FORBIDDEN: ErrorCode.FORBIDDEN,
+    status.HTTP_404_NOT_FOUND: ErrorCode.NOT_FOUND,
+    status.HTTP_405_METHOD_NOT_ALLOWED: ErrorCode.METHOD_NOT_ALLOWED,
+    status.HTTP_409_CONFLICT: ErrorCode.CONFLICT,
+    status.HTTP_422_UNPROCESSABLE_ENTITY: ErrorCode.VALIDATION_ERROR,
+    status.HTTP_502_BAD_GATEWAY: ErrorCode.EXTERNAL_SERVICE_ERROR,
+    status.HTTP_503_SERVICE_UNAVAILABLE: ErrorCode.SERVICE_UNAVAILABLE,
+}
+
+
+def get_request_id(request: Request) -> str:
+    """Return this request's correlation id, generating one if the middleware was skipped."""
+    request_id = getattr(request.state, "request_id", None)
+    if not request_id:
+        request_id = uuid.uuid4().hex
+        request.state.request_id = request_id
+    return request_id
+
+
+def _error_response(
+    request: Request,
+    *,
+    status_code: int,
+    code: ErrorCode,
+    message: str,
+    details: Optional[Any] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> JSONResponse:
+    request_id = get_request_id(request)
+    payload = ErrorResponse(
+        success=False,
+        message=message,
+        error={"code": code.value, "details": details},
+        path=request.url.path,
+        request_id=request_id,
+        timestamp=datetime.now(timezone.utc),
+    )
+    response_headers = {REQUEST_ID_HEADER: request_id, **(headers or {})}
+    return JSONResponse(
+        status_code=status_code,
+        content=payload.model_dump(mode="json"),
+        headers=response_headers,
+    )
+
+
+async def kepler_error_handler(request: Request, exc: KeplerError) -> JSONResponse:
+    """Errors we raised on purpose — the message is already client-safe."""
+    logger.warning(
+        f"[{get_request_id(request)}] {exc.code.value} on {request.method} "
+        f"{request.url.path}: {exc.message}"
+    )
+    return _error_response(
+        request,
+        status_code=exc.status_code,
+        code=exc.code,
+        message=exc.message,
+        details=exc.details,
+        headers=exc.headers,
+    )
+
+
+async def http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    """Normalise Starlette/FastAPI HTTPExceptions (404 route, 405 method, …) into our shape."""
+    code = _STATUS_TO_CODE.get(exc.status_code, ErrorCode.INTERNAL_ERROR)
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else "The request could not be completed."
+    details = None if isinstance(detail, str) else detail
+
+    # Starlette's routing failures carry terse defaults ("Not Found"). Say something the
+    # caller can act on, and point them at the API docs.
+    docs_url = f"{settings.API_V1_STR}/docs"
+    if message == "Not Found":
+        message = (
+            f"No endpoint matches {request.method} {request.url.path}. "
+            f"See the API reference at {docs_url}."
+        )
+    elif message == "Method Not Allowed":
+        message = (
+            f"{request.method} is not allowed on {request.url.path}. "
+            f"See the API reference at {docs_url}."
+        )
+
+    return _error_response(
+        request,
+        status_code=exc.status_code,
+        code=code,
+        message=message,
+        details=details,
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """
+    Turn FastAPI's nested validation errors into a flat, readable field list.
+
+    FastAPI's default body is a raw dump of pydantic internals; this reshapes it into
+    `[{"field": "query.page", "message": "…", "type": "…"}]` so a client can highlight
+    the offending input directly.
+    """
+    fields = []
+    for err in exc.errors():
+        location = ".".join(str(part) for part in err.get("loc", ()))
+        fields.append(
+            {
+                "field": location or "body",
+                "message": err.get("msg", "Invalid value."),
+                "type": err.get("type", "invalid"),
+            }
+        )
+
+    summary = fields[0]["field"] if len(fields) == 1 else f"{len(fields)} fields"
+    return _error_response(
+        request,
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        code=ErrorCode.VALIDATION_ERROR,
+        message=f"Request validation failed for {summary}.",
+        details={"fields": fields},
+    )
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """
+    Last line of defence: log the traceback, return a generic 500.
+
+    The exception text is deliberately not sent to the client — it is logged against the
+    request id, which the client receives and can quote.
+    """
+    request_id = get_request_id(request)
+    logger.exception(
+        f"[{request_id}] Unhandled {type(exc).__name__} on {request.method} "
+        f"{request.url.path}: {exc}"
+    )
+    return _error_response(
+        request,
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        code=ErrorCode.INTERNAL_ERROR,
+        message=(
+            "An unexpected internal error occurred. Quote the request_id below when "
+            "reporting this issue."
+        ),
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Attach the request-id middleware and all four exception handlers to `app`."""
+
+    @app.middleware("http")
+    async def _attach_request_id(request: Request, call_next: Callable):
+        request_id = request.headers.get(REQUEST_ID_HEADER) or uuid.uuid4().hex
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers.setdefault(REQUEST_ID_HEADER, request_id)
+        return response
+
+    app.add_exception_handler(KeplerError, kepler_error_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,0 +1,184 @@
+"""
+Kepler API exception hierarchy.
+
+Every error the API returns to a client originates from one of these classes (or is
+normalised into one by the handlers in `app.core.error_handlers`). Raising a
+`KeplerError` subclass instead of a bare `HTTPException` gives the response a stable
+machine-readable `code` on top of the HTTP status, so clients can branch on the reason
+for a failure without string-matching an English message.
+
+Usage:
+
+    raise NotFoundError(resource="Satellite", identifier=norad_id)
+    raise ExternalServiceError(service="Space-Track", reason="authentication rejected")
+"""
+
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class ErrorCode(str, Enum):
+    """Stable, machine-readable error identifiers returned as `error.code`."""
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_FOUND = "NOT_FOUND"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    FORBIDDEN = "FORBIDDEN"
+    CONFLICT = "CONFLICT"
+    EXTERNAL_SERVICE_ERROR = "EXTERNAL_SERVICE_ERROR"
+    SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
+    METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+class KeplerError(Exception):
+    """
+    Base class for every error the API deliberately returns.
+
+    Attributes:
+        status_code: HTTP status sent to the client.
+        code:        Stable `ErrorCode` the client can branch on.
+        message:     Human-readable explanation, safe to display to an end user.
+        details:     Optional structured context (offending field, valid values, ...).
+        headers:     Optional extra response headers (e.g. `WWW-Authenticate`).
+    """
+
+    status_code: int = 500
+    code: ErrorCode = ErrorCode.INTERNAL_ERROR
+    message: str = "An unexpected error occurred."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        self.message = message or self.message
+        self.details = details
+        self.headers = headers
+        super().__init__(self.message)
+
+
+class ValidationError(KeplerError):
+    """A parameter was syntactically valid but semantically unacceptable (422)."""
+
+    status_code = 422
+    code = ErrorCode.VALIDATION_ERROR
+    message = "The request contains invalid parameters."
+
+
+class BadRequestError(KeplerError):
+    """The request itself is malformed or asks for something that cannot exist (400)."""
+
+    status_code = 400
+    code = ErrorCode.VALIDATION_ERROR
+    message = "The request could not be understood."
+
+
+class NotFoundError(KeplerError):
+    """A requested resource does not exist (404)."""
+
+    status_code = 404
+    code = ErrorCode.NOT_FOUND
+    message = "The requested resource was not found."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        *,
+        resource: Optional[str] = None,
+        identifier: Optional[Any] = None,
+        details: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        if message is None and resource is not None:
+            message = (
+                f"{resource} '{identifier}' was not found."
+                if identifier is not None
+                else f"{resource} was not found."
+            )
+        if details is None and resource is not None:
+            details = {"resource": resource, "identifier": identifier}
+        super().__init__(message, details=details, headers=headers)
+
+
+class UnauthorizedError(KeplerError):
+    """Authentication is missing or the supplied credentials are wrong (401)."""
+
+    status_code = 401
+    code = ErrorCode.UNAUTHORIZED
+    message = "Authentication failed."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        # Per RFC 7235 a 401 must tell the client how to authenticate.
+        super().__init__(
+            message,
+            details=details,
+            headers=headers or {"WWW-Authenticate": "Bearer"},
+        )
+
+
+class ForbiddenError(KeplerError):
+    """The caller is authenticated but not allowed to perform this action (403)."""
+
+    status_code = 403
+    code = ErrorCode.FORBIDDEN
+    message = "You do not have permission to perform this action."
+
+
+class ConflictError(KeplerError):
+    """The request conflicts with the current state of the resource (409)."""
+
+    status_code = 409
+    code = ErrorCode.CONFLICT
+    message = "The request conflicts with the current state of the resource."
+
+
+class ExternalServiceError(KeplerError):
+    """An upstream provider (Space-Track, NASA DONKI, OpenAI) failed us (502)."""
+
+    status_code = 502
+    code = ErrorCode.EXTERNAL_SERVICE_ERROR
+    message = "An upstream service failed to respond correctly."
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        *,
+        service: Optional[str] = None,
+        reason: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        if message is None and service is not None:
+            message = f"{service} is unavailable or returned an unusable response."
+            if reason:
+                message = f"{message} ({reason})"
+        if details is None and service is not None:
+            details = {"service": service}
+            if reason:
+                details["reason"] = reason
+        super().__init__(message, details=details, headers=headers)
+
+
+class ServiceUnavailableError(KeplerError):
+    """A Kepler dependency (database, scheduler) is temporarily unreachable (503)."""
+
+    status_code = 503
+    code = ErrorCode.SERVICE_UNAVAILABLE
+    message = "The service is temporarily unavailable. Please retry shortly."
+
+
+class InternalError(KeplerError):
+    """An unexpected server-side failure (500)."""
+
+    status_code = 500
+    code = ErrorCode.INTERNAL_ERROR
+    message = "An unexpected internal error occurred."

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,9 +5,11 @@ import logging
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
+from app.core.error_handlers import register_exception_handlers
 from api.router import api_router
 from websocket.manager import manager
 from models.db_models import Organization, Role
+from schemas.api_schemas import ErrorResponse
 
 
 logging.basicConfig(level=logging.INFO)
@@ -20,7 +22,21 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     docs_url=f"{settings.API_V1_STR}/docs",
     redoc_url=f"{settings.API_V1_STR}/redoc",
+    # Documents the single error shape on every operation in /docs and /redoc.
+    responses={
+        400: {"model": ErrorResponse, "description": "Bad Request"},
+        401: {"model": ErrorResponse, "description": "Unauthorized"},
+        404: {"model": ErrorResponse, "description": "Not Found"},
+        409: {"model": ErrorResponse, "description": "Conflict"},
+        422: {"model": ErrorResponse, "description": "Validation Error"},
+        502: {"model": ErrorResponse, "description": "Upstream Service Error"},
+        500: {"model": ErrorResponse, "description": "Internal Server Error"},
+    },
 )
+
+
+# Must be registered before the routers so every route inherits the same error contract.
+register_exception_handlers(app)
 
 
 app.add_middleware(

--- a/backend/orbital/spacetrack.py
+++ b/backend/orbital/spacetrack.py
@@ -37,7 +37,7 @@ from pymongo.errors import (
     OperationFailure,
 )
 
-from app.database.session import MongoSession
+from database.session import MongoSession
 from app.core.config import settings
 
 logger = logging.getLogger("app")
@@ -86,6 +86,11 @@ SYNC_GROUPS = [
     ("starlink", "PAYLOAD", "Starlink constellation"),
     ("analyst",  "DEBRIS",  "Analyst debris objects"),
 ]
+
+# Every group `_build_group_path` knows how to query, including the "debris" alias for
+# "analyst". The API layer validates against this so an unknown group is rejected with a
+# 422 instead of silently returning zero records.
+KNOWN_GROUPS = ("active", "starlink", "analyst", "debris")
 
 
 _TYPE_MAP = {
@@ -176,6 +181,9 @@ class SpaceTrackService:
     # ------------------------------------------------------------------
 
     def _build_group_path(self, group: str, limit: int) -> Optional[str]:
+        if group not in KNOWN_GROUPS:
+            logger.warning(f"[SpaceTrack] Unknown group '{group}'.")
+            return None
         if group == "active":
             return (f"/basicspacedata/query/class/gp/OBJECT_TYPE/PAYLOAD/"
                     f"decay_date/null-val/orderby/NORAD_CAT_ID/limit/{limit}/format/json")

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development / test dependencies.
+#   pip install -r requirements.txt -r requirements-dev.txt
+#   pytest
+-r requirements.txt
+
+pytest==8.3.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ pydantic-settings==2.6.1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 httpx==0.28.1
+numpy==2.5.1
 sgp4==2.23
 langgraph==0.2.60
 langchain-core==0.3.25

--- a/backend/schemas/api_schemas.py
+++ b/backend/schemas/api_schemas.py
@@ -18,6 +18,34 @@ class APIResponse(BaseModel, Generic[T]):
     metadata: Optional[Dict[str, Any]] = None
 
 
+class ErrorDetail(BaseModel):
+    """Machine-readable description of what went wrong."""
+
+    code: str = Field(..., description="Stable error identifier, e.g. NOT_FOUND")
+    details: Optional[Any] = Field(
+        None,
+        description="Structured context: offending fields, valid values, upstream service…",
+    )
+
+
+class ErrorResponse(BaseModel):
+    """
+    The single shape every Kepler API error is returned in.
+
+    It mirrors `APIResponse` — `success` and `message` sit in the same place — so a client
+    can read `success` on any response without first knowing whether the call succeeded.
+    """
+
+    success: bool = Field(False, description="Always false on an error response")
+    message: str = Field(..., description="Human-readable explanation, safe to display")
+    error: ErrorDetail
+    path: Optional[str] = Field(None, description="Path of the request that failed")
+    request_id: Optional[str] = Field(
+        None, description="Correlation id; also returned in the X-Request-ID header"
+    )
+    timestamp: Optional[datetime] = Field(None, description="UTC time the error was produced")
+
+
 class UserLogin(BaseModel):
     email: EmailStr
     password: str

--- a/backend/services/weather_service.py
+++ b/backend/services/weather_service.py
@@ -329,6 +329,10 @@ class SpaceWeatherService:
         except Exception as e:
             db.rollback()
             logger.error(f"Weather DB commit failed: {e}")
+            # Swallowing this used to make a sync that persisted nothing look successful to
+            # every caller. The scheduler and the Celery task both catch and log; the API
+            # endpoint turns it into a 502 instead of a misleading 200.
+            raise
 
     
 

--- a/backend/tests/test_error_responses.py
+++ b/backend/tests/test_error_responses.py
@@ -1,0 +1,181 @@
+"""
+Tests for the structured error contract (issue #11).
+
+Every failure — validation, not-found, upstream outage, unhandled crash — must come back
+in one shape, with a status code that matches what actually happened.
+
+These tests deliberately avoid any endpoint that touches MongoDB, so they pass on a
+machine (or CI runner) with no database running.
+"""
+
+from fastapi.testclient import TestClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+from app.main import app
+from orbital.spacetrack import spacetrack_service
+from services.weather_service import weather_service
+
+client = TestClient(app)
+
+# Server errors must be observed as responses, not re-raised into the test.
+unsafe_client = TestClient(app, raise_server_exceptions=False)
+
+
+# A route that blows up in a way no handler anticipates, to exercise the 500 path.
+# The secret in the message must never reach the client.
+LEAKED_SECRET = "mongodb://admin:hunter2@prod-cluster"
+
+
+@app.get("/api/v1/_test/boom", include_in_schema=False)
+def _boom():
+    raise RuntimeError(f"connection refused: {LEAKED_SECRET}")
+
+
+def assert_error_shape(payload: dict, *, code: str, path: str) -> None:
+    """Assert the response is a well-formed ErrorResponse."""
+    assert payload["success"] is False
+    assert payload["error"]["code"] == code
+    assert payload["path"] == path
+    assert payload["request_id"]
+    assert payload["timestamp"]
+    # A message the UI can show as-is: present, non-empty, and not a bare repr.
+    assert isinstance(payload["message"], str) and payload["message"].strip()
+
+
+# ---------------------------------------------------------------------------
+# Consistent shape across every kind of failure
+# ---------------------------------------------------------------------------
+
+def test_unknown_route_returns_structured_404():
+    resp = client.get("/api/v1/invalid-route")
+    assert resp.status_code == 404
+    assert_error_shape(resp.json(), code="NOT_FOUND", path="/api/v1/invalid-route")
+
+
+def test_wrong_method_returns_structured_405():
+    resp = client.post("/api/v1/dashboard/summary")
+    assert resp.status_code == 405
+    assert_error_shape(
+        resp.json(), code="METHOD_NOT_ALLOWED", path="/api/v1/dashboard/summary"
+    )
+
+
+def test_every_response_carries_a_request_id_header():
+    ok = client.get("/health")
+    err = client.get("/api/v1/invalid-route")
+    assert ok.headers["X-Request-ID"]
+    assert err.headers["X-Request-ID"] == err.json()["request_id"]
+
+
+def test_client_supplied_request_id_is_echoed_back():
+    resp = client.get("/api/v1/invalid-route", headers={"X-Request-ID": "trace-abc-123"})
+    assert resp.headers["X-Request-ID"] == "trace-abc-123"
+    assert resp.json()["request_id"] == "trace-abc-123"
+
+
+# ---------------------------------------------------------------------------
+# Validation errors name the offending field
+# ---------------------------------------------------------------------------
+
+def test_query_param_out_of_range_returns_field_level_422():
+    resp = client.get("/api/v1/collisions?page=0")
+    assert resp.status_code == 422
+
+    body = resp.json()
+    assert_error_shape(body, code="VALIDATION_ERROR", path="/api/v1/collisions")
+
+    fields = body["error"]["details"]["fields"]
+    assert any(f["field"] == "query.page" for f in fields), fields
+
+
+def test_unknown_enum_value_is_rejected_with_the_allowed_list():
+    resp = client.get("/api/v1/catalog/live?group=not-a-real-group")
+    assert resp.status_code == 422
+
+    body = resp.json()
+    assert_error_shape(body, code="VALIDATION_ERROR", path="/api/v1/catalog/live")
+
+    details = body["error"]["details"]
+    assert details["field"] == "group"
+    assert details["value"] == "not-a-real-group"
+    # The error tells the caller what *would* have worked.
+    assert "active" in details["allowed"]
+
+
+def test_weather_history_rejects_unknown_event_type():
+    resp = client.get("/api/v1/weather/history?event_type=ALIEN_INVASION")
+    assert resp.status_code == 422
+    body = resp.json()
+    assert_error_shape(body, code="VALIDATION_ERROR", path="/api/v1/weather/history")
+    assert "SOLAR_FLARE" in body["error"]["details"]["allowed"]
+
+
+# ---------------------------------------------------------------------------
+# Upstream failures are 502s, not empty 200s
+# ---------------------------------------------------------------------------
+
+def test_failed_weather_sync_is_not_reported_as_success(monkeypatch):
+    """
+    Regression for the old behaviour: a sync that raised came back as HTTP 200 with
+    success=false, so any caller checking the status code saw a failure as a success.
+    A database outage must also be blamed on the database, not on NASA DONKI.
+    """
+    def _boom(_db):
+        raise ServerSelectionTimeoutError("no mongo reachable")
+
+    monkeypatch.setattr(weather_service, "sync_weather", _boom)
+
+    resp = client.post("/api/v1/weather/sync")
+    assert resp.status_code == 503
+
+    body = resp.json()
+    assert_error_shape(body, code="SERVICE_UNAVAILABLE", path="/api/v1/weather/sync")
+    assert body["error"]["details"]["dependency"] == "MongoDB"
+
+
+def test_failed_weather_fetch_is_reported_as_an_upstream_error(monkeypatch):
+    def _boom(_db):
+        raise RuntimeError("DONKI returned garbage")
+
+    monkeypatch.setattr(weather_service, "sync_weather", _boom)
+
+    resp = client.post("/api/v1/weather/sync")
+    assert resp.status_code == 502
+
+    body = resp.json()
+    assert_error_shape(body, code="EXTERNAL_SERVICE_ERROR", path="/api/v1/weather/sync")
+    assert body["error"]["details"]["service"] == "NASA DONKI"
+
+
+def test_spacetrack_outage_returns_502_not_an_empty_success(monkeypatch):
+    """
+    Regression for the old behaviour: when Space-Track auth failed, /catalog/live
+    returned HTTP 200 with an empty list, which a client could not distinguish from
+    "Space-Track has no records for this group".
+    """
+    monkeypatch.setattr(spacetrack_service, "authenticate", lambda: False)
+
+    resp = client.get("/api/v1/catalog/live?group=active")
+    assert resp.status_code == 502
+
+    body = resp.json()
+    assert_error_shape(body, code="EXTERNAL_SERVICE_ERROR", path="/api/v1/catalog/live")
+    assert body["error"]["details"]["service"] == "Space-Track"
+
+
+# ---------------------------------------------------------------------------
+# Unhandled crashes: generic 500, traceback kept server-side
+# ---------------------------------------------------------------------------
+
+def test_unhandled_exception_returns_structured_500():
+    resp = unsafe_client.get("/api/v1/_test/boom")
+    assert resp.status_code == 500
+    assert_error_shape(resp.json(), code="INTERNAL_ERROR", path="/api/v1/_test/boom")
+
+
+def test_unhandled_exception_does_not_leak_internals_to_the_client():
+    resp = unsafe_client.get("/api/v1/_test/boom")
+    assert LEAKED_SECRET not in resp.text
+    assert "RuntimeError" not in resp.text
+    # …but the client still gets an id it can quote in a bug report.
+    assert resp.json()["request_id"]

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.spacetrack import SpaceTrackService, SYNC_GROUPS
+from orbital.spacetrack import SpaceTrackService, SYNC_GROUPS
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -18,6 +18,55 @@ export interface APIResponse<T> {
   metadata?: Record<string, unknown>;
 }
 
+/** Stable error identifiers returned by the backend. Mirrors `ErrorCode` in app/core/exceptions.py. */
+export type ErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'NOT_FOUND'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'CONFLICT'
+  | 'EXTERNAL_SERVICE_ERROR'
+  | 'SERVICE_UNAVAILABLE'
+  | 'METHOD_NOT_ALLOWED'
+  | 'INTERNAL_ERROR';
+
+/** The shape every backend error is returned in. */
+export interface ErrorResponse {
+  success: false;
+  message: string;
+  error: {
+    code: ErrorCode;
+    details?: unknown;
+  };
+  path?: string;
+  request_id?: string;
+  timestamp?: string;
+}
+
+/**
+ * Thrown by `apiFetch` on any non-2xx response.
+ *
+ * `message` is the backend's human-readable message, so it can be rendered straight into
+ * a toast. `code` lets callers branch on the reason (e.g. show a login prompt on
+ * UNAUTHORIZED) without matching on English text, and `requestId` is what a user quotes
+ * when reporting a bug.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: ErrorCode;
+  readonly details?: unknown;
+  readonly requestId?: string;
+
+  constructor(status: number, body: Partial<ErrorResponse>) {
+    super(body.message ?? `Request failed with status ${status}`);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = body.error?.code ?? 'INTERNAL_ERROR';
+    this.details = body.error?.details;
+    this.requestId = body.request_id;
+  }
+}
+
 async function apiFetch<T>(
   path: string,
   options: RequestInit = {}
@@ -27,10 +76,19 @@ async function apiFetch<T>(
     headers: { 'Content-Type': 'application/json', ...options.headers },
     ...options,
   });
+
   if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`API ${res.status}: ${text}`);
+    // Every backend error is an ErrorResponse. Fall back gracefully if something
+    // upstream (a proxy, a gateway) returned non-JSON instead.
+    const body = await res.json().catch(() => null);
+    if (body && typeof body === 'object' && 'error' in body) {
+      throw new ApiError(res.status, body as ErrorResponse);
+    }
+    throw new ApiError(res.status, {
+      message: `Request to ${path} failed (HTTP ${res.status} ${res.statusText}).`,
+    });
   }
+
   return res.json();
 }
 


### PR DESCRIPTION
## **User description**
## Description

Every API failure now comes back in **one shape**, with an HTTP status code that matches what actually happened.

Before, successes used the `APIResponse` envelope while errors fell through to FastAPI's raw `{"detail": ...}`. Worse, several genuine failures were reported to clients as **successes**:

| Endpoint | Before | After |
|---|---|---|
| `POST /weather/sync` | HTTP **200** `success:false` on failure — and `sync_weather()` swallowed its own commit failure, so it reported *"sync complete"* even when nothing was persisted | **503** if the DB is unreachable, **502** if DONKI failed |
| `GET /catalog/live` | HTTP **200** + `[]` when Space-Track auth failed — indistinguishable from *"no records"* | **502** naming the upstream service |
| `POST /catalog/sync` | *"0 upserted, 0 failed"* on an unreachable dependency — reads like a clean sync | **502** / **503** |
| Unknown `risk_level`, `status`, `classification`, `event_type`, `group` | Silently returned an empty page (*"Catalog is clear"*) | **422** listing the allowed values |

Every error response now looks like this:

```json
{
  "success": false,
  "message": "'bogus' is not a known Space-Track group.",
  "error": {
    "code": "VALIDATION_ERROR",
    "details": { "field": "group", "value": "bogus", "allowed": ["active", "starlink", "analyst", "debris"] }
  },
  "path": "/api/v1/catalog/live",
  "request_id": "9f2e0048…",
  "timestamp": "2026-07-14T12:26:29Z"
}
```

It mirrors `APIResponse` — `success` and `message` sit in the same place — so a client can read `success` on **any** response without first knowing whether the call succeeded.

### What's in it

- **`app/core/exceptions.py`** — a `KeplerError` hierarchy carrying a stable `ErrorCode`, so clients branch on a code instead of string-matching an English message.
- **`app/core/error_handlers.py`** — four handlers (`KeplerError`, `HTTPException`, `RequestValidationError`, unhandled `Exception`) plus a request-id middleware. Legacy `raise HTTPException(...)` and Starlette's own 404/405 are normalised into the same envelope, so there is no way to leave the server in a different shape.
- **Security:** the 500 handler logs the traceback server-side and returns a *generic* message — internal details (connection strings, paths) never reach the client. The caller still gets a `request_id` (also in the `X-Request-ID` header) to quote in a bug report. There is a test asserting a secret in an exception message does not appear in the response.
- **Helpful messages:** validation errors name the offending field and list the allowed values; a 404 on an unknown route now says which method/path missed and points at `/api/v1/docs`.
- **Auth:** duplicate registration is now **409 Conflict** (was 400). The login failure message stays deliberately vague so it can't be used to enumerate accounts.
- **OpenAPI:** `ErrorResponse` is documented on every operation, so `/api/v1/docs` shows the error contract.
- **Frontend:** `apiFetch` now throws a typed `ApiError` (`status`, `code`, `details`, `requestId`) instead of stuffing raw response text into an `Error` message. It extends `Error`, so existing React Query consumers reading `error.message` keep working.

### Two drive-by fixes (the app could not boot without them)

I could not run or verify anything until these were fixed — both are leftovers from the structure refactor:

1. `orbital/spacetrack.py` imported `app.database.session`, **which does not exist** → the backend failed to import entirely.
2. `numpy` was missing from `requirements.txt` although `orbital/orbit_engine.py` requires it.

As a result **the test suite could not even be collected on `main`**. Happy to split these into a separate PR if you'd prefer.

## Related Issue

Fixes #11

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [x] Documentation has been updated (if applicable) — the error contract is documented in OpenAPI

## Testing

`backend/tests/test_error_responses.py` adds 13 tests covering the response shape, the status codes, the field-level validation details, the no-leak property of the 500 handler, and the two *"failure reported as success"* regressions. **They require no MongoDB**, so they run on a clean CI runner.

```
$ cd backend && pytest tests/ -q
26 passed
```

Also verified by hand against a live `uvicorn` instance (404, 405, 422, 502, 503 and the success paths), and `tsc --noEmit` passes on the frontend.

## Breaking Changes

Error **response bodies** change shape: `{"detail": "..."}` → the structured envelope above. Any client reading `.detail` must now read `.message` / `.error.code`. The bundled frontend is updated in this PR. Success responses are unchanged.

Two status codes are intentionally corrected: duplicate registration `400 → 409`, and a failed weather sync `200 → 502/503`.


___

## **CodeAnt-AI Description**
**Return consistent JSON errors with request IDs across the API**

### What Changed
- All API failures now return the same JSON error shape, with a clear message, a stable error code, the request path, and a request ID
- Validation errors now point to the exact field that failed and list the allowed values
- Missing routes, wrong methods, not-found resources, authentication failures, and duplicate registrations now use matching HTTP status codes instead of generic or misleading responses
- Weather and catalog sync endpoints now fail with a real error when the database or upstream service is unavailable, instead of reporting a successful empty sync
- The frontend now reads backend errors as typed failures, so it can show the message and use the request ID for support

### Impact
`✅ Clearer API failures`
`✅ Fewer false-success sync results`
`✅ Easier bug reports with request IDs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent, structured error responses across the API, including request IDs and actionable error details.
  * Improved validation for catalog, collision, weather, and authentication inputs.
  * Added clearer reporting for unavailable services and external provider failures.
  * Frontend API requests now expose typed errors with status, error codes, and request IDs.

* **Bug Fixes**
  * Missing resources now return accurate not-found responses.
  * Failed weather and catalog operations are no longer reported as successful.
  * Internal server details are hidden from error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a unified error response envelope (`ErrorResponse`) across every API failure path, replacing FastAPI's raw `{"detail": ...}` with a consistent `{success, message, error.code, path, request_id, timestamp}` shape. It also corrects several endpoints that were returning HTTP 200 on genuine failures, fixes a broken import that prevented the backend from starting, and adds a typed `ApiError` class to the frontend fetch utility.

- **`app/core/exceptions.py` + `error_handlers.py`**: A `KeplerError` hierarchy with stable `ErrorCode` values; four exception handlers normalize every failure — including Starlette's own 404/405 and unhandled crashes — into the same envelope, with the 500 handler deliberately suppressing exception text from the response body.
- **Endpoint changes**: `POST /weather/sync`, `GET /catalog/live`, and `POST /catalog/sync` now return proper 502/503 instead of misleading 200 success responses; unknown enum values for `group`, `classification`, `risk_level`, `status`, and `event_type` now return 422 with an `allowed` list instead of silently returning empty pages.
- **Drive-by fixes**: `orbital/spacetrack.py` import corrected (`app.database.session` → `database.session`) and `numpy` added to `requirements.txt`, both of which were boot-blocking.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the unsanitized X-Request-ID header being written to logs; the rest of the change is a well-structured improvement.

The core error-handling architecture is sound and the regression tests cover the key cases. However, the middleware writes the raw client-supplied X-Request-ID directly into log messages without stripping newlines or control characters, which allows any caller to inject arbitrary content into the server's log stream. That path is hit on every erroring request, making it easy to trigger in production. The env-var names in the catalog auth-failure reason and the test route registered on the production app instance are worth fixing before merge but are lower risk.

backend/app/core/error_handlers.py (X-Request-ID sanitization) and backend/api/v1/endpoints/catalog.py (auth error reason string and no_records → 502 semantics)

<details open><summary><h3>Security Review</h3></summary>

- **Log injection via `X-Request-ID`** (`error_handlers.py` line 199): the client-supplied header is stored in `request.state` and interpolated directly into log messages without any sanitization. A malicious caller can embed newlines or ANSI sequences to corrupt log files or spoof log entries.
- **Internal env-var names in error response** (`catalog.py` line 257): the `reason` field `\"authentication failed — check SPACETRACK_USERNAME / SPACETRACK_PASSWORD\"` is returned to clients verbatim in both the `message` and `details.reason` fields, unnecessarily revealing internal configuration variable names.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| backend/app/core/error_handlers.py | New file wiring four exception handlers and request-id middleware; the client-supplied X-Request-ID is stored and logged without sanitization, creating a log injection vector. |
| backend/app/core/exceptions.py | Clean exception hierarchy with stable ErrorCode enum; class-level defaults for status_code/code work correctly with Python's MRO and are safe to merge. |
| backend/api/v1/endpoints/catalog.py | Adds group/classification validation and surfaces sync sentinels as real HTTP errors; the no_records → 502 mapping and internal env var names in the auth error reason need attention. |
| backend/api/v1/endpoints/auth.py | Duplicate registration changed to 409 Conflict; UnauthorizedError correctly preserves WWW-Authenticate: Bearer via its default headers; login message stays vague to prevent account enumeration. |
| backend/api/v1/endpoints/weather.py | Correctly splits PyMongoError (503) from generic Exception (502); weather_service now re-raises commit failures so the endpoint sees them; pages division-by-zero guard added. |
| backend/schemas/api_schemas.py | Adds ErrorDetail and ErrorResponse Pydantic models mirroring APIResponse shape; straightforward and safe. |
| backend/tests/test_error_responses.py | Good regression coverage for the new error contract; the _test/boom route is registered on the shared production app instance at module-import time, which would survive into any non-test environment that imports this module. |
| frontend/src/services/api.ts | ApiError extends Error with typed fields; falls back gracefully when a proxy returns non-JSON; backward-compatible for existing error.message consumers. |
| backend/orbital/spacetrack.py | Fixes broken import (app.database.session → database.session); adds KNOWN_GROUPS constant and early return in _build_group_path for unknown groups. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Middleware as _attach_request_id<br/>(middleware)
    participant Route as FastAPI Route
    participant Handler as Exception Handler<br/>(kepler / http / validation / 500)

    Client->>Middleware: HTTP request (+ optional X-Request-ID)
    Middleware->>Middleware: store request_id in request.state
    Middleware->>Route: call_next(request)

    alt Route succeeds
        Route-->>Middleware: APIResponse (2xx)
        Middleware-->>Client: response + X-Request-ID header
    else KeplerError raised
        Route->>Handler: kepler_error_handler
        Handler-->>Middleware: ErrorResponse (4xx/5xx)
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    else HTTPException raised
        Route->>Handler: http_exception_handler
        Handler-->>Middleware: ErrorResponse (normalised)
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    else RequestValidationError
        Route->>Handler: validation_exception_handler
        Handler-->>Middleware: ErrorResponse 422 + field list
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    else Unhandled Exception
        Route->>Handler: unhandled_exception_handler
        Handler->>Handler: log traceback (server-side only)
        Handler-->>Middleware: ErrorResponse 500 (generic)
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Middleware as _attach_request_id<br/>(middleware)
    participant Route as FastAPI Route
    participant Handler as Exception Handler<br/>(kepler / http / validation / 500)

    Client->>Middleware: HTTP request (+ optional X-Request-ID)
    Middleware->>Middleware: store request_id in request.state
    Middleware->>Route: call_next(request)

    alt Route succeeds
        Route-->>Middleware: APIResponse (2xx)
        Middleware-->>Client: response + X-Request-ID header
    else KeplerError raised
        Route->>Handler: kepler_error_handler
        Handler-->>Middleware: ErrorResponse (4xx/5xx)
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    else HTTPException raised
        Route->>Handler: http_exception_handler
        Handler-->>Middleware: ErrorResponse (normalised)
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    else RequestValidationError
        Route->>Handler: validation_exception_handler
        Handler-->>Middleware: ErrorResponse 422 + field list
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    else Unhandled Exception
        Route->>Handler: unhandled_exception_handler
        Handler->>Handler: log traceback (server-side only)
        Handler-->>Middleware: ErrorResponse 500 (generic)
        Middleware-->>Client: ErrorResponse + X-Request-ID header
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/tests/test_error_responses.py`, line 1007-1009 ([link](https://github.com/7-blocks/kepler/blob/1679e87f4cee0dc979d709eba620f763a43df3ec/backend/tests/test_error_responses.py#L1007-L1009)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test route permanently modifies the production `app` instance**

   The `@app.get("/api/v1/_test/boom")` decorator registers a live route on the same `app` object imported by `app/main.py`. `include_in_schema=False` hides it from OpenAPI docs but does not remove it from the running server — it remains reachable via HTTP. If any deployment process (e.g. a Docker image that runs `pytest` and then `uvicorn`) imports this module, the endpoint is live in production. Consider using a pytest fixture with a local `FastAPI()` sub-application and a `TestClient` mounted on it, or gate the route registration on `settings.DEBUG`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/tests/test_error_responses.py
   Line: 1007-1009

   Comment:
   **Test route permanently modifies the production `app` instance**

   The `@app.get("/api/v1/_test/boom")` decorator registers a live route on the same `app` object imported by `app/main.py`. `include_in_schema=False` hides it from OpenAPI docs but does not remove it from the running server — it remains reachable via HTTP. If any deployment process (e.g. a Docker image that runs `pytest` and then `uvicorn`) imports this module, the endpoint is live in production. Consider using a pytest fixture with a local `FastAPI()` sub-application and a `TestClient` mounted on it, or gate the route registration on `settings.DEBUG`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
backend/app/core/error_handlers.py:199-200
**Unsanitized client header written to logs**

The `X-Request-ID` value is accepted from the client verbatim and embedded in every log line without any validation or sanitization. An attacker who controls this header can inject arbitrary text — including newlines (`%0A`), ANSI escape codes, or fake log entries — directly into the server's log stream. The injected content is then logged by `kepler_error_handler` (line 94) and `unhandled_exception_handler` (line 180) under `[{request_id}]`.

At minimum, strip characters outside `[\w\-.]` and cap the length (e.g. 64 chars) before storing the value in `request.state`.

### Issue 2 of 4
backend/api/v1/endpoints/catalog.py:255-258
**Internal configuration variable names exposed to API clients**

The `reason` string is included verbatim in both the response `message` (e.g. `"Space-Track is unavailable or returned an unusable response. (authentication failed — check SPACETRACK_USERNAME / SPACETRACK_PASSWORD)"`) and in `details.reason`. While the actual credential values never leave the server, revealing the exact environment variable names is unnecessary and reduces security-in-depth.

Replace the reason with a client-safe message that keeps the env var names server-side — e.g. `"authentication failed — credentials may be missing or expired"` — and log the variable names internally instead.

### Issue 3 of 4
backend/api/v1/endpoints/catalog.py:200-205
**`no_records` sentinel returns 502 Bad Gateway, which implies upstream failure**

502 Bad Gateway conventionally signals that the upstream service returned an invalid or unusable response — not that it returned a valid but empty result set. If Space-Track legitimately has zero records for a group (e.g. the `analyst` group is briefly empty after a deorbit wave), a client that retries on 502 will loop unnecessarily, while a monitoring system will page on-call as if an external service is down.

If `sync_group` sets the `no_records` sentinel exclusively for fetch failures (e.g. a non-200 HTTP response or a parse error), the error is correctly surfaced but the name `no_records` is misleading. It would be clearer to use a sentinel like `fetch_failed` or `empty_response` and document in `sync_group` when exactly it fires. If the sentinel also fires for a legitimately empty page, consider returning a 200 with a descriptive message instead of a 502.

### Issue 4 of 4
backend/tests/test_error_responses.py:1007-1009
**Test route permanently modifies the production `app` instance**

The `@app.get("/api/v1/_test/boom")` decorator registers a live route on the same `app` object imported by `app/main.py`. `include_in_schema=False` hides it from OpenAPI docs but does not remove it from the running server — it remains reachable via HTTP. If any deployment process (e.g. a Docker image that runs `pytest` and then `uvicorn`) imports this module, the endpoint is live in production. Consider using a pytest fixture with a local `FastAPI()` sub-application and a `TestClient` mounted on it, or gate the route registration on `settings.DEBUG`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): return structured JSON error ..."](https://github.com/7-blocks/kepler/commit/1679e87f4cee0dc979d709eba620f763a43df3ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44167059)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->