### PR TITLE
feat: standardize API error responses

### DIFF
--- a/backend/api/v1/endpoints/auth.py
+++ b/backend/api/v1/endpoints/auth.py
@@ -14,7 +14,10 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
 def register(user_in: UserCreate, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == user_in.email).first()
     if user:
-        raise HTTPException(status_code=400, detail="Email already registered")
+        raise HTTPException(
+            status_code=400,
+            detail=f"An account with email '{user_in.email}' is already registered.",
+        )
     
     
     hashed_pwd = get_password_hash(user_in.password)
@@ -56,7 +59,7 @@ def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db:
     if not user or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect email or password",
+            detail="Login failed: the email or password provided is incorrect.",
             headers={"WWW-Authenticate": "Bearer"},
         )
     

--- a/backend/api/v1/endpoints/catalog.py
+++ b/backend/api/v1/endpoints/catalog.py
@@ -126,7 +126,7 @@ def get_space_object(catalog_number: str, db: MongoSession = Depends(get_db)):
     if not doc:
         raise HTTPException(
             status_code=404,
-            detail=f"Object {catalog_number} not found in catalog or Space-Track",
+            detail=f"Space object with NORAD catalog number '{catalog_number}' was not found in the catalog or on Space-Track.",
         )
     return APIResponse(success=True, message="Object retrieved", data=_serialize_doc(doc))
 

--- a/backend/api/v1/endpoints/collisions.py
+++ b/backend/api/v1/endpoints/collisions.py
@@ -91,7 +91,10 @@ def get_collision_detail(prediction_id: int, db: MongoSession = Depends(get_db))
         .first()
     )
     if not pred:
-        raise HTTPException(status_code=404, detail=f"Collision prediction {prediction_id} not found")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collision prediction with ID {prediction_id} was not found.",
+        )
 
     detail = _serialize_collision(pred)
     detail["risk_scores"] = [
@@ -110,11 +113,17 @@ def update_collision_status(
     """Update the status of a collision prediction (PENDING → MITIGATED | ASSESSED | IGNORED)."""
     valid = {"PENDING", "MITIGATED", "ASSESSED", "IGNORED"}
     if status.upper() not in valid:
-        raise HTTPException(status_code=422, detail=f"Status must be one of {valid}")
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid status '{status}'. Status must be one of: {', '.join(sorted(valid))}.",
+        )
 
     pred = db.query(CollisionPrediction).filter(CollisionPrediction.id == prediction_id).first()
     if not pred:
-        raise HTTPException(status_code=404, detail=f"Prediction {prediction_id} not found")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collision prediction with ID {prediction_id} was not found.",
+        )
 
     pred.status = status.upper()
     db.commit()
