### PR TITLE
feat(ingestion): multi-source satellite providers with automatic failover (fixes #15)

### DIFF
--- a/backend/api/v1/endpoints/catalog.py
+++ b/backend/api/v1/endpoints/catalog.py
@@ -170,6 +170,32 @@ def get_catalog_stats(db: MongoSession = Depends(get_db)):
 
 
 # ---------------------------------------------------------------------------
+# GET /catalog/providers
+# ---------------------------------------------------------------------------
+
+@router.get("/providers", response_model=APIResponse[Dict[str, Any]])
+def get_provider_chain():
+    """
+    Show the data source failover chain and which links are currently usable.
+
+    Ingestion walks this list top to bottom and uses the first provider that answers, so
+    this is the quickest way to see why a sync came back from a fallback source.
+    """
+    chain = spacetrack_service.providers
+    providers = [
+        {"name": p.name, "priority": i + 1, "available": p.is_available()}
+        for i, p in enumerate(chain.providers)
+    ]
+    usable = sum(1 for p in providers if p["available"])
+
+    return APIResponse(
+        success=True,
+        message=f"{usable}/{len(providers)} providers available — {' → '.join(chain.order)}",
+        data={"providers": providers},
+    )
+
+
+# ---------------------------------------------------------------------------
 # POST /catalog/sync
 # ---------------------------------------------------------------------------
 
@@ -180,7 +206,7 @@ def trigger_sync(
     background_tasks: BackgroundTasks = None,
     db: MongoSession = Depends(get_db),
 ):
-    """Manually trigger a Space-Track sync."""
+    """Manually trigger a catalog sync (Space-Track → CelesTrak → cache)."""
     if group:
         _validate_group(group)
         type_override = next(
@@ -197,18 +223,22 @@ def trigger_sync(
                 "The catalog database is unreachable, so the sync could not be stored.",
                 details={"group": group, "sync_status": status},
             )
-        if "no_records" in errors:
+        if "all_providers_failed" in errors:
+            # Only reachable once *every* source is down — including the local cache.
             raise ExternalServiceError(
-                service="Space-Track",
-                reason=f"returned no records for group '{group}'",
-                details={"service": "Space-Track", "group": group, "sync_status": status},
+                f"No satellite data provider could serve group '{group}'.",
+                details={
+                    "group": group,
+                    "providers_tried": spacetrack_service.providers.order,
+                    "provider_failures": status.get("provider_failures", {}),
+                },
             )
 
         return APIResponse(
             success=status["failed"] == 0,
             message=(
-                f"Synced group '{group}': {status['upserted']} upserted, "
-                f"{status['failed']} failed"
+                f"Synced group '{group}' from '{status['source']}': "
+                f"{status['upserted']} upserted, {status['failed']} failed"
             ),
             data=status,
         )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,6 +24,12 @@ class Settings(BaseSettings):
     SPACETRACK_USERNAME: Optional[str] = None
     SPACETRACK_PASSWORD: Optional[str] = None
 
+    # Satellite data sources, tried in this order. If one fails, ingestion falls through
+    # to the next, so a single upstream outage cannot stop the pipeline (issue #15).
+    # Known providers: space-track, celestrak, cache.
+    SATELLITE_PROVIDER_PRIORITY: str = "space-track,celestrak,cache"
+    CELESTRAK_BASE_URL: str = "https://celestrak.org"
+
     
     OPENAI_API_KEY: Optional[str] = "mock-key"
 

--- a/backend/orbital/providers/__init__.py
+++ b/backend/orbital/providers/__init__.py
@@ -1,0 +1,74 @@
+"""
+Multi-source satellite data providers (issue #15).
+
+Ingestion no longer depends on a single upstream. `build_provider_chain` assembles the
+sources in the order given by `settings.SATELLITE_PROVIDER_PRIORITY`, defaulting to:
+
+    space-track -> celestrak -> cache
+"""
+
+import logging
+from typing import Any, List
+
+from app.core.config import settings
+from orbital.providers.base import (
+    AllProvidersFailedError,
+    ProviderError,
+    SatelliteDataProvider,
+)
+from orbital.providers.cache import LocalCacheProvider
+from orbital.providers.celestrak import CelesTrakProvider
+from orbital.providers.chain import ProviderChain
+from orbital.providers.spacetrack import SpaceTrackProvider
+
+logger = logging.getLogger("app")
+
+__all__ = [
+    "AllProvidersFailedError",
+    "CelesTrakProvider",
+    "LocalCacheProvider",
+    "ProviderChain",
+    "ProviderError",
+    "SatelliteDataProvider",
+    "SpaceTrackProvider",
+    "build_provider_chain",
+]
+
+
+def build_provider_chain(spacetrack_service: Any) -> ProviderChain:
+    """
+    Build the failover chain in the configured priority order.
+
+    `spacetrack_service` is injected rather than imported, so this module stays free of a
+    circular dependency on `orbital.spacetrack`.
+    """
+    cache = LocalCacheProvider()
+    available = {
+        SpaceTrackProvider.name: lambda: SpaceTrackProvider(spacetrack_service),
+        CelesTrakProvider.name:  CelesTrakProvider,
+        LocalCacheProvider.name: lambda: cache,
+    }
+
+    providers: List[SatelliteDataProvider] = []
+    for raw_name in settings.SATELLITE_PROVIDER_PRIORITY.split(","):
+        name = raw_name.strip().lower()
+        if not name:
+            continue
+        factory = available.get(name)
+        if factory is None:
+            logger.warning(
+                f"[Providers] Unknown provider '{name}' in SATELLITE_PROVIDER_PRIORITY — "
+                f"ignored. Known: {sorted(available)}."
+            )
+            continue
+        providers.append(factory())
+
+    if not providers:
+        logger.error(
+            "[Providers] SATELLITE_PROVIDER_PRIORITY produced no usable provider; "
+            "falling back to the default chain."
+        )
+        providers = [SpaceTrackProvider(spacetrack_service), CelesTrakProvider(), cache]
+
+    logger.info(f"[Providers] Chain: {' -> '.join(p.name for p in providers)}")
+    return ProviderChain(providers, cache=cache)

--- a/backend/orbital/providers/base.py
+++ b/backend/orbital/providers/base.py
@@ -1,0 +1,65 @@
+"""
+The contract every satellite data provider implements.
+
+Providers all speak the same dialect: they return **GP/OMM records** — the CCSDS field
+names Space-Track already serves (`NORAD_CAT_ID`, `OBJECT_NAME`, `MEAN_MOTION`, …). That
+is the shape `SpaceTrackService._gp_to_satellite_doc` already consumes, so a new provider
+plugs into the existing ingestion pipeline without touching the transform.
+
+A provider signals failure by raising `ProviderError`. Returning an empty list counts as a
+failure too: for the groups Kepler syncs ("active", "starlink", "debris") an empty catalog
+is never a legitimate answer — it means the provider is degraded — so the chain falls
+through to the next source rather than persisting nothing and calling it a success.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from database.session import MongoSession
+
+
+class ProviderError(Exception):
+    """A provider could not serve the requested group."""
+
+    def __init__(self, provider: str, reason: str):
+        self.provider = provider
+        self.reason = reason
+        super().__init__(f"{provider}: {reason}")
+
+
+class AllProvidersFailedError(Exception):
+    """Every provider in the chain failed. Carries the reason each one gave."""
+
+    def __init__(self, group: str, failures: Dict[str, str]):
+        self.group = group
+        self.failures = failures
+        detail = "; ".join(f"{name} ({reason})" for name, reason in failures.items())
+        super().__init__(f"All providers failed for group '{group}': {detail}")
+
+
+class SatelliteDataProvider(ABC):
+    """A source of GP/OMM records for a named group."""
+
+    #: Stable identifier, stored on each ingested document as `source`.
+    name: str = "unknown"
+
+    def is_available(self) -> bool:
+        """
+        Cheap, non-fetching readiness check (credentials present, service reachable…).
+
+        The chain skips a provider that reports False instead of paying for a doomed
+        request. Defaults to True for providers that need no setup.
+        """
+        return True
+
+    @abstractmethod
+    def fetch_group(
+        self, group: str, limit: int, db: Optional[MongoSession] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Return GP/OMM records for `group`, or raise `ProviderError`.
+
+        `db` is only used by providers backed by our own database (the local cache);
+        remote providers ignore it.
+        """
+        raise NotImplementedError

--- a/backend/orbital/providers/cache.py
+++ b/backend/orbital/providers/cache.py
@@ -1,0 +1,74 @@
+"""
+Local cache provider — the last resort.
+
+Every successful remote fetch is written to the `provider_cache` collection, one document
+per group. When Space-Track *and* CelesTrak are both unreachable, the chain replays the
+last payload we received instead of ingesting nothing.
+
+The data it serves is by definition stale, so the age of the payload is logged and
+returned in the sync status. Ingestion keeping the catalog warm during an outage is the
+point; pretending the data is fresh is not.
+"""
+
+import datetime
+import logging
+from typing import Any, Dict, List, Optional
+
+from database.session import MongoSession
+from orbital.providers.base import ProviderError, SatelliteDataProvider
+
+logger = logging.getLogger("app")
+
+CACHE_COLLECTION = "provider_cache"
+
+
+class LocalCacheProvider(SatelliteDataProvider):
+    name = "cache"
+
+    def store(
+        self,
+        db: MongoSession,
+        group: str,
+        source: str,
+        records: List[Dict[str, Any]],
+    ) -> None:
+        """Overwrite the cached payload for `group` with a fresh remote answer."""
+        if not records:
+            return
+
+        db.db[CACHE_COLLECTION].update_one(
+            {"_id": group},
+            {
+                "$set": {
+                    "group":    group,
+                    "source":   source,
+                    "records":  records,
+                    "count":    len(records),
+                    "cachedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                }
+            },
+            upsert=True,
+        )
+        logger.info(f"[Cache] Stored {len(records)} records for '{group}' (from {source}).")
+
+    def fetch_group(
+        self, group: str, limit: int, db: Optional[MongoSession] = None
+    ) -> List[Dict[str, Any]]:
+        if db is None:
+            raise ProviderError(self.name, "no database session available")
+
+        doc = db.db[CACHE_COLLECTION].find_one({"_id": group})
+        if not doc or not doc.get("records"):
+            raise ProviderError(self.name, f"nothing cached for group '{group}'")
+
+        cached_at = doc.get("cachedAt")
+        logger.warning(
+            f"[Cache] ⚠️  Serving STALE data for '{group}': {doc.get('count')} records "
+            f"cached at {cached_at} (from {doc.get('source')}). All remote providers are down."
+        )
+        return doc["records"][:limit]
+
+    def age(self, db: MongoSession, group: str) -> Optional[str]:
+        """ISO timestamp of the cached payload for `group`, or None if nothing is cached."""
+        doc = db.db[CACHE_COLLECTION].find_one({"_id": group}, {"cachedAt": 1})
+        return doc.get("cachedAt") if doc else None

--- a/backend/orbital/providers/celestrak.py
+++ b/backend/orbital/providers/celestrak.py
@@ -1,0 +1,127 @@
+"""
+CelesTrak provider — the first fallback.
+
+CelesTrak serves the same CCSDS/OMM JSON that Space-Track does, and needs no credentials,
+which makes it a genuinely independent second source: a Space-Track outage or an expired
+password does not affect it.
+
+Two differences from Space-Track are handled here:
+
+  * CelesTrak has no generic "debris" group, so Kepler's `debris`/`analyst` group maps to
+    the major tracked debris clouds and their records are concatenated.
+  * The GP endpoint has no `limit` parameter, so the cap is applied client-side.
+
+OMM records omit `TLE_LINE1`/`TLE_LINE2`; the ingestion transform already treats those as
+optional (`has_tle` simply becomes false), so no change is needed downstream.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from app.core.config import settings
+from database.session import MongoSession
+from orbital.providers.base import ProviderError, SatelliteDataProvider
+
+logger = logging.getLogger("app")
+
+# Kepler group -> CelesTrak GROUP query value(s).
+_GROUP_MAP: Dict[str, List[str]] = {
+    "active":   ["active"],
+    "starlink": ["starlink"],
+    "analyst":  ["cosmos-1408-debris", "fengyun-1c-debris",
+                 "iridium-33-debris", "cosmos-2251-debris"],
+}
+_GROUP_MAP["debris"] = _GROUP_MAP["analyst"]
+
+
+class CelesTrakProvider(SatelliteDataProvider):
+    name = "celestrak"
+
+    def __init__(self, base_url: Optional[str] = None, timeout: float = 30.0):
+        self.base_url = (base_url or settings.CELESTRAK_BASE_URL).rstrip("/")
+        # CelesTrak asks clients to identify themselves so it can contact heavy users.
+        self.client = httpx.Client(
+            timeout=timeout,
+            follow_redirects=True,
+            headers={"User-Agent": "Kepler/1.0 (+https://github.com/7-Blocks/Kepler)"},
+        )
+
+    def fetch_group(
+        self, group: str, limit: int, db: Optional[MongoSession] = None
+    ) -> List[Dict[str, Any]]:
+        celestrak_groups = _GROUP_MAP.get(group)
+        if not celestrak_groups:
+            raise ProviderError(self.name, f"no CelesTrak group maps to '{group}'")
+
+        records: List[Dict[str, Any]] = []
+        errors: List[str] = []
+
+        for ct_group in celestrak_groups:
+            if len(records) >= limit:
+                break
+            try:
+                records.extend(self._fetch_one(ct_group))
+            except ProviderError as exc:
+                # One debris cloud failing should not discard the ones that worked.
+                errors.append(exc.reason)
+
+        if not records:
+            reason = "; ".join(errors) if errors else f"returned no records for '{group}'"
+            raise ProviderError(self.name, reason)
+
+        if errors:
+            logger.warning(
+                f"[CelesTrak] Partial result for '{group}': {len(records)} records, "
+                f"{len(errors)} sub-group(s) failed — {errors}"
+            )
+
+        return records[:limit]
+
+    def _fetch_one(self, celestrak_group: str) -> List[Dict[str, Any]]:
+        url = f"{self.base_url}/NORAD/elements/gp.php"
+        params = {"GROUP": celestrak_group, "FORMAT": "json"}
+
+        try:
+            resp = self.client.get(url, params=params)
+        except httpx.RequestError as exc:
+            raise ProviderError(
+                self.name, f"network error for '{celestrak_group}': {exc}"
+            ) from exc
+
+        # CelesTrak refreshes GP data every 2 hours and answers 403 if you ask again before
+        # it has changed. That is a rate limit, not an outage — the honest response is to
+        # fall through to the cached payload, which holds exactly the data it is declining
+        # to resend. Kepler's scheduler polls far more often than every 2 hours, so this is
+        # the common case, not an edge case.
+        if resp.status_code == 403 and "has not updated" in resp.text:
+            raise ProviderError(
+                self.name,
+                f"data unchanged since our last download of '{celestrak_group}' "
+                f"(CelesTrak refreshes every 2h)",
+            )
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ProviderError(
+                self.name, f"HTTP {exc.response.status_code} for '{celestrak_group}'"
+            ) from exc
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise ProviderError(
+                self.name, f"non-JSON response for '{celestrak_group}'"
+            ) from exc
+
+        # On an unknown group CelesTrak answers 200 with an error string, not a list.
+        if not isinstance(data, list):
+            raise ProviderError(
+                self.name,
+                f"unexpected response for '{celestrak_group}': {str(data)[:120]}",
+            )
+
+        logger.info(f"[CelesTrak] '{celestrak_group}': {len(data)} records.")
+        return data

--- a/backend/orbital/providers/chain.py
+++ b/backend/orbital/providers/chain.py
@@ -1,0 +1,96 @@
+"""
+Priority chain over the satellite data providers.
+
+Tries each provider in order and returns the first usable answer, so a single upstream
+outage no longer stops ingestion. Whatever a remote provider returns is written to the
+local cache, which is what lets the last link in the chain keep serving data when every
+remote source is down.
+
+    Space-Track  ->  CelesTrak  ->  local cache
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from database.session import MongoSession
+from orbital.providers.base import (
+    AllProvidersFailedError,
+    ProviderError,
+    SatelliteDataProvider,
+)
+from orbital.providers.cache import LocalCacheProvider
+
+logger = logging.getLogger("app")
+
+
+class ProviderChain:
+    """Ordered set of providers with automatic failover."""
+
+    def __init__(
+        self,
+        providers: Sequence[SatelliteDataProvider],
+        cache: Optional[LocalCacheProvider] = None,
+    ):
+        self.providers = list(providers)
+        self.cache = cache
+
+    @property
+    def order(self) -> List[str]:
+        return [p.name for p in self.providers]
+
+    def fetch_group(
+        self, group: str, limit: int, db: Optional[MongoSession] = None
+    ) -> Tuple[List[Dict[str, Any]], str]:
+        """
+        Return `(records, provider_name)` from the first provider that can serve `group`.
+
+        Raises `AllProvidersFailedError` — carrying each provider's reason — only when
+        every source has been tried and none produced records.
+        """
+        failures: Dict[str, str] = {}
+
+        for provider in self.providers:
+            if not provider.is_available():
+                reason = "unavailable (not configured or unreachable)"
+                logger.warning(f"[Providers] Skipping '{provider.name}' — {reason}.")
+                failures[provider.name] = reason
+                continue
+
+            try:
+                logger.info(f"[Providers] Trying '{provider.name}' for group '{group}' …")
+                records = provider.fetch_group(group, limit, db=db)
+            except ProviderError as exc:
+                logger.warning(f"[Providers] '{provider.name}' failed: {exc.reason}")
+                failures[provider.name] = exc.reason
+                continue
+            except Exception as exc:
+                # A provider must never take the whole chain down with it.
+                logger.exception(f"[Providers] '{provider.name}' raised unexpectedly: {exc}")
+                failures[provider.name] = f"unexpected error: {exc}"
+                continue
+
+            logger.info(
+                f"[Providers] ✅ '{provider.name}' served {len(records)} records "
+                f"for group '{group}'."
+            )
+            self._cache(group, provider, records, db)
+            return records, provider.name
+
+        logger.error(f"[Providers] ❌ Every provider failed for group '{group}': {failures}")
+        raise AllProvidersFailedError(group, failures)
+
+    def _cache(
+        self,
+        group: str,
+        provider: SatelliteDataProvider,
+        records: List[Dict[str, Any]],
+        db: Optional[MongoSession],
+    ) -> None:
+        """Refresh the local cache from a remote provider's answer, never from itself."""
+        if self.cache is None or db is None or provider is self.cache:
+            return
+        try:
+            self.cache.store(db, group, provider.name, records)
+        except Exception as exc:
+            # Failing to cache must not fail an otherwise successful fetch.
+            logger.warning(f"[Providers] Could not cache group '{group}': {exc}")

--- a/backend/orbital/providers/spacetrack.py
+++ b/backend/orbital/providers/spacetrack.py
@@ -1,0 +1,42 @@
+"""
+Space-Track provider — the primary source.
+
+This wraps the existing `SpaceTrackService` rather than reimplementing it: the service is
+injected, so this module does not import `orbital.spacetrack` and there is no import
+cycle. Everything Space-Track-specific (session auth, retry/backoff, group query paths)
+stays where it already lives.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from database.session import MongoSession
+from orbital.providers.base import ProviderError, SatelliteDataProvider
+
+logger = logging.getLogger("app")
+
+
+class SpaceTrackProvider(SatelliteDataProvider):
+    name = "space-track"
+
+    def __init__(self, service: Any):
+        # Duck-typed: anything exposing authenticate() and fetch_group_json().
+        self.service = service
+
+    def is_available(self) -> bool:
+        """Space-Track needs credentials; without them every request is a wasted round-trip."""
+        return bool(self.service.username and self.service.password)
+
+    def fetch_group(
+        self, group: str, limit: int, db: Optional[MongoSession] = None
+    ) -> List[Dict[str, Any]]:
+        if not self.service.authenticate():
+            raise ProviderError(self.name, "authentication failed")
+
+        records = self.service.fetch_group_json(group, limit=limit)
+        if not records:
+            # fetch_group_json swallows HTTP errors and returns []. For these groups an
+            # empty answer means Space-Track is degraded, not that the sky is empty.
+            raise ProviderError(self.name, f"returned no records for group '{group}'")
+
+        return records

--- a/backend/orbital/spacetrack.py
+++ b/backend/orbital/spacetrack.py
@@ -39,6 +39,7 @@ from pymongo.errors import (
 
 from database.session import MongoSession
 from app.core.config import settings
+from orbital.providers import AllProvidersFailedError, ProviderChain, build_provider_chain
 
 logger = logging.getLogger("app")
 
@@ -130,6 +131,24 @@ class SpaceTrackService:
         self.base_url = "https://www.space-track.org"
         self.client   = httpx.Client(timeout=60.0, follow_redirects=True)
         self._authenticated = False
+        self._providers: Optional["ProviderChain"] = None
+
+    @property
+    def providers(self) -> "ProviderChain":
+        """
+        The multi-source failover chain (Space-Track -> CelesTrak -> cache).
+
+        Built on first use rather than in __init__ so that tests can substitute a chain,
+        and so importing this module never constructs HTTP clients. `getattr` keeps this
+        working for instances created via `__new__` (as the ingestion tests do).
+        """
+        if getattr(self, "_providers", None) is None:
+            self._providers = build_provider_chain(self)
+        return self._providers
+
+    @providers.setter
+    def providers(self, chain: "ProviderChain") -> None:
+        self._providers = chain
 
     # ------------------------------------------------------------------
     # Authentication
@@ -268,10 +287,16 @@ class SpaceTrackService:
     # ------------------------------------------------------------------
 
     def _gp_to_satellite_doc(
-        self, rec: Dict[str, Any], object_type_override: Optional[str] = None
+        self,
+        rec: Dict[str, Any],
+        object_type_override: Optional[str] = None,
+        source: str = "space-track",
     ) -> Dict[str, Any]:
         """
-        Map a Space-Track GP JSON record to a MongoDB satellite/debris document.
+        Map a GP/OMM JSON record to a MongoDB satellite/debris document.
+
+        Every provider speaks this same CCSDS field vocabulary, so the transform is shared;
+        `source` records which one actually served the record.
 
         Field names match the MongoDB Satellite/SpaceObject schema (camelCase):
         noradId, objectName, objectType, meanMotion …  Writing snake_case names
@@ -307,7 +332,7 @@ class SpaceTrackService:
             "inclination":  inclination,
             "eccentricity": eccentricity,
             "meanMotion":   mean_motion,
-            "source":       "space-track",
+            "source":       source,
             "createdAt":    now,
             "updatedAt":    now,
             "semimajor_axis":  semimajor,
@@ -397,17 +422,28 @@ class SpaceTrackService:
             {group, fetched, parsed, upserted, failed, errors}
         """
         if not self._ensure_db_connection(db):
-            return {"group": group, "fetched": 0, "parsed": 0,
-                    "upserted": 0, "failed": 0, "errors": ["db_unreachable"]}
+            return {"group": group, "fetched": 0, "parsed": 0, "upserted": 0,
+                    "failed": 0, "source": None, "errors": ["db_unreachable"]}
 
-        logger.info(f"[SpaceTrack] Upsert start: group '{group}'.")
-        records = self.fetch_group_json(group, limit=limit or 500)
-        if not records:
-            logger.warning(f"[SpaceTrack] Upsert aborted for '{group}': 0 records fetched.")
-            return {"group": group, "fetched": 0, "parsed": 0,
-                    "upserted": 0, "failed": 0, "errors": ["no_records"]}
+        logger.info(f"[Ingest] Upsert start: group '{group}'.")
 
-        logger.info(f"[SpaceTrack] JSON parsing: building docs for {len(records)} records …")
+        # Ask the provider chain rather than Space-Track directly: if Space-Track is down
+        # we fall through to CelesTrak, then to the last cached payload (issue #15).
+        try:
+            records, source = self.providers.fetch_group(group, limit or 500, db=db)
+        except AllProvidersFailedError as exc:
+            logger.error(f"[Ingest] Upsert aborted for '{group}': every provider failed.")
+            return {
+                "group": group, "fetched": 0, "parsed": 0, "upserted": 0, "failed": 0,
+                "source": None,
+                "errors": ["all_providers_failed"],
+                "provider_failures": exc.failures,
+            }
+
+        logger.info(
+            f"[Ingest] JSON parsing: building docs for {len(records)} records "
+            f"from '{source}' …"
+        )
         is_debris = (object_type_override == "DEBRIS" or group in ("analyst", "debris"))
         collection = "debris" if is_debris else "satellites"
 
@@ -415,7 +451,7 @@ class SpaceTrackService:
         parse_errors: List[str] = []
         for rec in records:
             try:
-                doc = self._gp_to_satellite_doc(rec, object_type_override)
+                doc = self._gp_to_satellite_doc(rec, object_type_override, source=source)
                 if doc.get("noradId"):
                     docs.append(doc)
                 else:
@@ -424,14 +460,14 @@ class SpaceTrackService:
                 parse_errors.append(f"{rec.get('NORAD_CAT_ID', '?')}:{exc}")
 
         logger.info(
-            f"[SpaceTrack] Upsert start: writing {len(docs)} docs to '{collection}' "
+            f"[Ingest] Upsert start: writing {len(docs)} docs to '{collection}' "
             f"({len(parse_errors)} unparseable)."
         )
         try:
             upserted, failed_ids = self._bulk_upsert(db, collection, docs)
             logger.info(
-                f"[SpaceTrack] ✅ Upsert success: group '{group}' — {upserted} written, "
-                f"{len(failed_ids)} failed."
+                f"[Ingest] ✅ Upsert success: group '{group}' via '{source}' — "
+                f"{upserted} written, {len(failed_ids)} failed."
             )
             return {
                 "group": group,
@@ -439,16 +475,18 @@ class SpaceTrackService:
                 "parsed": len(docs),
                 "upserted": upserted,
                 "failed": len(failed_ids) + len(parse_errors),
+                "source": source,
                 "errors": failed_ids + parse_errors,
             }
         except Exception as exc:
-            logger.error(f"[SpaceTrack] ❌ Upsert failure: group '{group}': {exc}")
+            logger.error(f"[Ingest] ❌ Upsert failure: group '{group}': {exc}")
             return {
                 "group": group,
                 "fetched": len(records),
                 "parsed": len(docs),
                 "upserted": 0,
                 "failed": len(docs) + len(parse_errors),
+                "source": source,
                 "errors": [str(exc)] + parse_errors,
             }
 

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from orbital.providers.chain import ProviderChain
+from orbital.providers.spacetrack import SpaceTrackProvider
 from orbital.spacetrack import SpaceTrackService, SYNC_GROUPS
 
 
@@ -133,6 +135,11 @@ def _build_service_with_mock_client(payloads_per_group):
 
     mock_client.get.side_effect = _get
     svc.client = mock_client
+
+    # These tests exercise the Space-Track path in isolation, so pin the provider chain to
+    # Space-Track alone. Without this the default chain (issue #15) would fall back to
+    # CelesTrak on any group the mock leaves empty — hitting the real network from a test.
+    svc.providers = ProviderChain([SpaceTrackProvider(svc)])
     return svc
 
 

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1,0 +1,386 @@
+"""
+Tests for multi-source satellite provider support (issue #15).
+
+Acceptance criteria under test:
+  * ingestion does not depend on a single provider
+  * providers are tried in the correct priority order
+  * fallback happens automatically on failure
+  * no single API outage stops ingestion
+
+No network and no MongoDB are required: remote calls are mocked and the cache is backed by
+a fake collection.
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from orbital.providers import build_provider_chain
+from orbital.providers.base import (
+    AllProvidersFailedError,
+    ProviderError,
+    SatelliteDataProvider,
+)
+from orbital.providers.cache import CACHE_COLLECTION, LocalCacheProvider
+from orbital.providers.celestrak import CelesTrakProvider
+from orbital.providers.chain import ProviderChain
+from orbital.providers.spacetrack import SpaceTrackProvider
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+def _gp_record(norad_id: str, name: str = "SAT") -> Dict[str, Any]:
+    return {
+        "NORAD_CAT_ID": norad_id,
+        "OBJECT_NAME": f"{name}-{norad_id}",
+        "EPOCH": "2026-07-14T00:00:00",
+        "MEAN_MOTION": "15.5",
+        "ECCENTRICITY": "0.0001",
+        "INCLINATION": "51.6",
+        "RA_OF_ASC_NODE": "120.0",
+        "ARG_OF_PERICENTER": "90.0",
+        "MEAN_ANOMALY": "270.0",
+    }
+
+
+class StubProvider(SatelliteDataProvider):
+    """A provider that either serves records, fails, or reports itself unavailable."""
+
+    def __init__(self, name: str, records=None, fail: bool = False, available: bool = True):
+        self.name = name
+        self._records = records or []
+        self._fail = fail
+        self._available = available
+        self.calls: List[str] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def fetch_group(self, group: str, limit: int, db: Optional[Any] = None):
+        self.calls.append(group)
+        if self._fail:
+            raise ProviderError(self.name, "simulated outage")
+        return self._records
+
+
+class FakeMongo:
+    """Minimal stand-in for `db.db[collection]` supporting the cache's two operations."""
+
+    def __init__(self):
+        self.store: Dict[str, Dict[str, Any]] = {}
+        self.db = {CACHE_COLLECTION: self}
+
+    def update_one(self, flt, update, upsert=False):
+        self.store[flt["_id"]] = {"_id": flt["_id"], **update["$set"]}
+
+    def find_one(self, flt, projection=None):
+        return self.store.get(flt["_id"])
+
+
+# ---------------------------------------------------------------------------
+# Priority order and automatic failover
+# ---------------------------------------------------------------------------
+
+def test_the_first_healthy_provider_wins_and_the_rest_are_never_called():
+    primary = StubProvider("space-track", records=[_gp_record("25544")])
+    secondary = StubProvider("celestrak", records=[_gp_record("99999")])
+    chain = ProviderChain([primary, secondary])
+
+    records, source = chain.fetch_group("active", 100)
+
+    assert source == "space-track"
+    assert records[0]["NORAD_CAT_ID"] == "25544"
+    assert secondary.calls == [], "the fallback must not be hit when the primary works"
+
+
+def test_failure_falls_through_to_the_next_provider_automatically():
+    primary = StubProvider("space-track", fail=True)
+    secondary = StubProvider("celestrak", records=[_gp_record("99999")])
+    chain = ProviderChain([primary, secondary])
+
+    records, source = chain.fetch_group("active", 100)
+
+    assert source == "celestrak"
+    assert records[0]["NORAD_CAT_ID"] == "99999"
+    assert primary.calls == ["active"], "the primary must be tried before the fallback"
+
+
+def test_an_unavailable_provider_is_skipped_without_being_called():
+    primary = StubProvider("space-track", available=False)
+    secondary = StubProvider("celestrak", records=[_gp_record("1")])
+    chain = ProviderChain([primary, secondary])
+
+    _, source = chain.fetch_group("active", 100)
+
+    assert source == "celestrak"
+    assert primary.calls == []
+
+
+def test_providers_are_tried_in_the_declared_order():
+    tried: List[str] = []
+
+    class Recorder(StubProvider):
+        def fetch_group(self, group, limit, db=None):
+            tried.append(self.name)
+            return super().fetch_group(group, limit, db)
+
+    chain = ProviderChain([
+        Recorder("space-track", fail=True),
+        Recorder("celestrak", fail=True),
+        Recorder("cache", records=[_gp_record("1")]),
+    ])
+
+    _, source = chain.fetch_group("active", 100)
+
+    assert tried == ["space-track", "celestrak", "cache"]
+    assert source == "cache"
+
+
+def test_a_crashing_provider_does_not_take_the_chain_down():
+    class Exploding(StubProvider):
+        def fetch_group(self, group, limit, db=None):
+            raise RuntimeError("boom")  # not a ProviderError
+
+    chain = ProviderChain([
+        Exploding("space-track"),
+        StubProvider("celestrak", records=[_gp_record("1")]),
+    ])
+
+    _, source = chain.fetch_group("active", 100)
+    assert source == "celestrak"
+
+
+def test_all_providers_failing_reports_every_reason():
+    chain = ProviderChain([
+        StubProvider("space-track", fail=True),
+        StubProvider("celestrak", fail=True),
+        StubProvider("cache", fail=True),
+    ])
+
+    with pytest.raises(AllProvidersFailedError) as exc_info:
+        chain.fetch_group("active", 100)
+
+    failures = exc_info.value.failures
+    assert set(failures) == {"space-track", "celestrak", "cache"}
+    assert "simulated outage" in failures["space-track"]
+
+
+# ---------------------------------------------------------------------------
+# The cache is what makes a total outage survivable
+# ---------------------------------------------------------------------------
+
+def test_a_successful_remote_fetch_is_written_to_the_cache():
+    db = FakeMongo()
+    cache = LocalCacheProvider()
+    chain = ProviderChain([StubProvider("space-track", records=[_gp_record("25544")])], cache=cache)
+
+    chain.fetch_group("active", 100, db=db)
+
+    cached = db.store["active"]
+    assert cached["source"] == "space-track"
+    assert cached["count"] == 1
+    assert cached["records"][0]["NORAD_CAT_ID"] == "25544"
+
+
+def test_ingestion_survives_a_total_remote_outage_by_replaying_the_cache():
+    """The headline acceptance criterion: no single API outage stops data ingestion."""
+    db = FakeMongo()
+    cache = LocalCacheProvider()
+
+    # A good day: Space-Track answers, and the payload is cached.
+    healthy = ProviderChain([StubProvider("space-track", records=[_gp_record("25544")])], cache=cache)
+    healthy.fetch_group("active", 100, db=db)
+
+    # A bad day: both remote sources are down.
+    degraded = ProviderChain(
+        [
+            StubProvider("space-track", fail=True),
+            StubProvider("celestrak", fail=True),
+            cache,
+        ],
+        cache=cache,
+    )
+    records, source = degraded.fetch_group("active", 100, db=db)
+
+    assert source == "cache"
+    assert records[0]["NORAD_CAT_ID"] == "25544"
+
+
+def test_the_cache_does_not_overwrite_itself_when_it_serves_a_request():
+    db = FakeMongo()
+    cache = LocalCacheProvider()
+    cache.store(db, "active", "space-track", [_gp_record("25544")])
+    cached_at = db.store["active"]["cachedAt"]
+
+    chain = ProviderChain([cache], cache=cache)
+    chain.fetch_group("active", 100, db=db)
+
+    # Serving from cache must not refresh the timestamp: the data is still just as stale.
+    assert db.store["active"]["cachedAt"] == cached_at
+
+
+def test_an_empty_cache_fails_rather_than_returning_nothing():
+    cache = LocalCacheProvider()
+    with pytest.raises(ProviderError):
+        cache.fetch_group("active", 100, db=FakeMongo())
+
+
+# ---------------------------------------------------------------------------
+# Space-Track provider
+# ---------------------------------------------------------------------------
+
+def test_spacetrack_provider_is_unavailable_without_credentials():
+    service = MagicMock(username=None, password=None)
+    assert SpaceTrackProvider(service).is_available() is False
+
+    service = MagicMock(username="u", password="p")
+    assert SpaceTrackProvider(service).is_available() is True
+
+
+def test_spacetrack_provider_treats_an_empty_answer_as_a_failure():
+    """An empty 'active' catalog means Space-Track is degraded, not that the sky is empty."""
+    service = MagicMock(username="u", password="p")
+    service.authenticate.return_value = True
+    service.fetch_group_json.return_value = []
+
+    with pytest.raises(ProviderError):
+        SpaceTrackProvider(service).fetch_group("active", 100)
+
+
+def test_spacetrack_provider_fails_when_authentication_is_rejected():
+    service = MagicMock(username="u", password="p")
+    service.authenticate.return_value = False
+
+    with pytest.raises(ProviderError, match="authentication failed"):
+        SpaceTrackProvider(service).fetch_group("active", 100)
+
+
+# ---------------------------------------------------------------------------
+# CelesTrak provider
+# ---------------------------------------------------------------------------
+
+def _celestrak_provider(handler) -> CelesTrakProvider:
+    provider = CelesTrakProvider(base_url="https://celestrak.test")
+    provider.client = httpx.Client(transport=httpx.MockTransport(handler))
+    return provider
+
+
+def test_celestrak_returns_omm_records_and_respects_the_limit():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["GROUP"] == "active"
+        assert request.url.params["FORMAT"] == "json"
+        return httpx.Response(200, json=[_gp_record(str(i)) for i in range(10)])
+
+    records = _celestrak_provider(handler).fetch_group("active", limit=3)
+
+    assert len(records) == 3
+    assert records[0]["NORAD_CAT_ID"] == "0"
+
+
+def test_celestrak_maps_debris_onto_the_tracked_debris_clouds():
+    seen: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.params["GROUP"])
+        return httpx.Response(200, json=[_gp_record("1")])
+
+    _celestrak_provider(handler).fetch_group("debris", limit=500)
+
+    assert "cosmos-2251-debris" in seen
+    assert all("debris" in g for g in seen)
+
+
+def test_celestrak_raises_on_an_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    with pytest.raises(ProviderError, match="503"):
+        _celestrak_provider(handler).fetch_group("active", limit=10)
+
+
+def test_celestrak_rate_limit_falls_through_to_the_cache_instead_of_erroring_out():
+    """
+    CelesTrak answers 403 when the data has not changed since our last download (it
+    refreshes GP every 2 hours). This is the response it actually sends:
+
+        "GP data has not updated since your last successful download of
+         GROUP=starlink at 2026-07-14 17:57:21 UTC. Data is updated once every 2 hours."
+
+    Kepler's scheduler polls far more often than that, so this must degrade to the cached
+    payload rather than being reported as an outage.
+    """
+    body = (
+        "GP data has not updated since your last successful download of "
+        "GROUP=starlink at 2026-07-14 17:57:21 UTC. Data is updated once every 2 hours."
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text=body)
+
+    provider = _celestrak_provider(handler)
+    with pytest.raises(ProviderError, match="data unchanged"):
+        provider.fetch_group("starlink", limit=10)
+
+    # And the chain turns that into a cache hit rather than a failed sync.
+    db = FakeMongo()
+    cache = LocalCacheProvider()
+    cache.store(db, "starlink", "celestrak", [_gp_record("25544")])
+
+    records, source = ProviderChain([provider, cache], cache=cache).fetch_group(
+        "starlink", 10, db=db
+    )
+    assert source == "cache"
+    assert records[0]["NORAD_CAT_ID"] == "25544"
+
+
+def test_celestrak_raises_when_the_response_is_not_a_record_list():
+    """CelesTrak answers an unknown group with HTTP 200 and an error string."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"error": "Invalid query"})
+
+    with pytest.raises(ProviderError):
+        _celestrak_provider(handler).fetch_group("active", limit=10)
+
+
+def test_celestrak_keeps_the_debris_clouds_that_did_answer():
+    """One failing sub-group must not discard the records the others returned."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params["GROUP"] == "cosmos-1408-debris":
+            return httpx.Response(500)
+        return httpx.Response(200, json=[_gp_record("42")])
+
+    records = _celestrak_provider(handler).fetch_group("debris", limit=500)
+    assert len(records) > 0
+
+
+# ---------------------------------------------------------------------------
+# Chain assembly from configuration
+# ---------------------------------------------------------------------------
+
+def test_the_default_chain_is_spacetrack_then_celestrak_then_cache():
+    chain = build_provider_chain(MagicMock(username="u", password="p"))
+    assert chain.order == ["space-track", "celestrak", "cache"]
+
+
+def test_the_priority_order_is_configurable(monkeypatch):
+    from app.core import config
+
+    monkeypatch.setattr(config.settings, "SATELLITE_PROVIDER_PRIORITY", "celestrak,cache")
+    chain = build_provider_chain(MagicMock(username="u", password="p"))
+
+    assert chain.order == ["celestrak", "cache"]
+
+
+def test_an_unknown_provider_name_is_ignored_rather_than_crashing(monkeypatch):
+    from app.core import config
+
+    monkeypatch.setattr(
+        config.settings, "SATELLITE_PROVIDER_PRIORITY", "space-track,not-a-provider,cache"
+    )
+    chain = build_provider_chain(MagicMock(username="u", password="p"))
+
+    assert chain.order == ["space-track", "cache"]


### PR DESCRIPTION
## **User description**
## Description

Satellite ingestion no longer depends on a single upstream. Sources are tried in priority order and the first one that answers wins:

```
Space-Track  →  CelesTrak  →  local cache
```

### How it works

- **`orbital/providers/`** — every provider returns **GP/OMM records**, the CCSDS field names Space-Track already serves. That is exactly the shape `_gp_to_satellite_doc` already consumes, so all sources feed the existing pipeline **without touching the transform**. Adding a fourth source later means adding one class, not rewiring ingestion.
- **`ProviderChain`** walks the list, skips providers that report themselves unavailable (e.g. Space-Track with no credentials — no point paying for a doomed round-trip), catches provider failures *and* unexpected crashes, and falls through. Only when every source is exhausted does it raise `AllProvidersFailedError`, carrying the reason each one gave.
- **CelesTrak needs no credentials**, which makes it a genuinely independent fallback: a Space-Track outage, an expired password or a rate-limit does not affect it.
- **`LocalCacheProvider`** stores every successful remote payload and replays it when both remote sources are down. This is what actually keeps ingestion alive during a total outage. Stale data is logged and labelled as stale — never passed off as fresh.
- Priority is configurable via `SATELLITE_PROVIDER_PRIORITY` (default `space-track,celestrak,cache`).
- Ingested documents now record **which** provider served them (`source`), the sync status reports it, and **`GET /catalog/providers`** shows the chain and its health:

```json
{
  "success": true,
  "message": "2/3 providers available — space-track → celestrak → cache",
  "data": { "providers": [
    { "name": "space-track", "priority": 1, "available": false },
    { "name": "celestrak",   "priority": 2, "available": true  },
    { "name": "cache",       "priority": 3, "available": true  }
  ]}
}
```

### One finding worth flagging

**CelesTrak's `403` is a rate limit, not an outage.** It declines to resend GP data that hasn't changed since your last download:

> `GP data has not updated since your last successful download of GROUP=starlink at 2026-07-14 17:57:21 UTC. Data is updated once every 2 hours.`

Kepler's scheduler polls **every 5 minutes**, so this is the *common* case, not an edge case. Treating it as a failure would have made CelesTrak look permanently broken. It is now handled explicitly and degrades to the cached payload — which holds exactly the data CelesTrak is declining to resend. I found this by calling the real API, not by reading the docs.

## Related Issue

Fixes #15

- [x] Data ingestion does not depend on a single provider
- [x] Providers are tried in the correct priority order
- [x] Fallback happens automatically on failure
- [x] No single API outage stops data ingestion

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [x] Documentation has been updated (if applicable) — new endpoint + settings are documented in OpenAPI and `config.py`

## Testing

**48 passed** (22 new in `tests/test_providers.py`). They need **no network and no MongoDB**: CelesTrak is driven through `httpx.MockTransport` and the cache through a fake collection, so they run on a clean CI runner.

Covered: priority order is honoured, the fallback is not called when the primary works, an unavailable provider is skipped without a request, a provider that crashes (rather than raising `ProviderError`) does not take the chain down, all-providers-failed reports every reason, a total remote outage is survived by replaying the cache, and the CelesTrak rate-limit degrades to the cache.

**Verified against the live CelesTrak API**: 16,021 real records fetched for `active` and run through the existing transform, producing valid documents (`CALSPHERE 1`, NORAD 900, `source: celestrak`) — i.e. ingestion genuinely works with Space-Track out of the picture.

> Note: I had to pin the existing Space-Track ingestion tests to a Space-Track-only chain (2 lines in their fixture). Without it, the new fallback made those tests reach the **real network** on any group their mock left empty. Their intent is unchanged.

## Breaking Changes

None to the API contract. Two additive changes: ingested documents carry `source: "space-track" | "celestrak" | "cache"` (previously hardcoded to `space-track`), and the sync status dict gains `source` / `provider_failures`.

___

## **CodeAnt-AI Description**
**Add multi-source satellite ingestion with automatic failover**

### What Changed
- Ingestion now tries Space-Track, CelesTrak, then the local cache in priority order, and uses the first source that returns data
- If a source is unavailable, returns no records, or fails during a request, ingestion falls through instead of stopping
- Successful remote responses are saved to the local cache, so ingestion can keep working during a full upstream outage
- Each ingested record now shows which source supplied it, and the sync result includes that source
- A new `GET /catalog/providers` endpoint shows the current provider order and which sources are available

### Impact
`✅ Fewer ingestion stoppages during provider outages`
`✅ Clearer sync results when a fallback source is used`
`✅ Faster diagnosis of unavailable satellite data sources`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added satellite data provider failover across Space-Track, CelesTrak, and local cache sources.
  - Added a catalog endpoint to view provider availability and failover order.
  - Satellite synchronization now reports its source, record counts, and provider failures.
  - Added cached-data fallback when remote providers are unavailable.

- **Bug Fixes**
  - Improved sync error handling and visibility when all data sources fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the single-provider Space-Track ingestion with a three-link failover chain (Space-Track → CelesTrak → local cache), surfacing which provider served each sync and adding a `/catalog/providers` health endpoint. The implementation is well-structured — each provider implements a clean `SatelliteDataProvider` contract, the chain catches both expected `ProviderError` and unexpected crashes, and the CelesTrak 403 rate-limit is handled explicitly rather than masking CelesTrak as permanently broken.

- **Provider chain (`orbital/providers/`)**: new `SpaceTrackProvider`, `CelesTrakProvider`, `LocalCacheProvider`, and `ProviderChain` wired by `build_provider_chain`; ingestion in `spacetrack.py` now delegates to the chain and records `source` on every upserted document.
- **Cache write-through is always active**: `build_provider_chain` unconditionally passes a `LocalCacheProvider` as `cache=` to `ProviderChain`, so successful remote fetches are written to `provider_cache` even when \"cache\" is excluded from `SATELLITE_PROVIDER_PRIORITY`.
- **Debris group coverage gap**: `CelesTrakProvider.fetch_group` exits the debris-cloud loop as soon as `len(records) >= limit`; since `cosmos-1408-debris` alone can return 1,500+ objects vs. the default limit of 500, the remaining three debris clouds are silently skipped and the cached payload covers only one of four clouds.

<h3>Confidence Score: 3/5</h3>

Merge with caution — the debris coverage gap silently drops three of four tracked debris clouds from the cache whenever the first cloud alone meets the fetch limit.

The failover chain itself is well-designed and the happy-path ingestion is correct. The most consequential issue is in CelesTrakProvider.fetch_group: the early-exit loop means that in practice, with cosmos-1408-debris alone exceeding the 500-record default limit, the other three debris clouds are never queried. The provider_cache entry for debris then contains only one cloud's data, and every subsequent cache-replayed sync during an outage serves that incomplete set without warning.

backend/orbital/providers/celestrak.py (debris loop limit logic) and backend/orbital/providers/__init__.py (unconditional cache wiring) need the most attention before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| backend/orbital/providers/celestrak.py | New CelesTrak provider with 403 rate-limit handling; debris group loop breaks on limit before all 4 clouds are fetched, potentially caching incomplete debris data. |
| backend/orbital/providers/__init__.py | Factory for the provider chain; always passes a LocalCacheProvider as write-through cache regardless of whether "cache" appears in SATELLITE_PROVIDER_PRIORITY. |
| backend/orbital/spacetrack.py | Core ingestion now delegates to ProviderChain; lazy providers init is not thread-safe and could create orphaned httpx.Client connections under concurrency. |
| backend/orbital/providers/chain.py | ProviderChain correctly skips unavailable providers, catches unexpected exceptions, and writes successful remote results to the local cache; logic is sound. |
| backend/orbital/providers/cache.py | LocalCacheProvider stores and replays GP records; raises on empty cache, avoids overwriting itself on serve, logs stale-data warnings clearly. |
| backend/api/v1/endpoints/catalog.py | New GET /catalog/providers endpoint and updated sync error handling; both are straightforward additions with correct error discrimination. |
| backend/tests/test_providers.py | 22 new tests covering priority order, failover, and CelesTrak mocking; debris limit boundary (first cloud exceeds limit) is not covered. |
| backend/tests/test_ingestion.py | Correctly pins existing ingestion tests to a Space-Track-only chain to prevent accidental network calls via the new fallback. |
| backend/app/core/config.py | Adds SATELLITE_PROVIDER_PRIORITY and CELESTRAK_BASE_URL settings with sensible defaults; no issues. |
| backend/orbital/providers/base.py | Clean abstract base with ProviderError and AllProvidersFailedError; contract is well-documented. |
| backend/orbital/providers/spacetrack.py | Thin adapter over SpaceTrackService; correctly raises ProviderError on empty response and failed auth; no circular import via injection. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Scheduler
    participant ST as upsert_group
    participant PC as ProviderChain
    participant STP as SpaceTrackProvider
    participant CT as CelesTrakProvider
    participant LC as LocalCacheProvider
    participant DB as MongoDB

    S->>ST: upsert_group(group, limit, db)
    ST->>PC: fetch_group(group, limit, db)
    PC->>STP: is_available()?
    alt credentials present
        STP-->>PC: True
        PC->>STP: fetch_group(group, limit)
        alt Space-Track OK
            STP-->>PC: records[]
            PC->>LC: store(db, group, space-track, records)
            PC-->>ST: records, space-track
        else Space-Track fails
            STP-->>PC: ProviderError
            PC->>CT: fetch_group(group, limit)
            alt CelesTrak OK
                CT-->>PC: records[]
                PC->>LC: store(db, group, celestrak, records)
                PC-->>ST: records, celestrak
            else 403 or error
                CT-->>PC: ProviderError
                PC->>LC: fetch_group(group, limit, db)
                alt cache populated
                    LC->>DB: find_one
                    DB-->>LC: cached doc
                    LC-->>PC: stale records[]
                    PC-->>ST: records, cache
                else empty cache
                    LC-->>PC: ProviderError
                    PC-->>ST: AllProvidersFailedError
                end
            end
        end
    else no credentials
        STP-->>PC: False, skip to CelesTrak
    end
    ST->>DB: bulk upsert
    ST-->>S: status with source
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Scheduler
    participant ST as upsert_group
    participant PC as ProviderChain
    participant STP as SpaceTrackProvider
    participant CT as CelesTrakProvider
    participant LC as LocalCacheProvider
    participant DB as MongoDB

    S->>ST: upsert_group(group, limit, db)
    ST->>PC: fetch_group(group, limit, db)
    PC->>STP: is_available()?
    alt credentials present
        STP-->>PC: True
        PC->>STP: fetch_group(group, limit)
        alt Space-Track OK
            STP-->>PC: records[]
            PC->>LC: store(db, group, space-track, records)
            PC-->>ST: records, space-track
        else Space-Track fails
            STP-->>PC: ProviderError
            PC->>CT: fetch_group(group, limit)
            alt CelesTrak OK
                CT-->>PC: records[]
                PC->>LC: store(db, group, celestrak, records)
                PC-->>ST: records, celestrak
            else 403 or error
                CT-->>PC: ProviderError
                PC->>LC: fetch_group(group, limit, db)
                alt cache populated
                    LC->>DB: find_one
                    DB-->>LC: cached doc
                    LC-->>PC: stale records[]
                    PC-->>ST: records, cache
                else empty cache
                    LC-->>PC: ProviderError
                    PC-->>ST: AllProvidersFailedError
                end
            end
        end
    else no credentials
        STP-->>PC: False, skip to CelesTrak
    end
    ST->>DB: bulk upsert
    ST-->>S: status with source
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/orbital/spacetrack.py`, line 625-636 ([link](https://github.com/7-blocks/kepler/blob/b0f75ae65ba985255f39d416d8d99943b0e809ac/backend/orbital/spacetrack.py#L625-L636)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Non-atomic lazy init of `providers` property is not thread-safe**

   The check-then-assign pattern `if getattr(self, "_providers", None) is None: self._providers = build_provider_chain(self)` is not atomic. In a multi-threaded FastAPI deployment two concurrent requests can both observe `None` simultaneously and each call `build_provider_chain`, creating two separate `CelesTrakProvider` instances each with its own `httpx.Client` connection pool. The "loser" assignment is silently overwritten and its client is orphaned until GC collects it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/orbital/spacetrack.py
   Line: 625-636

   Comment:
   **Non-atomic lazy init of `providers` property is not thread-safe**

   The check-then-assign pattern `if getattr(self, "_providers", None) is None: self._providers = build_provider_chain(self)` is not atomic. In a multi-threaded FastAPI deployment two concurrent requests can both observe `None` simultaneously and each call `build_provider_chain`, creating two separate `CelesTrakProvider` instances each with its own `httpx.Client` connection pool. The "loser" assignment is silently overwritten and its client is orphaned until GC collects it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
backend/orbital/providers/celestrak.py:61-63
**Debris group completeness breaks when first cloud exceeds limit**

The `break` fires as soon as `len(records) >= limit`. For the `debris`/`analyst` group (mapped to 4 clouds), `cosmos-1408-debris` alone contains ~1,500+ tracked objects in CelesTrak — well above the default `limit` of 500. When that happens the other three clouds (`fengyun-1c-debris`, `iridium-33-debris`, `cosmos-2251-debris`) are never fetched. The 500 records stored in the `provider_cache` then represent only that one cloud, and when the cache is replayed during a remote outage, coverage across the remaining three debris fields is silently absent for every sync until a full refresh occurs. The existing test (`test_celestrak_maps_debris_onto_the_tracked_debris_clouds`) uses 1 record per cloud so the break never fires there — it does not exercise this path.

### Issue 2 of 2
backend/orbital/spacetrack.py:625-636
**Non-atomic lazy init of `providers` property is not thread-safe**

The check-then-assign pattern `if getattr(self, "_providers", None) is None: self._providers = build_provider_chain(self)` is not atomic. In a multi-threaded FastAPI deployment two concurrent requests can both observe `None` simultaneously and each call `build_provider_chain`, creating two separate `CelesTrakProvider` instances each with its own `httpx.Client` connection pool. The "loser" assignment is silently overwritten and its client is orphaned until GC collects it.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ingestion): multi-source satellite ..."](https://github.com/7-blocks/kepler/commit/b0f75ae65ba985255f39d416d8d99943b0e809ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44216337)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->