### PR TITLE
Improved mobile responsiveness

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,6 +74,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -332,27 +333,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -638,7 +618,6 @@
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
       "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -687,7 +666,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -704,7 +682,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,7 +698,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,7 +714,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -755,7 +730,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -772,7 +746,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,7 +762,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -806,7 +778,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -823,7 +794,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -840,7 +810,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -857,7 +826,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -874,7 +842,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -891,7 +858,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -910,7 +876,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -927,7 +892,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -941,7 +905,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
@@ -1444,8 +1407,9 @@
       "version": "24.13.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
       "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1454,8 +1418,9 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1464,8 +1429,9 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1528,6 +1494,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -1839,6 +1806,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1956,6 +1924,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1996,6 +1965,7 @@
       "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.142.0.tgz",
       "integrity": "sha512-Z6mBxdeBS0lEXM7WAQgG8Q0FovXYAJpZsMOSWgd7dH28Ov+djJxWOlUMiG8jOai0TzeOYdYsMLgnYb2uB/aI/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "workspaces": [
         "packages/engine",
         "packages/widgets",
@@ -2069,7 +2039,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2175,6 +2145,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2429,6 +2400,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2651,7 +2623,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2771,7 +2742,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2882,6 +2852,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -3441,7 +3412,6 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3580,15 +3550,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3600,7 +3569,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3686,6 +3654,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3695,6 +3664,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3707,6 +3677,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3718,11 +3689,19 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3813,7 +3792,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3834,7 +3814,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.133.0",
@@ -3862,6 +3841,22 @@
         "@rolldown/binding-wasm32-wasi": "1.0.3",
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-external-globals": {
@@ -4057,7 +4052,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4131,6 +4125,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4167,7 +4162,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -4261,8 +4256,8 @@
       "version": "8.0.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4401,6 +4396,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -442,74 +442,74 @@ export const EarthTwin: React.FC = () => {
       )}
 
       {/* ── HUD Overlay ───────────────────────────────────────── */}
-      <div className="absolute inset-0 p-6 flex flex-col justify-between z-10 pointer-events-none">
+      <div className="absolute inset-0 p-3 md:p-6 flex flex-col justify-between z-10 pointer-events-none overflow-hidden">
 
         {/* Top Row */}
-        <div className="flex justify-between items-start">
-          <div className="glass-panel p-4 border-l-4 border-l-primary-container animate-[slideDown_0.5s_ease-out]">
-            <p className="font-label-caps text-label-caps text-primary-container/80 drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
+        <div className="flex flex-col sm:flex-row justify-between items-start gap-2">
+          <div className="glass-panel p-2 md:p-4 border-l-4 border-l-primary-container animate-[slideDown_0.5s_ease-out] max-w-[70%] sm:max-w-none">
+            <p className="font-label-caps text-[9px] md:text-label-caps text-primary-container/80 drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
               ORBITAL INTELLIGENCE
             </p>
-            <h2 className="font-display-lg text-headline-lg font-bold text-on-surface">
+            <h2 className="font-display-lg text-sm md:text-headline-lg font-bold text-on-surface">
               {activeSector ? activeSector.toUpperCase() : 'GLOBAL VIEW'}
             </h2>
             {dataLoaded && (
-              <p className="font-technical-data text-[10px] text-on-surface-variant mt-1">
+              <p className="font-technical-data text-[9px] md:text-[10px] text-on-surface-variant mt-1">
                 {objectCounts.total.toLocaleString()} objects tracked · Synced {stats.lastSync}
               </p>
             )}
           </div>
 
-          <div className="text-right space-y-1 animate-[slideDown_0.5s_ease-out]">
+          <div className="text-right space-y-1 animate-[slideDown_0.5s_ease-out] hidden sm:block">
             {objectCounts.collisions > 0 ? (
-              <div className="bg-status-emergency/20 border border-status-emergency px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
+              <div className="bg-status-emergency/20 border border-status-emergency px-3 md:px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
                 <MaterialIcon name="warning" className="text-status-emergency text-sm animate-pulse" />
-                <span className="font-technical-data text-status-emergency text-[12px] font-bold">
+                <span className="font-technical-data text-status-emergency text-[11px] md:text-[12px] font-bold">
                   {objectCounts.collisions} ACTIVE CONJUNCTION{objectCounts.collisions !== 1 ? 'S' : ''}
                 </span>
               </div>
             ) : (
-              <div className="bg-status-success/20 border border-status-success px-4 py-1 flex items-center gap-2">
+              <div className="bg-status-success/20 border border-status-success px-3 md:px-4 py-1 flex items-center gap-2">
                 <MaterialIcon name="verified_user" className="text-status-success text-sm" />
-                <span className="font-technical-data text-status-success text-[12px] font-bold">
-                  ALL CLEAR — NO CONJUNCTION RISKS
+                <span className="font-technical-data text-status-success text-[11px] md:text-[12px] font-bold">
+                  ALL CLEAR
                 </span>
               </div>
             )}
-            <p className="font-technical-data text-[10px] text-primary/70">
+            <p className="font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block">
               WEATHER: {stats.weatherIndex} · DATA SOURCE: SPACE-TRACK / NASA DONKI
             </p>
           </div>
         </div>
 
         {/* Bottom Row */}
-        <div className="flex gap-6 items-end justify-between animate-[slideUp_0.5s_ease-out]">
-          <div className="flex gap-8">
-            <div className="space-y-1">
-              <p className="font-label-caps text-[10px] text-primary/70 uppercase">Objects Tracked</p>
-              <p className="font-headline-lg text-primary text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-6 items-start sm:items-end justify-between animate-[slideUp_0.5s_ease-out]">
+          <div className="flex gap-4 md:gap-8 flex-wrap">
+            <div className="space-y-0.5">
+              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
+              <p className="font-headline-lg text-primary text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
                 {objectCounts.total.toLocaleString()}
               </p>
             </div>
-            <div className="space-y-1">
-              <p className="font-label-caps text-[10px] text-primary/70 uppercase">Debris</p>
-              <p className="font-headline-lg text-status-warning text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(255,170,0,0.4)]">
+            <div className="space-y-0.5">
+              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Debris</p>
+              <p className="font-headline-lg text-status-warning text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(255,170,0,0.4)]">
                 {objectCounts.debris.toLocaleString()}
               </p>
             </div>
-            <div className="space-y-1">
-              <p className="font-label-caps text-[10px] text-primary/70 uppercase">Collision Risks</p>
-              <p className={`font-headline-lg text-3xl font-bold font-technical-data ${objectCounts.collisions > 0 ? 'text-status-emergency animate-pulse drop-shadow-[0_0_8px_rgba(255,59,48,0.6)]' : 'text-status-success drop-shadow-[0_0_8px_rgba(0,255,136,0.4)]'}`}>
+            <div className="space-y-0.5">
+              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Collision Risks</p>
+              <p className={`font-headline-lg text-xl md:text-3xl font-bold font-technical-data ${objectCounts.collisions > 0 ? 'text-status-emergency animate-pulse drop-shadow-[0_0_8px_rgba(255,59,48,0.6)]' : 'text-status-success drop-shadow-[0_0_8px_rgba(0,255,136,0.4)]'}`}>
                 {objectCounts.collisions}
               </p>
             </div>
           </div>
 
           {/* Controls */}