@@ -156,7 +165,10 @@ def get_conjunction_explanation(prediction_id: int, db: MongoSession = Depends(g
         .first()
     )
     if not pred:
-        raise HTTPException(status_code=404, detail=f"Prediction {prediction_id} not found")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collision prediction with ID {prediction_id} was not found.",
+        )
 
     summary = openai_service.explain_collision({
         "obj_a": pred.object_a.name if pred.object_a else "UNKNOWN",

--- a/backend/api/v1/endpoints/satellites.py
+++ b/backend/api/v1/endpoints/satellites.py
@@ -99,7 +99,10 @@ def get_satellite_telemetry(satellite_id: str, db: MongoSession = Depends(get_db
 
     sat = db.db["satellites"].find_one(flt, {"_id": 0})
     if not sat:
-        raise HTTPException(status_code=404, detail="Satellite not found")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Satellite '{satellite_id}' was not found in the catalog.",
+        )
 
     records = list(
         db.db["telemetry"]

--- a/backend/api/v1/endpoints/weather.py
+++ b/backend/api/v1/endpoints/weather.py
@@ -4,7 +4,7 @@ Exposes real-time space weather events: CME, solar flares, geomagnetic storms,
 radiation events, and overall severity status from NASA DONKI API.
 """
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Optional
 from datetime import datetime
@@ -13,6 +13,10 @@ from database.session import get_db
 from models.db_models import SpaceWeather, Alert
 from schemas.api_schemas import APIResponse, PaginationSchema
 from services.weather_service import weather_service
+
+import logging
+
+logger = logging.getLogger("app")
 
 router = APIRouter()
 
@@ -159,14 +163,14 @@ def trigger_weather_sync(
     """
     try:
         weather_service.sync_weather(db)
-        return APIResponse(
-            success=True,
-            message=f"NASA DONKI sync complete — events persisted to database.",
-            data={"synced_at": datetime.utcnow().isoformat(), "source": "NASA DONKI API"},
+    except Exception:
+        logger.error("NASA DONKI weather sync failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Space weather sync could not be completed. The NASA DONKI service may be temporarily unavailable.",
         )
-    except Exception as e:
-        return APIResponse(
-            success=False,
-            message=f"Sync failed: {str(e)}",
-            data=None,
-        )
+    return APIResponse(
+        success=True,
+        message="NASA DONKI sync complete — events persisted to database.",
+        data={"synced_at": datetime.utcnow().isoformat(), "source": "NASA DONKI API"},
+    )

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,0 +1,126 @@
+"""
+Centralized FastAPI exception handlers.
+
+These handlers guarantee that every error — whether an explicit
+``HTTPException``, a request validation failure, or an unexpected
+server error — is returned as a unified JSON envelope:
+
+    {
+        "success": false,
+        "error": {
+            "code": "NOT_FOUND",
+            "message": "Satellite with NORAD ID 25544 was not found.",
+            "details": null
+        }
+    }
+
+No stack traces or internal exception text are ever exposed to clients.
+"""
+
+import logging
+from typing import Any, Dict, Optional, Union
+
+from fastapi import FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from schemas.api_schemas import APIErrorDetail, APIErrorResponse
+
+logger = logging.getLogger("app")
+
+
+# ---------------------------------------------------------------------------
+# Error code resolution
+# ---------------------------------------------------------------------------
+
+# Map human-readable codes to HTTP status codes for consistency.
+_STATUS_CODE_MAP: Dict[int, str] = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    409: "CONFLICT",
+    422: "VALIDATION_ERROR",
+    429: "RATE_LIMITED",
+    500: "INTERNAL_SERVER_ERROR",
+    502: "BAD_GATEWAY",
+    503: "SERVICE_UNAVAILABLE",
+    504: "GATEWAY_TIMEOUT",
+}
+
+
+def _code_for_status(status_code: int) -> str:
+    return _STATUS_CODE_MAP.get(status_code, f"ERROR_{status_code}")
+
+
+def _make_response(
+    status_code: int,
+    code: str,
+    message: str,
+    details: Optional[Any] = None,
+) -> JSONResponse:
+    payload = APIErrorResponse(
+        success=False,
+        error=APIErrorDetail(code=code, message=message, details=details),
+    )
+    return JSONResponse(status_code=status_code, content=payload.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+async def http_exception_handler(
+    request: Request, exc: Union[StarletteHTTPException, RequestValidationError]
+) -> JSONResponse:
+    """Handle FastAPI/Starlette HTTPException with the unified envelope."""
+    if isinstance(exc, StarletteHTTPException):
+        status_code = exc.status_code
+        code = _code_for_status(status_code)
+        # `detail` may be a str or a structured dict/list.
+        detail = exc.detail
+        message = detail if isinstance(detail, str) else "Request failed."
+        return _make_response(status_code, code, message)
+    return _make_response(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "INTERNAL_SERVER_ERROR",
+        "An unexpected error occurred.",
+    )
+
+
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Return 422 with the unified envelope, nesting Pydantic errors in details."""
+    return _make_response(
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "VALIDATION_ERROR",
+        "Request validation failed. Please review the supplied parameters.",
+        details=exc.errors(),
+    )
+
+
+async def unhandled_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Catch every otherwise-unhandled exception and hide internals."""
+    logger.error(
+        "Unhandled exception on %s %s: %s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True,
+    )
+    return _make_response(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "INTERNAL_SERVER_ERROR",
+        "An internal server error occurred. Our team has been notified.",
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Attach all centralized handlers to the FastAPI application."""
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
+from app.core.exceptions import register_exception_handlers
 from api.router import api_router
 from websocket.manager import manager
 from models.db_models import Organization, Role
@@ -33,6 +34,9 @@ app.add_middleware(
 
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
+
+# Centralized, unified JSON error handling for every request.
+register_exception_handlers(app)
 
 
 @app.get("/", tags=["Health"])

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration: ensure the backend package root is importable."""
+import os
+import sys
+
+# Add the backend directory (this file's parent) to sys.path so that
+# top-level packages (app, api, schemas, services, ...) can be imported
+# regardless of the directory pytest is invoked from.
+_BACKEND_ROOT = os.path.dirname(os.path.abspath(__file__))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)

--- a/backend/orbital/spacetrack.py
+++ b/backend/orbital/spacetrack.py
@@ -37,7 +37,7 @@ from pymongo.errors import (
     OperationFailure,
 )
 
-from app.database.session import MongoSession
+from database.session import MongoSession
 from app.core.config import settings
 
 logger = logging.getLogger("app")

--- a/backend/schemas/api_schemas.py
+++ b/backend/schemas/api_schemas.py
@@ -18,6 +18,28 @@ class APIResponse(BaseModel, Generic[T]):
     metadata: Optional[Dict[str, Any]] = None
 
 
+# ---------------------------------------------------------------------------
+# Unified error response schema
+# ---------------------------------------------------------------------------
+
+class APIErrorDetail(BaseModel):
+    """Structured error payload returned for all failed requests."""
+    code: str
+    message: str
+    details: Optional[Any] = None
+
+
+class APIErrorResponse(BaseModel):
+    """Consistent failure envelope used by all global exception handlers.
+
+    Mirrors the success envelope's `success` flag while nesting failure
+    information under `error` so API consumers can reliably branch on
+    `response.success` and read `response.error.code` / `response.error.message`.
+    """
+    success: bool = False
+    error: APIErrorDetail
+
+
 class UserLogin(BaseModel):
     email: EmailStr
     password: str

--- a/backend/tests/test_error_responses.py
+++ b/backend/tests/test_error_responses.py
@@ -1,0 +1,159 @@
+"""
+Tests for unified API error responses (GitHub Issue #11).
+
+Verifies that:
+  - 404 / invalid routes return the unified JSON envelope.
+  - 422 validation failures return the unified JSON envelope with details.
+  - HTTPException-based 4xx responses use the unified envelope.
+  - Unhandled exceptions return a 500 unified envelope (no leaks).
+  - The JSON schema is consistent (success=false, error.code, error.message).
+"""
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from app.main import app as real_app
+from app.core.exceptions import (
+    http_exception_handler,
+    validation_exception_handler,
+    unhandled_exception_handler,
+    _make_response,
+)
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+client = TestClient(real_app)
+
+
+# ---------------------------------------------------------------------------
+# Schema contract
+# ---------------------------------------------------------------------------
+
+def _assert_error_envelope(payload: dict, status_code: int):
+    assert payload.get("success") is False, "success flag must be false"
+    error = payload.get("error")
+    assert isinstance(error, dict), "error must be an object"
+    assert "code" in error, "error.code is required"
+    assert "message" in error, "error.message is required"
+    assert isinstance(error["message"], str) and error["message"].strip(), \
+        "error.message must be a non-empty string"
+    # No internal exception leakage patterns
+    assert "Traceback" not in error["message"]
+    assert "Traceback" not in str(payload)
+    return error
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown route
+# ---------------------------------------------------------------------------
+
+def test_404_unknown_route_returns_unified_envelope():
+    resp = client.get("/api/v1/this-route-does-not-exist")
+    assert resp.status_code == 404
+    error = _assert_error_envelope(resp.json(), 404)
+    assert error["code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# 422 — validation error
+# ---------------------------------------------------------------------------
+
+def test_422_validation_error_returns_unified_envelope():
+    # /satellites uses Query(ge=1). page=0 violates the constraint.
+    resp = client.get("/api/v1/satellites?page=0")
+    assert resp.status_code == 422
+    error = _assert_error_envelope(resp.json(), 422)
+    assert error["code"] == "VALIDATION_ERROR"
+    assert error.get("details") is not None, "validation details should be present"
+
+
+def test_422_validation_error_on_collisions_status():
+    # update_collision_status expects a Body; missing body triggers 422.
+    resp = client.patch("/api/v1/collisions/999/status")
+    assert resp.status_code == 422
+    error = _assert_error_envelope(resp.json(), 422)
+    assert error["code"] == "VALIDATION_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# 404 — known endpoint, missing resource (HTTPException path)
+# ---------------------------------------------------------------------------
+
+def test_404_missing_collision_returns_unified_envelope():
+    resp = client.get("/api/v1/collisions/999999")
+    assert resp.status_code == 404
+    error = _assert_error_envelope(resp.json(), 404)
+    assert error["code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# 500 — unhandled exception
+# ---------------------------------------------------------------------------
+
+def test_500_unhandled_exception_returns_unified_envelope():
+    # Build a throwaway app with a route that raises, to exercise the
+    # global unhandled-exception handler without touching production routes.
+    test_app = FastAPI()
+    from app.core.exceptions import register_exception_handlers
+    register_exception_handlers(test_app)
+
+    @test_app.get("/boom")
+    def boom():
+        raise RuntimeError("secret-internal-detail")
+
+    # raise_server_exceptions=False so the TestClient returns the
+    # handled JSON response instead of re-raising the server error.
+    test_client = TestClient(test_app, raise_server_exceptions=False)
+    resp = test_client.get("/boom")
+    assert resp.status_code == 500
+    error = _assert_error_envelope(resp.json(), 500)
+    assert error["code"] == "INTERNAL_SERVER_ERROR"
+    # Internal detail must NOT be exposed
+    assert "secret-internal-detail" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Handler unit tests
+# ---------------------------------------------------------------------------
+
+def test_http_exception_handler_uses_unified_format():
+    from starlette.requests import Request as StarletteRequest
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/x",
+        "headers": [],
+        "query_string": b"",
+    }
+    request = StarletteRequest(scope)
+    exc = StarletteHTTPException(status_code=401, detail="bad credentials")
+    import asyncio
+    response = asyncio.run(http_exception_handler(request, exc))
+    assert response.status_code == 401
+    body = response.body.decode()
+    assert '"success":false' in body or '"success": false' in body
+    assert "UNAUTHORIZED" in body
+    assert "bad credentials" in body
+
+
+def test_422_handler_nests_validation_details():
+    from starlette.requests import Request as StarletteRequest
+    scope = {"type": "http", "method": "GET", "path": "/x", "headers": [], "query_string": b""}
+    request = StarletteRequest(scope)
+    # Minimal fake validation error list
+    fake_exc = RequestValidationError(errors=[{"loc": ("query", "page"), "msg": "x", "type": "y"}])
+    import asyncio
+    response = asyncio.run(validation_exception_handler(request, fake_exc))
+    assert response.status_code == 422
+    body = response.body.decode()
+    assert "VALIDATION_ERROR" in body
+    assert "details" in body
+
+
+def test_make_response_helper():
+    resp = _make_response(409, "CONFLICT", "Duplicate resource")
+    assert resp.status_code == 409
+    assert "CONFLICT" in resp.body.decode()
+    assert "Duplicate resource" in resp.body.decode()


### PR DESCRIPTION
## **User description**
## Summary

Fixes #11

This PR standardizes API error responses across the FastAPI backend by introducing centralized exception handling and a consistent JSON error response format.

## Changes Made

- Added centralized exception handlers for:
  - HTTPException
  - RequestValidationError
  - Unhandled exceptions
- Added unified `APIErrorResponse` and `APIErrorDetail` schemas.
- Registered global exception handlers in the FastAPI application.
- Updated API endpoints to return clearer and more descriptive error messages.
- Fixed the weather sync endpoint to return the appropriate HTTP status code instead of returning HTTP 200 on failures.
- Added comprehensive test coverage for:
  - 401 Unauthorized
  - 404 Not Found
  - 422 Validation Errors
  - 500 Internal Server Errors
- Included a small import fix in `backend/orbital/spacetrack.py` required for successful application startup during testing.

## Files Added

- `backend/app/core/exceptions.py`
- `backend/conftest.py`
- `backend/tests/test_error_responses.py`

## Files Updated

- `backend/app/main.py`
- `backend/schemas/api_schemas.py`
- `backend/api/v1/endpoints/auth.py`
- `backend/api/v1/endpoints/catalog.py`
- `backend/api/v1/endpoints/collisions.py`
- `backend/api/v1/endpoints/satellites.py`
- `backend/api/v1/endpoints/weather.py`
- `backend/orbital/spacetrack.py`

## Testing

Executed:

```bash
python -m pytest tests/test_backend.py tests/test_error_responses.py -v
```

**Result**

- ✅ 14 tests passed

## Manual Verification

Verified the following API responses:

- 401 Unauthorized
- 404 Not Found
- 422 Validation Error
- 500 Internal Server Error

All now return the unified JSON error response format with the correct HTTP status codes.
<img width="701" height="102" alt="image" src="https://github.com/user-attachments/assets/756d1f34-5b6a-46a6-b759-e02e42581ab7" />

___

## **CodeAnt-AI Description**
Standardize API error responses and make failures clearer

### What Changed
- All API errors now return the same JSON error shape, with a clear error code and message
- Validation failures now include field details instead of a plain error string
- Missing resources, invalid login, duplicate signup, and invalid collision status requests now show clearer messages
- Weather sync failures now return a service-unavailable error instead of looking like a successful request
- Added tests that verify 404, 422, and 500 responses all use the new error format and do not expose internal details

### Impact
`✅ Clearer API error messages`
`✅ Fewer false-success responses`
`✅ Safer server error handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized API error responses with consistent status codes, error codes, messages, and validation details.
  * Improved error messages for authentication, catalog, collision, and satellite lookup failures.
  * Weather synchronization failures now return a clear service-unavailable response.
  * Unexpected server errors no longer expose internal details.
* **Testing**
  * Added coverage for unified error responses, validation failures, missing resources, and unexpected exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces centralized exception handling for the FastAPI backend, replacing scattered per-endpoint error responses with a unified `{success, error: {code, message, details}}` JSON envelope for all failure paths.

- **New `exceptions.py`** registers three global handlers covering `HTTPException`, `RequestValidationError`, and bare `Exception`, ensuring no stack traces reach clients and every error carries a machine-readable `code` string.
- **Weather sync** is corrected from swallowing exceptions and returning HTTP 200 to properly raising a 503 `HTTPException`.
- **Error messages** across auth, catalog, satellites, and collisions are made more descriptive; a broken import in `spacetrack.py` is also fixed.

<h3>Confidence Score: 3/5</h3>

The handler drops response headers from intercepted HTTPExceptions, stripping the RFC-required WWW-Authenticate header from every 401 response.

The new http_exception_handler constructs a bare JSONResponse with no headers argument, silently discarding any headers set on the original exception. The login endpoint raises its 401 with WWW-Authenticate: Bearer — after this PR that header never reaches the client, affecting every protected endpoint.

backend/app/core/exceptions.py — the _make_response helper and http_exception_handler need to forward exc.headers to the JSONResponse.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| backend/app/core/exceptions.py | New centralized exception handler module; drops WWW-Authenticate headers from 401 responses and contains dead code in http_exception_handler. |
| backend/app/main.py | Registers global exception handlers after include_router; functionally harmless in FastAPI. |
| backend/schemas/api_schemas.py | Adds APIErrorDetail and APIErrorResponse schemas; clean and consistent with existing patterns. |
| backend/api/v1/endpoints/weather.py | Correctly converts swallowed-exception 200 responses to proper 503 HTTPException; uses deprecated datetime.utcnow(). |
| backend/api/v1/endpoints/auth.py | Updated error messages are more descriptive; the 401 login error raises with WWW-Authenticate header that gets silently dropped by the new exception handler. |
| backend/tests/test_error_responses.py | Good coverage of envelope shape and 500 leak prevention; no test for WWW-Authenticate header preservation on 401 responses. |
| backend/api/v1/endpoints/collisions.py | Error messages updated to be more descriptive; no functional changes beyond message clarity. |
| backend/orbital/spacetrack.py | Import path fixed from app.database.session to database.session; necessary for test startup. |
| backend/conftest.py | Standard sys.path setup for pytest; missing newline at EOF. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
backend/app/core/exceptions.py:78-84
**WWW-Authenticate header silently dropped on 401 responses**

`_make_response` constructs a plain `JSONResponse` with no `headers` argument, so any headers on the original exception are discarded. The login endpoint raises its 401 with `headers={"WWW-Authenticate": "Bearer"}` (RFC 6750 requirement), but that header never reaches the client after this handler intercepts it. OAuth2 clients — including Swagger UI's Authorize dialog — rely on this header to recognize that Bearer auth is expected; dropping it breaks the spec-required challenge mechanism.

### Issue 2 of 3
backend/app/core/exceptions.py:74-89
**Dead fallback branch in `http_exception_handler`**

The function is registered exclusively for `StarletteHTTPException`, so the `else` path can never be triggered in practice. If it were somehow reached, it would silently return a 500 instead of the expected response. Removing the dead branch and tightening the type annotation makes the intent unambiguous.

```suggestion
async def http_exception_handler(
    request: Request, exc: StarletteHTTPException
) -> JSONResponse:
    """Handle FastAPI/Starlette HTTPException with the unified envelope."""
    status_code = exc.status_code
    code = _code_for_status(status_code)
    # `detail` may be a str or a structured dict/list.
    detail = exc.detail
    message = detail if isinstance(detail, str) else "Request failed."
    return _make_response(status_code, code, message)
```

### Issue 3 of 3
backend/api/v1/endpoints/weather.py:175
`datetime.utcnow()` is deprecated in Python 3.12+ — it returns a naive datetime with no timezone information attached. `datetime.now(timezone.utc)` is the recommended replacement and produces an aware datetime.

```suggestion
        data={"synced_at": datetime.now(timezone.utc).isoformat(), "source": "NASA DONKI API"},
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: standardize API error responses"](https://github.com/7-blocks/kepler/commit/994aa51c93b4990f943c95fcdf3993c7c42c242f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44191321)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->