-          <div className="flex gap-2 pointer-events-auto">
+          <div className="flex gap-1.5 md:gap-2 pointer-events-auto">
             <button
               onClick={() => setShowLegend(v => !v)}
-              className={`px-4 py-2.5 font-bold text-xs transition-all active:scale-95 cursor-pointer border ${
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-all active:scale-95 cursor-pointer border ${
                 showLegend ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
               }`}
             >
@@ -517,7 +517,7 @@ export const EarthTwin: React.FC = () => {
             </button>
             <button
               onClick={() => setShowDensity(v => !v)}
-              className={`px-4 py-2.5 font-bold text-xs transition-all active:scale-95 cursor-pointer border ${
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-all active:scale-95 cursor-pointer border ${
                 showDensity ? 'bg-status-warning text-bg-deep-space border-status-warning' : 'border-status-warning/50 text-status-warning hover:bg-status-warning/10'
               }`}
             >
@@ -525,7 +525,7 @@ export const EarthTwin: React.FC = () => {
             </button>
             <button
               onClick={() => setShowRiskOverlay(v => !v)}
-              className={`px-4 py-2.5 font-bold text-xs transition-all active:scale-95 cursor-pointer border ${
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-all active:scale-95 cursor-pointer border ${
                 showRiskOverlay ? 'bg-status-emergency text-white border-status-emergency' : 'border-status-emergency/50 text-status-emergency hover:bg-status-emergency/10'
               }`}
             >
@@ -537,7 +537,7 @@ export const EarthTwin: React.FC = () => {
 
       {/* ── Legend Panel ───────────────────────────────────────── */}
       {showLegend && (
-        <div className="absolute bottom-24 left-6 z-20 pointer-events-auto animate-[slideUp_0.3s_ease-out]">
+        <div className="absolute bottom-16 md:bottom-24 left-3 md:left-6 z-20 pointer-events-auto animate-[slideUp_0.3s_ease-out]">
           <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[200px] shadow-[0_0_30px_rgba(0,0,0,0.6)]">
             <div className="flex justify-between items-center mb-3">
               <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">ORBITAL LEGEND</span>
@@ -573,15 +573,10 @@ export const EarthTwin: React.FC = () => {
 
       {/* ── Loading Indicator ─────────────────────────────────── */}
       {!useFallback && !dataLoaded && (
-        <div className="absolute inset-0 z-30 flex items-center justify-center pointer-events-none">
-          <div className="bg-bg-deep-space/80 backdrop-blur-xl border border-primary-container/30 px-8 py-6 flex flex-col items-center gap-3 shadow-[0_0_40px_rgba(0,229,255,0.15)]">
-            <MaterialIcon name="satellite_alt" className="text-primary-container text-4xl animate-pulse" />
-            <p className="font-label-caps text-label-caps text-primary-container font-bold tracking-widest">
-              LOADING ORBITAL DATA
-            </p>
-            <p className="font-technical-data text-[10px] text-on-surface-variant">
-              Fetching real catalog objects from Space-Track GP API…
-            </p>
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-30 pointer-events-none">
+          <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-primary-container/50 px-4 py-2 flex items-center gap-3 rounded-full shadow-[0_0_20px_rgba(0,229,255,0.2)]">
+            <MaterialIcon name="sync" className="text-primary-container text-sm animate-spin" />
+            <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">LOADING ORBITAL DATA...</span>
           </div>
         </div>
       )}

--- a/frontend/src/components/layouts/MainLayout.tsx
+++ b/frontend/src/components/layouts/MainLayout.tsx
@@ -14,6 +14,7 @@ export const MainLayout: React.FC = () => {
 
   const location = useLocation();
   const [utcTime, setUtcTime] = useState<string>('00:00:00 UTC');
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
 
   useEffect(() => {
@@ -29,6 +30,11 @@ export const MainLayout: React.FC = () => {
     const interval = setInterval(updateTime, 1000);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    // Close mobile sidebar on route change
+    setMobileSidebarOpen(false);
+  }, [location.pathname]);
 
   const navItems = [
     { name: 'Dashboard', path: '/', icon: 'dashboard' },
@@ -68,30 +74,50 @@ export const MainLayout: React.FC = () => {
       <div className="scanlines" />
 
       {/* Main Container */}
-      <div className="flex w-full h-full">
+      <div className="flex w-full h-full relative">
+
+        {/* Mobile Sidebar Overlay */}
+        <AnimatePresence>
+          {mobileSidebarOpen && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setMobileSidebarOpen(false)}
+              className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40 md:hidden"
+            />
+          )}
+        </AnimatePresence>
 
         {/* Left Navigation Sidebar */}
         <aside
-          className={`flex flex-col h-full bg-bg-deep-space border-r border-border-panel transition-all duration-300 z-40 ${sidebarCollapsed ? 'w-20' : 'w-64'
-            }`}
+          className={`fixed inset-y-0 left-0 flex flex-col h-full bg-bg-deep-space border-r border-border-panel transition-all duration-300 z-50 md:relative ${
+            mobileSidebarOpen ? 'translate-x-0 w-64' : '-translate-x-full md:translate-x-0'
+          } ${!mobileSidebarOpen && sidebarCollapsed ? 'md:w-20' : 'md:w-64'}`}
         >
           {/* Logo & Header */}
           <div className="px-6 py-5 flex items-center justify-between">
-            <div className={`${sidebarCollapsed ? 'hidden' : 'block'}`}>
+            <div className={`${!mobileSidebarOpen && sidebarCollapsed ? 'hidden' : 'block'}`}>
               <h1 className="font-display-lg text-headline-lg font-bold tracking-tighter text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]">
                 KEPLER
               </h1>
-              <p className="font-label-caps text-label-caps text-primary-fixed-dim opacity-70 mt-1">
+              <p className="font-label-caps text-[9px] sm:text-label-caps text-primary-fixed-dim opacity-70 mt-1">
                 AI STRATEGIC COMMAND
               </p>
             </div>
 
-            {/* Collapse toggle */}
+            {/* Collapse toggle (desktop) / Close toggle (mobile) */}
             <button
-              onClick={toggleSidebar}
+              onClick={() => {
+                if (window.innerWidth < 768) {
+                  setMobileSidebarOpen(false);
+                } else {
+                  toggleSidebar();
+                }
+              }}
               className="p-1.5 rounded border border-border-panel hover:bg-surface-variant/50 transition-colors text-primary-container"
             >
-              <MaterialIcon name={sidebarCollapsed ? 'chevron_right' : 'chevron_left'} className="text-sm" />
+              <MaterialIcon name={!mobileSidebarOpen && sidebarCollapsed ? 'chevron_right' : 'chevron_left'} className="text-sm" />
             </button>
           </div>
 
@@ -102,7 +128,7 @@ export const MainLayout: React.FC = () => {
                 key={item.path}
                 to={item.path}
                 className={({ isActive }) =>
-                  `flex items-center px-3 py-3 transition-all duration-200 group border-r-2 ${isActive
+                  `flex items-center px-3 py-3 min-h-[44px] transition-all duration-200 group border-r-2 ${isActive
                     ? 'text-primary-container bg-primary-fixed-dim/10 border-primary-container'
                     : 'text-on-surface-variant hover:text-primary hover:bg-surface-variant/40 border-transparent'
                   }`
@@ -113,7 +139,7 @@ export const MainLayout: React.FC = () => {
                   className={`mr-4 transition-all ${location.pathname === item.path ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-on-surface-variant group-hover:text-primary'
                     }`}
                 />
-                {!sidebarCollapsed && (
+                {(mobileSidebarOpen || !sidebarCollapsed) && (
                   <span className="font-technical-data text-technical-data font-medium transition-opacity duration-300">
                     {item.name}
                   </span>
@@ -125,13 +151,13 @@ export const MainLayout: React.FC = () => {
           {/* Footer User Profile Section */}
           <div className="p-4 border-t border-border-panel bg-bg-deep-space mt-auto">
             <div className="flex items-center">
-              <div className="w-8 h-8 rounded bg-primary-container/20 flex items-center justify-center border border-primary-container/40">
+              <div className="w-8 h-8 rounded shrink-0 bg-primary-container/20 flex items-center justify-center border border-primary-container/40">
                 <MaterialIcon name="account_circle" className="text-primary-container text-lg" />
               </div>
-              {!sidebarCollapsed && (
-                <div className="ml-3 animate-fade-in">
-                  <p className="text-xs font-bold text-on-surface font-technical-data uppercase">M. CONTROL</p>
-                  <p className="text-[10px] text-primary-container/60 font-technical-data">LVL 5 CLEARANCE</p>
+              {(mobileSidebarOpen || !sidebarCollapsed) && (
+                <div className="ml-3 animate-fade-in min-w-0">
+                  <p className="text-xs font-bold text-on-surface font-technical-data uppercase truncate">M. CONTROL</p>
+                  <p className="text-[10px] text-primary-container/60 font-technical-data truncate">LVL 5 CLEARANCE</p>
                 </div>
               )}
             </div>
@@ -142,42 +168,49 @@ export const MainLayout: React.FC = () => {
         <div className="flex-1 flex flex-col h-full min-w-0 relative">
 
           {/* Top Command Bar */}
-          <header className="h-12 bg-bg-deep-space/95 border-b border-border-panel flex justify-between items-center px-6 w-full sticky top-0 z-30">
-            {/* Command Search */}
-            <div className="flex items-center gap-4">
-              <div className="relative flex items-center">
+          <header className="h-12 bg-bg-deep-space/95 border-b border-border-panel flex justify-between items-center px-4 md:px-6 w-full sticky top-0 z-30">
+            {/* Command Search & Mobile Toggle */}
+            <div className="flex items-center gap-2 sm:gap-4 flex-1">
+              <button
+                onClick={() => setMobileSidebarOpen(true)}
+                className="md:hidden p-1 text-primary hover:text-primary-container transition-colors cursor-pointer mr-2 shrink-0"
+              >
+                <MaterialIcon name="menu" className="text-xl" />
+              </button>
+              
+              <div className="relative flex items-center w-full max-w-[120px] sm:max-w-[256px]">
                 <MaterialIcon name="search" className="absolute left-2 text-primary/50 text-sm" />
                 <input
                   type="text"
-                  placeholder="OBJECT ID / TLE SEARCH"
-                  className="bg-surface-container-low border-b border-primary/30 text-primary font-technical-data text-[12px] pl-8 pr-16 py-1 focus:outline-none focus:border-primary-container transition-all w-64 placeholder:text-primary/30"
+                  placeholder="ID / TLE SEARCH"
+                  className="bg-surface-container-low w-full border-b border-primary/30 text-primary font-technical-data text-[12px] pl-8 pr-2 sm:pr-16 py-1 focus:outline-none focus:border-primary-container transition-all placeholder:text-primary/30"
                 />
-                <span className="absolute right-2 text-[9px] text-primary/40 font-mono">CMD+K</span>
+                <span className="hidden sm:block absolute right-2 text-[9px] text-primary/40 font-mono">CMD+K</span>
               </div>
             </div>
 
             {/* Diagnostics & Right Tray Toggles */}
-            <div className="flex items-center space-x-6">
-              <div className="flex items-center gap-2">
+            <div className="flex items-center space-x-3 sm:space-x-6 ml-4 shrink-0">
+              <div className="hidden sm:flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-status-success shadow-[0_0_8px_#34C759] animate-pulse"></span>
                 <span className="font-technical-data text-[11px] text-status-success uppercase font-semibold">
                   Systems Nominal
                 </span>
               </div>
-              <div className="text-primary/45 font-technical-data text-[11px]">
+              <div className="text-primary/45 font-technical-data text-[10px] sm:text-[11px] hidden sm:block">
                 {utcTime}
               </div>
               <div className="flex items-center gap-4">
                 <button
                   onClick={toggleRightDrawer}
-                  className={`transition-colors cursor-pointer ${rightDrawerOpen ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-primary hover:text-primary-fixed'}`}
+                  className={`transition-colors cursor-pointer p-2 min-w-[44px] min-h-[44px] flex items-center justify-center ${rightDrawerOpen ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-primary hover:text-primary-fixed'}`}
                 >
                   <MaterialIcon name="monitor_heart" />
                 </button>
-                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-colors">
+                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-colors p-2 min-w-[44px] min-h-[44px] flex items-center justify-center">
                   <MaterialIcon name="schedule" />
                 </button>
-                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-colors">
+                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-colors p-2 min-w-[44px] min-h-[44px] flex items-center justify-center">
                   <MaterialIcon name="account_circle" />
                 </button>
               </div>
@@ -194,11 +227,11 @@ export const MainLayout: React.FC = () => {
             <AnimatePresence>
               {rightDrawerOpen && (
                 <motion.aside
-                  initial={{ x: 320, opacity: 0.8 }}
+                  initial={{ x: '100%', opacity: 0.8 }}
                   animate={{ x: 0, opacity: 1 }}
-                  exit={{ x: 320, opacity: 0.8 }}
+                  exit={{ x: '100%', opacity: 0.8 }}
                   transition={{ type: 'spring', damping: 25, stiffness: 200 }}
-                  className="w-80 h-full bg-surface-container-lowest border-l border-border-panel flex flex-col z-35 shadow-[-10px_0_30px_rgba(0,0,0,0.8)] relative"
+                  className="w-full sm:w-80 h-full bg-surface-container-lowest border-l border-border-panel flex flex-col z-35 shadow-[-10px_0_30px_rgba(0,0,0,0.8)] absolute right-0 top-0 sm:relative"
                 >
                   {/* Assistant Header */}
                   <div className="p-6 border-b border-border-panel flex justify-between items-center">

--- a/frontend/src/pages/AIAgents.tsx
+++ b/frontend/src/pages/AIAgents.tsx
@@ -79,10 +79,10 @@ export const AIAgents: React.FC = () => {
   }, [allDecisions.length]);
 
   return (
-    <div className="flex h-full min-w-0 overflow-hidden relative">
+    <div className="flex flex-col xl:flex-row h-full min-w-0 overflow-y-auto xl:overflow-hidden relative custom-scrollbar">
 
       {/* ── Left: Agent Status Cards ─────────────────────────── */}
-      <section className="w-80 border-r border-border-panel flex flex-col bg-surface-container-lowest/50 h-full overflow-hidden">
+      <section className="w-full xl:w-80 border-b xl:border-b-0 xl:border-r border-border-panel flex flex-col bg-surface-container-lowest/50 h-[300px] xl:h-full overflow-hidden shrink-0">
         <div className="p-4 border-b border-border-panel">
           <h2 className="font-label-caps text-label-caps text-primary uppercase font-bold tracking-wider">
             Autonomous Fleet
@@ -159,15 +159,15 @@ export const AIAgents: React.FC = () => {
       </section>
 
       {/* ── Center: Workflow Node Visualizer ─────────────────── */}
-      <section className="flex-1 relative bg-[radial-gradient(circle_at_center,_#111827_0%,_#000000_100%)] overflow-hidden h-full">
+      <section className="flex-1 min-h-[500px] xl:min-h-0 relative bg-[radial-gradient(circle_at_center,_#111827_0%,_#000000_100%)] overflow-hidden">
         <div className="absolute inset-0 opacity-10 pointer-events-none technical-grid" />
 
-        <svg className="absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="none">
+        <svg className="hidden xl:block absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="none">
           <path className="flow-line" d="M 170 300 Q 290 300, 410 300" fill="none" opacity="0.6" stroke="#00e5ff" strokeWidth="2" />
           <path className="flow-line" d="M 570 300 Q 690 300, 810 300" fill="none" opacity="0.6" stroke="#FF9500" strokeWidth="2" style={{ animationDelay: '0.5s' }} />
         </svg>
 
-        <div className="absolute inset-0 flex items-center justify-around px-12">
+        <div className="absolute inset-0 flex flex-col xl:flex-row items-center justify-around px-4 xl:px-12 pt-12 pb-40 xl:py-0 gap-6 xl:gap-0 overflow-y-auto custom-scrollbar">
           {NODE_ROLES.map((node, i) => {
             
             const roleDecision = activeDecisions.find(d =>
@@ -200,20 +200,20 @@ export const AIAgents: React.FC = () => {
         </div>
 
         {/* Status bar */}
-        <div className="absolute bottom-10 left-1/2 -translate-x-1/2 glass-panel px-6 py-3 rounded-full flex items-center gap-6 border-primary-container/30">
+        <div className="absolute bottom-4 xl:bottom-10 left-1/2 -translate-x-1/2 glass-panel px-4 xl:px-6 py-3 rounded-xl xl:rounded-full flex flex-col xl:flex-row items-center gap-2 xl:gap-6 border-primary-container/30 w-[90%] xl:w-auto max-w-xl text-center z-10">
           <div className="flex items-center gap-2">
             <span className={`w-2 h-2 rounded-full ${runs.some(r => r.status === 'RUNNING') ? 'bg-primary-container animate-ping' : 'bg-white/30'}`} />
             <span className="font-label-caps text-[10px] font-bold text-on-surface">
               {runs.some(r => r.status === 'RUNNING') ? 'AGENTS ACTIVE' : 'AGENTS IDLE'}
             </span>
           </div>
-          <div className="h-4 w-[1px] bg-border-panel" />
+          <div className="hidden xl:block h-4 w-[1px] bg-border-panel" />
           <div className="flex items-center gap-2">
             <span className="font-label-caps text-[10px] font-bold text-on-surface">
               {activeRun ? `WORKFLOW: ${activeRun.workflow_name}` : 'NO ACTIVE WORKFLOW'}
             </span>
           </div>
-          <div className="h-4 w-[1px] bg-border-panel" />
+          <div className="hidden xl:block h-4 w-[1px] bg-border-panel" />
           <div className="flex items-center gap-2">
             <span className="font-label-caps text-[10px] font-bold text-on-surface">
               {allDecisions.length} TOTAL DECISIONS
@@ -223,7 +223,7 @@ export const AIAgents: React.FC = () => {
       </section>
 
       {/* ── Right: Execution Log Terminal ─────────────────────── */}
-      <section className="w-80 border-l border-border-panel flex flex-col bg-bg-deep-space h-full overflow-hidden">
+      <section className="w-full xl:w-80 border-t xl:border-t-0 xl:border-l border-border-panel flex flex-col bg-bg-deep-space h-[400px] xl:h-full overflow-hidden shrink-0">
         <div className="p-4 border-b border-border-panel flex justify-between items-center bg-bg-deep-space">
           <h2 className="font-label-caps text-label-caps text-on-surface-variant font-bold">
             Live Execution Log

--- a/frontend/src/pages/CollisionCenter.tsx
+++ b/frontend/src/pages/CollisionCenter.tsx
@@ -64,12 +64,12 @@ export const CollisionCenter: React.FC = () => {
   const latestDecision = latestRun?.decisions?.[latestRun.decisions.length - 1];
 
   return (
-    <div className="p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
+    <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-end gap-4">
         <div>
-          <h2 className="font-headline-lg text-headline-lg text-primary tracking-tight font-bold">
+          <h2 className="font-headline-lg text-lg md:text-headline-lg text-primary tracking-tight font-bold">
             COLLISION CENTER
           </h2>
           <div className="flex items-center gap-4 mt-2 flex-wrap">
@@ -101,7 +101,7 @@ export const CollisionCenter: React.FC = () => {
           <select
             value={riskFilter}
             onChange={e => setRiskFilter(e.target.value)}
-            className="bg-surface-container border border-border-panel text-primary font-technical-data text-xs px-3 py-2 focus:outline-none focus:border-primary-container cursor-pointer"
+            className="bg-surface-container border border-border-panel text-primary font-technical-data text-xs px-3 py-2 focus:outline-none focus:border-primary-container cursor-pointer min-h-[44px]"
           >
             <option value="">ALL RISK LEVELS</option>
             <option value="CRITICAL">CRITICAL</option>
@@ -112,7 +112,7 @@ export const CollisionCenter: React.FC = () => {
           <select
             value={statusFilter}
             onChange={e => setStatusFilter(e.target.value)}
-            className="bg-surface-container border border-border-panel text-primary font-technical-data text-xs px-3 py-2 focus:outline-none focus:border-primary-container cursor-pointer"
+            className="bg-surface-container border border-border-panel text-primary font-technical-data text-xs px-3 py-2 focus:outline-none focus:border-primary-container cursor-pointer min-h-[44px]"
           >
             <option value="">ALL STATUSES</option>
             <option value="PENDING">PENDING</option>
@@ -123,7 +123,7 @@ export const CollisionCenter: React.FC = () => {
           <button
             onClick={() => evaluate.mutate()}
             disabled={evaluate.isPending}
-            className="bg-primary-container text-on-primary font-label-caps text-label-caps px-6 py-2.5 border-b-2 border-primary hover:brightness-110 transition-all flex items-center gap-2 font-bold cursor-pointer drop-shadow-[0_0_10px_rgba(0,229,255,0.4)] disabled:opacity-50"
+            className="bg-primary-container text-on-primary font-label-caps text-label-caps px-4 md:px-6 py-2.5 border-b-2 border-primary hover:brightness-110 transition-all flex items-center gap-2 font-bold cursor-pointer drop-shadow-[0_0_10px_rgba(0,229,255,0.4)] disabled:opacity-50 min-h-[44px]"
           >
             <MaterialIcon name={evaluate.isPending ? 'sync' : 'bolt'} className={`text-sm ${evaluate.isPending ? 'animate-spin' : ''}`} />
             {evaluate.isPending ? 'SCANNING…' : 'RUN CONJUNCTION SCAN'}
@@ -135,7 +135,7 @@ export const CollisionCenter: React.FC = () => {
       <div className="grid grid-cols-12 gap-6">
 
         {/* Conjunction Table — 8 cols */}
-        <div className="col-span-12 lg:col-span-8 bg-surface-container-lowest/90 backdrop-blur-xl border border-border-panel p-4">
+        <div className="col-span-12 lg:col-span-8 bg-surface-container-lowest/90 backdrop-blur-xl border border-border-panel p-4 min-w-0">
           <div className="flex justify-between items-center mb-4">
             <div className="font-label-caps text-label-caps text-primary-container font-bold tracking-wider">
               PROBABILITY MATRIX

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -121,12 +121,12 @@ export const Dashboard: React.FC = () => {
     <div className="flex flex-col min-h-screen">
 
       {/* 3D Earth Twin Digital Hero */}
-      <section className="h-[409px] relative border-b border-border-panel bg-bg-deep-space">
+      <section className="h-[250px] md:h-[409px] relative border-b border-border-panel bg-bg-deep-space">
         <EarthTwin />
       </section>
 
       {/* KPI Bento Grid */}
-      <section className="p-6 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+      <section className="p-3 md:p-6 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-3">
         {summary.isLoading
           ? Array(6).fill(0).map((_, i) => <KPISkeleton key={i} />)
           : summary.isError
@@ -146,7 +146,7 @@ export const Dashboard: React.FC = () => {
               </p>
               <div className="flex justify-between items-end">
                 <div className="flex items-baseline gap-1">
-                  <span className={`font-headline-lg text-2xl font-bold font-technical-data ${kpi.text}`}>
+                  <span className={`font-headline-lg text-lg md:text-2xl font-bold font-technical-data ${kpi.text}`}>
                     {kpi.value}
                   </span>
                   {kpi.subValue && (
@@ -161,10 +161,10 @@ export const Dashboard: React.FC = () => {
       </section>
 
       {/* Bottom Timeline & Reasoning Stream */}
-      <section className="px-6 pb-6 grid grid-cols-1 lg:grid-cols-3 gap-6 flex-1 min-h-0">
+      <section className="px-3 md:px-6 pb-6 grid grid-cols-1 lg:grid-cols-3 gap-4 md:gap-6 flex-1 min-h-0">
 
         {/* Left (2/3): Live Collision Timeline */}
-        <div className="lg:col-span-2 flex flex-col min-h-0">
+        <div className="lg:col-span-2 flex flex-col min-h-0 min-w-0">
           <div className="flex justify-between items-center mb-3">
             <h3 className="font-label-caps text-label-caps text-primary flex items-center gap-2 drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
               <MaterialIcon name="timeline" className="text-sm" />
@@ -199,7 +199,7 @@ export const Dashboard: React.FC = () => {
                 {conjunctions.map((conj: Collision) => (
                   <div
                     key={conj.id}
-                    className={`w-72 glass-panel p-4 border-l-4 ${riskColor(conj.risk_level)} relative overflow-hidden group hover:bg-surface-variant/30 transition-all cursor-pointer`}
+                    className={`w-64 sm:w-72 shrink-0 glass-panel p-4 border-l-4 ${riskColor(conj.risk_level)} relative overflow-hidden group hover:bg-surface-variant/30 transition-all cursor-pointer`}
                   >
                     <div className="absolute top-0 right-0 p-2 opacity-10 group-hover:opacity-20 transition-opacity">
                       <MaterialIcon name="crisis_alert" className={`text-6xl ${riskBarColor(conj.risk_level)}`} />

--- a/frontend/src/pages/Debris.tsx
+++ b/frontend/src/pages/Debris.tsx
@@ -77,12 +77,12 @@ export const Debris: React.FC = () => {
   const totalDebris = (stats?.debris ?? 0) + (stats?.rocket_bodies ?? 0);
 
   return (
-    <div className="p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
+    <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-end gap-4 border-b border-border-panel pb-4">
         <div>
-          <h2 className="font-headline-lg text-headline-lg text-primary tracking-tight font-bold">
+          <h2 className="font-headline-lg text-lg md:text-headline-lg text-primary tracking-tight font-bold">
             DEBRIS CATALOG
           </h2>
           <p className="text-xs text-on-surface-variant font-technical-data mt-1">
@@ -95,7 +95,7 @@ export const Debris: React.FC = () => {
           <button
             onClick={() => syncM.mutate('analyst')}
             disabled={syncM.isPending}
-            className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 cursor-pointer transition-all disabled:opacity-50"
+            className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 cursor-pointer transition-all disabled:opacity-50 min-h-[44px]"
           >
             <MaterialIcon name={syncM.isPending ? 'sync' : 'cloud_download'} className={`text-sm mr-2 ${syncM.isPending ? 'animate-spin' : ''}`} />
             <span className="font-label-caps text-label-caps">
@@ -150,8 +150,8 @@ export const Debris: React.FC = () => {
       </div>
 
       {/* Table */}
-      <div className="glass-panel overflow-hidden">
-        <div className="overflow-x-auto">
+      <div className="glass-panel overflow-hidden min-w-0">
+        <div className="overflow-x-auto custom-scrollbar">
           <table className="w-full text-left border-collapse">
             <thead className="bg-surface-container-high border-b border-border-panel">
               <tr>

--- a/frontend/src/pages/MissionPlanner.tsx
+++ b/frontend/src/pages/MissionPlanner.tsx
@@ -3,17 +3,17 @@ import { MaterialIcon } from '@/components/MaterialIcon';
 
 export const MissionPlanner: React.FC = () => {
   return (
-    <div className="p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
-      <div className="flex justify-between items-end border-b border-border-panel pb-4">
+    <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-end gap-3 border-b border-border-panel pb-4">
         <div>
-          <h2 className="font-headline-lg text-headline-lg text-primary tracking-tight font-bold">
+          <h2 className="font-headline-lg text-lg md:text-headline-lg text-primary tracking-tight font-bold">
             MISSION PLANNER
           </h2>
           <p className="text-xs text-on-surface-variant font-technical-data mt-1">
             OPTIMIZE FUEL EXPENDITURE & TRAJECTORY WINDOWS
           </p>
         </div>
-        <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary cursor-pointer">
+        <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary cursor-pointer min-h-[44px]">
           <MaterialIcon name="play_arrow" className="text-sm mr-2" />
           RUN SIMULATION
         </button>

--- a/frontend/src/pages/Satellites.tsx
+++ b/frontend/src/pages/Satellites.tsx
@@ -83,12 +83,12 @@ export const Satellites: React.FC = () => {
     <div className="flex h-full min-w-0 relative">
 
       {/* ── Table Section ──────────────────────────────────────── */}
-      <div className="flex-1 flex flex-col p-6 space-y-6 overflow-y-auto custom-scrollbar xl:mr-[420px]">
+      <div className={`flex-1 flex flex-col p-4 md:p-6 space-y-6 overflow-y-auto custom-scrollbar min-w-0 ${selectedObj ? 'xl:mr-[420px]' : ''}`}>
 
         {/* Header */}
         <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
           <div>
-            <h2 className="font-headline-lg text-headline-lg text-on-surface">SATELLITE FLEET</h2>
+            <h2 className="font-headline-lg text-lg md:text-headline-lg text-on-surface">SATELLITE FLEET</h2>
             <div className="flex items-center gap-3 mt-2 flex-wrap">
               {statsQ.isLoading ? (
                 <div className="h-5 w-32 bg-surface-container-high rounded animate-pulse" />
@@ -113,14 +113,14 @@ export const Satellites: React.FC = () => {
             <button
               onClick={() => syncM.mutate(undefined)}
               disabled={syncM.isPending}
-              className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 transition-all cursor-pointer disabled:opacity-50"
+              className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 transition-all cursor-pointer disabled:opacity-50 min-h-[44px]"
             >
               <MaterialIcon name={syncM.isPending ? 'sync' : 'cloud_download'} className={`text-sm mr-2 ${syncM.isPending ? 'animate-spin' : ''}`} />
               <span className="font-label-caps text-label-caps">
                 {syncM.isPending ? 'SYNCING…' : 'SYNC SPACE-TRACK'}
               </span>
             </button>
-            <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-all glow-cyan cursor-pointer">
+            <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-all glow-cyan cursor-pointer min-h-[44px]">
               <MaterialIcon name="filter_alt" className="text-sm mr-2" />
               FILTERS
             </button>
@@ -145,8 +145,8 @@ export const Satellites: React.FC = () => {
         </div>
 
         {/* Data Table */}
-        <div className="glass-panel overflow-hidden">
-          <div className="overflow-x-auto">
+        <div className="glass-panel overflow-hidden min-w-0">
+          <div className="overflow-x-auto custom-scrollbar">
             <table className="w-full text-left border-collapse">
               <thead className="bg-surface-container-high border-b border-border-panel">
                 <tr>
@@ -326,11 +326,11 @@ export const Satellites: React.FC = () => {
       <AnimatePresence>
         {selectedObj && (
           <motion.aside
-            initial={{ x: 420 }}
+            initial={{ x: '100%' }}
             animate={{ x: 0 }}
-            exit={{ x: 420 }}
+            exit={{ x: '100%' }}
             transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-            className="w-[420px] border-l border-border-panel bg-surface-container-lowest/95 backdrop-blur-xl h-full flex flex-col fixed right-0 top-12 bottom-0 z-30 shadow-[-10px_0_30px_rgba(0,0,0,0.6)]"
+            className="w-full md:w-[420px] border-l border-border-panel bg-surface-container-lowest/95 backdrop-blur-xl h-full flex flex-col fixed right-0 top-12 bottom-0 z-40 shadow-[-10px_0_30px_rgba(0,0,0,0.6)]"
           >
             {/* Drawer Header */}
             <div className="p-6 border-b border-border-panel flex justify-between items-center">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -3,10 +3,10 @@ import { MaterialIcon } from '@/components/MaterialIcon';
 
 export const Settings: React.FC = () => {
   return (
-    <div className="p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
+    <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
       <div className="flex justify-between items-end border-b border-border-panel pb-4">
         <div>
-          <h2 className="font-headline-lg text-headline-lg text-primary tracking-tight font-bold">
+          <h2 className="font-headline-lg text-lg md:text-headline-lg text-primary tracking-tight font-bold">
             SYSTEM SETTINGS
           </h2>
           <p className="text-xs text-on-surface-variant font-technical-data mt-1">
@@ -18,14 +18,14 @@ export const Settings: React.FC = () => {
       <div className="max-w-2xl glass-panel p-6 space-y-6">
         <div>
           <h3 className="font-label-caps text-primary-container font-bold mb-4 uppercase">User Profile</h3>
-          <div className="grid grid-cols-2 gap-4 text-xs font-technical-data">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-xs font-technical-data">
             <div>
               <p className="text-on-surface-variant mb-1">CALLSIGN</p>
-              <input type="text" defaultValue="M. CONTROL" className="w-full bg-surface-container border border-border-panel p-2 text-primary focus:outline-none" />
+              <input type="text" defaultValue="M. CONTROL" className="w-full bg-surface-container border border-border-panel p-2 min-h-[44px] text-primary focus:outline-none" />
             </div>
             <div>
               <p className="text-on-surface-variant mb-1">CLEARANCE LEVEL</p>
-              <input type="text" defaultValue="LEVEL 5 ADMIN" disabled className="w-full bg-surface-container-high border border-border-panel p-2 text-on-surface-variant opacity-60" />
+              <input type="text" defaultValue="LEVEL 5 ADMIN" disabled className="w-full bg-surface-container-high border border-border-panel p-2 min-h-[44px] text-on-surface-variant opacity-60" />
             </div>
           </div>
         </div>
@@ -35,11 +35,11 @@ export const Settings: React.FC = () => {
           <div className="space-y-4 text-xs font-technical-data">
             <div>
               <p className="text-on-surface-variant mb-1">CRITICAL COLLISION PROBABILITY (&gt; X%)</p>
-              <input type="text" defaultValue="1.0" className="w-full bg-surface-container border border-border-panel p-2 text-primary focus:outline-none" />
+              <input type="text" defaultValue="1.0" className="w-full bg-surface-container border border-border-panel p-2 min-h-[44px] text-primary focus:outline-none" />
             </div>
             <div>
               <p className="text-on-surface-variant mb-1">PROXIMITY WARNING RADIUS (KM)</p>
-              <input type="text" defaultValue="5.0" className="w-full bg-surface-container border border-border-panel p-2 text-primary focus:outline-none" />
+              <input type="text" defaultValue="5.0" className="w-full bg-surface-container border border-border-panel p-2 min-h-[44px] text-primary focus:outline-none" />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/SpaceTraffic.tsx
+++ b/frontend/src/pages/SpaceTraffic.tsx
@@ -3,10 +3,10 @@ import { MaterialIcon } from '@/components/MaterialIcon';
 
 export const SpaceTraffic: React.FC = () => {
   return (
-    <div className="p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
-      <div className="flex justify-between items-end border-b border-border-panel pb-4">
+    <div className="p-4 md:p-6 space-y-6 overflow-y-auto h-full custom-scrollbar technical-grid">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-end gap-3 border-b border-border-panel pb-4">
         <div>
-          <h2 className="font-headline-lg text-headline-lg text-primary tracking-tight font-bold">
+          <h2 className="font-headline-lg text-lg md:text-headline-lg text-primary tracking-tight font-bold">
             SPACE TRAFFIC MONITOR
           </h2>
           <p className="text-xs text-on-surface-variant font-technical-data mt-1">
@@ -14,7 +14,7 @@ export const SpaceTraffic: React.FC = () => {
           </p>
         </div>
         <div className="flex gap-2">
-          <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-all cursor-pointer">
+          <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-all cursor-pointer min-h-[44px]">
             <MaterialIcon name="filter_alt" className="text-sm mr-2" />
             REGISTRY FILTER
           </button>


### PR DESCRIPTION
## Description
Responsiveness update for mobile and other smaller screens

1. MainLayout (Sidebar, Header, Right Drawer)
Hamburger menu added for < md (768px) — sidebar slides in as a drawer with backdrop overlay
Header scales search bar, hides secondary diagnostics on mobile, adds touch-friendly icon buttons (min-h-[44px])
Right AI drawer goes full-width on mobile, positioned absolutely to avoid pushing content
Nav links have min-h-[44px] for touch targets
2. Dashboard
EarthTwin hero shrinks to 250px on mobile, 409px on desktop
KPI grid uses grid-cols-2 on mobile → grid-cols-3 tablet → grid-cols-6 desktop; values scale text-lg md:text-2xl
Section padding responsive: p-3 md:p-6
Collision cards flexible width w-64 sm:w-72 with shrink-0
3. EarthTwin HUD Overlay
Top row stacks vertically on small screens; conjunction status hidden below sm
Bottom stats use text-xl md:text-3xl; controls use px-2.5 md:px-4 with text-[10px] md:text-xs
Legend panel repositioned: bottom-16 md:bottom-24
Loading indicator converted from large box to compact pill
4. Satellites
Header stacks on mobile, buttons wrap
Table in scrollable container with overflow-x-auto + min-w-0
Detail drawer full-width on mobile, 420px on md+
Buttons have min-h-[44px]
5. Debris
Page padding responsive p-4 md:p-6
Header responsive heading text-lg md:text-headline-lg
Table scrollable within container
Sync button touch-friendly min-h-[44px]
6. Collision Center
Header/heading responsive sizes
Selects and buttons all have min-h-[44px] for touch
Table container has min-w-0 to prevent overflow
Button padding scales px-4 md:px-6
7. AI Agents
Three-panel layout stacks vertically (flex-col xl:flex-row)
Left panel w-full xl:w-80 with h-[300px] xl:h-full
Center visualizer scrollable with pb-40 to clear status bar
Right log panel w-full xl:w-80 with h-[400px] xl:h-full
Status bar stacks vertically on mobile with z-10
SVG connector lines hidden on mobile
8. Space Traffic
Header stacks on mobile (flex-col sm:flex-row)
Button has min-h-[44px]
9. Mission Planner
Header stacks on mobile (flex-col sm:flex-row)
Run Simulation button has min-h-[44px]
10. Settings
Form grid stacks on mobile (grid-cols-1 sm:grid-cols-2)
All inputs have min-h-[44px] for easy touch interaction
Heading responsive text-lg md:text-headline-lg
<!-- Describe your changes in detail -->

## Related Issue
The PR addresess #32 
<!-- Link to the issue this PR resolves: e.g. Fixes #123 -->

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [x] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings
<img width="628" height="884" alt="dashboard_mobile_view_1784129537486" src="https://github.com/user-attachments/assets/fe5a446f-c003-4d56-b173-2ec5be626aac" />
<img width="628" height="884" alt="sidebar_open_mobile_1784129571080" src="https://github.com/user-attachments/assets/5e6eff06-5dda-4751-bea0-71354c64d8bd" />

<!-- If applicable, add screenshots to help explain your changes -->

## Breaking Changes
THere are no any breaking changes, just light work
<!-- Does this PR introduce a breaking change? Please describe it -->

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [ ] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive mobile navigation drawer with a dismissible overlay and mobile menu control.
  * Improved responsive layouts across dashboards, agent workflows, tables, settings, and mission planning views.
  * Added compact loading and status overlays for orbital data and collision monitoring.

* **Style**
  * Refined typography, spacing, controls, panels, drawers, tables, and touch-target sizing across the application.
  * Improved small-screen scrolling, stacking, and panel behavior for easier mobile use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds mobile responsiveness across all pages and the shared layout shell, introducing a hamburger-triggered sidebar drawer, responsive grid/padding breakpoints, and `min-h-[44px]` touch targets on interactive controls.

- `MainLayout.tsx` adds a fixed-position slide-in sidebar with an `AnimatePresence` backdrop, responsive header that collapses secondary diagnostics on small screens, and a full-width right AI drawer on mobile. Two gaps remain: the sidebar toggle reads `window.innerWidth` at click time (fragile at the exact breakpoint) and there is no body scroll lock when the drawer is open.
- `Satellites.tsx` raises the detail drawer's z-index to `z-40` — matching the mobile backdrop overlay — so the drawer renders above the backdrop when both are simultaneously open on mobile, breaking overlay dismissal in that scenario.
- All page files (`Dashboard`, `AIAgents`, `CollisionCenter`, `Debris`, `MissionPlanner`, `Settings`, `SpaceTraffic`) receive consistent responsive padding, heading sizes, and touch-target updates with no logic changes.

<h3>Confidence Score: 3/5</h3>

Safe to merge for most use cases, but the mobile sidebar overlay does not correctly cover the satellite detail drawer when both are open simultaneously, leaving a broken interaction path on mobile.

The vast majority of the changes — responsive padding, text scaling, touch targets, and the hamburger drawer mechanism — are correct and well-structured. The one functional defect is in Satellites.tsx: the detail drawer's z-index was raised to match the mobile backdrop, so on mobile a selected satellite's drawer renders above the overlay, preventing the user from dismissing the sidebar by tapping the backdrop in that area. Two secondary quality issues (body scroll not locked behind the drawer, and a window.innerWidth snapshot in the toggle handler) are unlikely to cause failures in normal use but are worth addressing.

MainLayout.tsx (sidebar drawer scroll lock and toggle handler) and Satellites.tsx (detail drawer z-index vs backdrop z-index).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/layouts/MainLayout.tsx | Adds mobile hamburger menu, slide-in sidebar drawer with backdrop, and responsive header — has two issues: window.innerWidth snapshot in click handler and missing body scroll lock when the drawer is open. |
| frontend/src/components/EarthTwin.tsx | HUD overlay made responsive with smaller text/padding on mobile; conjunction status area hidden below sm breakpoint (intentional per PR description); loading indicator converted to compact pill — no logic bugs introduced. |
| frontend/src/pages/Satellites.tsx | Detail drawer z-index raised from z-30 to z-40, matching the mobile backdrop overlay's z-index; this causes the drawer to render above the backdrop when both are open simultaneously on mobile. |
| frontend/src/pages/AIAgents.tsx | Three-panel layout now stacks vertically below xl breakpoint with fixed panel heights; SVG connector lines hidden on mobile; status bar switches to vertical stacking — responsive changes are logically sound. |
| frontend/src/pages/Dashboard.tsx | EarthTwin hero section reduced to 250px on mobile, KPI grid padding and gap scaled responsively, collision cards now use shrink-0 with flexible width — clean changes. |
| frontend/src/pages/CollisionCenter.tsx | Responsive padding, min-h-[44px] on select and button controls, min-w-0 on table container to prevent overflow — straightforward and correct. |
| frontend/src/pages/Debris.tsx | Responsive padding, touch-friendly sync button, and custom-scrollbar added to table overflow container — no issues. |
| frontend/src/pages/Settings.tsx | Form grid changed from grid-cols-2 to grid-cols-1 sm:grid-cols-2, all inputs gain min-h-[44px] — safe, mechanical change. |
| frontend/src/pages/SpaceTraffic.tsx | Header stacks on mobile, filter button gets min-h-[44px] — trivial responsive update with no issues. |
| frontend/src/pages/MissionPlanner.tsx | Header stacks on mobile, Run Simulation button gets min-h-[44px] — trivial and correct. |
| frontend/package-lock.json | Lock file updated as part of dependency resolution — no functional changes to review. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User on Mobile] --> B{Viewport < md?}
    B -- Yes --> C[Header shows hamburger button]
    B -- No --> D[Desktop: sidebar always visible\ncollapse toggle works normally]

    C --> E[Click hamburger]
    E --> F[mobileSidebarOpen = true]
    F --> G[Backdrop overlay z-40 renders]
    F --> H[Sidebar slides in z-50]

    G --> I{Satellite detail drawer open?}
    I -- Yes --> J[⚠️ Drawer z-40 renders ABOVE backdrop\nBackdrop click blocked in drawer area]
    I -- No --> K[Backdrop click → mobileSidebarOpen = false\nSidebar slides out]

    H --> L[Click sidebar close / navigate]
    L --> M[Route change useEffect\nmobileSidebarOpen = false]

    style J fill:#ff4444,color:#fff
    style G fill:#555,color:#fff
    style H fill:#006688,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User on Mobile] --> B{Viewport < md?}
    B -- Yes --> C[Header shows hamburger button]
    B -- No --> D[Desktop: sidebar always visible\ncollapse toggle works normally]

    C --> E[Click hamburger]
    E --> F[mobileSidebarOpen = true]
    F --> G[Backdrop overlay z-40 renders]
    F --> H[Sidebar slides in z-50]

    G --> I{Satellite detail drawer open?}
    I -- Yes --> J[⚠️ Drawer z-40 renders ABOVE backdrop\nBackdrop click blocked in drawer area]
    I -- No --> K[Backdrop click → mobileSidebarOpen = false\nSidebar slides out]

    H --> L[Click sidebar close / navigate]
    L --> M[Route change useEffect\nmobileSidebarOpen = false]

    style J fill:#ff4444,color:#fff
    style G fill:#555,color:#fff
    style H fill:#006688,color:#fff
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/layouts/MainLayout.tsx`, line 246-250 ([link](https://github.com/7-blocks/kepler/blob/e02ce4fa7cf40e0f6aba2cae1d945c153cd9fe2e/frontend/src/components/layouts/MainLayout.tsx#L246-L250)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The close button inside the right AI drawer omits `min-h-[44px]` and the associated padding that every other interactive button in this PR received. On touch devices this produces a sub-standard tap target, inconsistent with the stated goal of touch-friendly icon buttons throughout.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/components/layouts/MainLayout.tsx
   Line: 246-250

   Comment:
   The close button inside the right AI drawer omits `min-h-[44px]` and the associated padding that every other interactive button in this PR received. On touch devices this produces a sub-standard tap target, inconsistent with the stated goal of touch-friendly icon buttons throughout.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
frontend/src/pages/Satellites.tsx:336
**Satellite drawer z-index conflicts with mobile backdrop**

The satellite detail drawer's z-index was raised from `z-30` to `z-40` — the same value as the mobile sidebar backdrop in `MainLayout.tsx`. Both are `fixed`-positioned elements. Because the satellite drawer is rendered later in the DOM (inside `<main>` via `<Outlet />`), it will paint on top of the backdrop when both are present simultaneously. A user who has selected a satellite and then opens the hamburger menu will see the sidebar backdrop fail to visually cover the satellite drawer, meaning clicks on the drawer area cannot reach the backdrop's `onClick` handler to close the sidebar.

### Issue 2 of 4
frontend/src/components/layouts/MainLayout.tsx:246-250
The close button inside the right AI drawer omits `min-h-[44px]` and the associated padding that every other interactive button in this PR received. On touch devices this produces a sub-standard tap target, inconsistent with the stated goal of touch-friendly icon buttons throughout.

```suggestion
                    <button
                      onClick={toggleRightDrawer}
                      className="text-on-surface-variant hover:text-primary transition-colors p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
                    >
                      <MaterialIcon name="close" />
```

### Issue 3 of 4
frontend/src/components/layouts/MainLayout.tsx:110-117
The sidebar toggle button reads `window.innerWidth` at click time to distinguish mobile vs desktop behavior. This snapshot will be wrong if the user has already resized the window after the page loaded, and will drift relative to the Tailwind `md` breakpoint on browsers where scrollbar width narrows the viewport (the CSS `md` breakpoint uses `min-width: 768px` against the viewport, while `window.innerWidth` includes the scrollbar on some platforms). A state-driven approach is more reliable.

```suggestion
            <button
              onClick={() => {
                if (mobileSidebarOpen) {
                  setMobileSidebarOpen(false);
                } else {
                  toggleSidebar();
                }
              }}
```

### Issue 4 of 4
frontend/src/components/layouts/MainLayout.tsx:80-90
**Background content remains scrollable when mobile sidebar is open**

When `mobileSidebarOpen` is `true`, only a visual backdrop overlay is rendered — nothing prevents the `<main>` scroll container (or any other scrollable child) from responding to touch-scroll gestures behind the drawer. The standard fix is to apply `overflow-hidden` to the `<body>` element while the drawer is open and remove it on close, typically via a `useEffect` that toggles `document.body.style.overflow`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Improved mobile responsiveness"](https://github.com/7-blocks/kepler/commit/e02ce4fa7cf40e0f6aba2cae1d945c153cd9fe2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44501557)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->