### PR TITLE
Added Skeleton Loaders, Primitive Loader Removed (#33)

### DIFF
--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -120,6 +120,9 @@ async function fetchCollisions(): Promise<CollisionRisk[]> {
   return json.data ?? [];
 }
 
+const LegendCardSkeleton = () => (
+  <div className="min-w-[200px] glass-panel p-4 animate-pulse bg-surface-container/40 h-48" />
+);
 
 export const EarthTwin: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -461,6 +464,8 @@ export const EarthTwin: React.FC = () => {
           </div>
 
           <div className="text-right space-y-1 animate-[slideDown_0.5s_ease-out] hidden sm:block">
+          {dataLoaded ? (
+            <>
             {objectCounts.collisions > 0 ? (
               <div className="bg-status-emergency/20 border border-status-emergency px-3 md:px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
                 <MaterialIcon name="warning" className="text-status-emergency text-sm animate-pulse" />
@@ -476,15 +481,25 @@ export const EarthTwin: React.FC = () => {
                 </span>
               </div>
             )}
-            <p className="font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block">
+            </>
+          ) : (
+            <>
+            <div className="w-full h-8 bg-surface-container/80 animate-pulse" />
+            <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
+            </>
+          ) }
+            <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block opacity-0 ${dataLoaded ? 'opacity-100 transition-opacity duration-500' : ''}`}>
               WEATHER: {stats.weatherIndex} · DATA SOURCE: SPACE-TRACK / NASA DONKI
             </p>
+
           </div>
         </div>
 
         {/* Bottom Row */}
         <div className="flex flex-col sm:flex-row gap-3 sm:gap-6 items-start sm:items-end justify-between animate-[slideUp_0.5s_ease-out]">
           <div className="flex gap-4 md:gap-8 flex-wrap">
+            {dataLoaded ? (
+              <>
             <div className="space-y-0.5">
               <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
               <p className="font-headline-lg text-primary text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
@@ -503,6 +518,10 @@ export const EarthTwin: React.FC = () => {
                 {objectCounts.collisions}
               </p>
             </div>
+            </>
+            ) : (
+              <div className="min-w-[250px] p-4 animate-pulse bg-surface-container/80 h-12" />
+            )}
           </div>
 
           {/* Controls */}
@@ -538,6 +557,7 @@ export const EarthTwin: React.FC = () => {
       {/* ── Legend Panel ───────────────────────────────────────── */}
       {showLegend && (
         <div className="absolute bottom-16 md:bottom-24 left-3 md:left-6 z-20 pointer-events-auto animate-[slideUp_0.3s_ease-out]">
+          {dataLoaded ? (
           <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[200px] shadow-[0_0_30px_rgba(0,0,0,0.6)]">
             <div className="flex justify-between items-center mb-3">
               <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">ORBITAL LEGEND</span>
@@ -568,19 +588,9 @@ export const EarthTwin: React.FC = () => {
               All positions from real orbital elements
             </div>
           </div>
+          ) : (<LegendCardSkeleton />) }
         </div>
       )}
-
-      {/* ── Loading Indicator ─────────────────────────────────── */}
-      {!useFallback && !dataLoaded && (
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-30 pointer-events-none">
-          <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-primary-container/50 px-4 py-2 flex items-center gap-3 rounded-full shadow-[0_0_20px_rgba(0,229,255,0.2)]">
-            <MaterialIcon name="sync" className="text-primary-container text-sm animate-spin" />
-            <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">LOADING ORBITAL DATA...</span>
-          </div>
-        </div>
-      )}
-
       {/* ── Inline Styles for Animations ──────────────────────── */}
       <style>{`
         @keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -488,7 +488,7 @@ export const EarthTwin: React.FC = () => {
             <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
             </>
           ) }
-            <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block opacity-0 ${dataLoaded ? 'opacity-100 transition-opacity duration-500' : ''}`}>
+            <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block transition-opacity duration-500 ${dataLoaded ? 'opacity-100' : 'opacity-0'}`}>
               WEATHER: {stats.weatherIndex} · DATA SOURCE: SPACE-TRACK / NASA DONKI
             </p>
 

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -498,7 +498,9 @@ export const EarthTwin: React.FC = () => {
         {/* Bottom Row */}
         <div className="flex flex-col sm:flex-row gap-3 sm:gap-6 items-start sm:items-end justify-between animate-[slideUp_0.5s_ease-out]">
           <div className="flex gap-4 md:gap-8 flex-wrap">
-            {dataLoaded ? (
+            {!dataLoaded && !useFallback ? (
+              <div className="min-w-[250px] p-4 animate-pulse bg-surface-container/80 h-12" />
+            ) : (
               <>
             <div className="space-y-0.5">
               <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
@@ -519,9 +521,8 @@ export const EarthTwin: React.FC = () => {
               </p>
             </div>
             </>
-            ) : (
-              <div className="min-w-[250px] p-4 animate-pulse bg-surface-container/80 h-12" />
-            )}
+            )
+          }
           </div>
 
           {/* Controls */}


### PR DESCRIPTION
## Description

Added Skeleton Loaders to `EarthTwin.tsx` component file.

It was the only component visible on the Web App which had missing loaders on dynamic data DOM elements.

In-case i missed any component of page, please let me know.

## Related Issue

Fixes #33 

## Checklist

- [X] I have read the contributing guidelines
- [X] My code follows the project guidelines
- [X] I have completed testing of my changes
- [X] Documentation has been updated (if applicable)

## Screenshots/Screen Recordings

<img width="1408" height="769" alt="Screenshot 2026-07-15 at 11 25 58 PM" src="https://github.com/user-attachments/assets/c888a9f8-ef91-4377-824c-52d65d65741d" />

## Breaking Changes

No Breaking Changes.

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [X] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated loading placeholders for Earth view HUD elements (collision status, summary/metrics cards, weather/source text) while orbital data is unavailable.
  * Enhanced the Legend Panel behavior: it now shows skeleton content until data is loaded, and renders full legend details only after readiness—improving perceived responsiveness and clarity during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the single centered `LOADING ORBITAL DATA…` spinner in `EarthTwin.tsx` with three inline skeleton placeholders: one for the HUD top-right collision/all-clear status, one for the bottom stats row, and one for the legend panel.

- The bottom-stats skeleton correctly guards on `!dataLoaded && !useFallback`, so it falls through to showing zeroed counts in fallback mode.
- The top-right status and legend skeletons gate only on `dataLoaded`, with no `!useFallback` guard — meaning they persist in skeleton state on any error path (both Cesium init failure and a failed `populateEntities` API call), since `populateEntities`'s own `catch` block never calls `setDataLoaded(true)`.
- The `LegendCardSkeleton` component is defined outside the component function with a fixed `h-48`, which may produce a slight layout shift when the real legend (variable height) replaces it.

<h3>Confidence Score: 3/5</h3>

The skeleton loaders work correctly on the happy path, but two of the three new guards leave the UI stuck in an indefinite loading state when the orbital data API call fails inside `populateEntities`.

The `populateEntities` catch block silently swallows fetch errors without calling `setDataLoaded(true)`. When that path is taken, `useFallback` remains `false` (Cesium initialized fine), so the top-right status and legend panel skeleton guards — both checking only `dataLoaded` — never resolve. Users see a permanently pulsing skeleton over a live globe with no recovery path. This is a real failure mode any time the Space-Track or NASA DONKI endpoints are unavailable.

frontend/src/components/EarthTwin.tsx — specifically the `populateEntities` catch block (around line 255) and the skeleton guard conditions for the top-right status area and the legend panel.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/EarthTwin.tsx | Replaces the old centered loading spinner with inline skeleton loaders for the HUD status row, stats row, and legend panel. The bottom-stats skeleton is correctly gated on `!useFallback`, but the top-right status and legend skeletons check only `dataLoaded`, leaving them indefinitely stuck in skeleton state on both Cesium initialization failure and API fetch failure inside `populateEntities`. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component Mount\nuseFallback=true, dataLoaded=false] --> B[useEffect: init Cesium]
    B -- success --> C[setUseFallback false\nuseFallback=false, dataLoaded=false]
    B -- throws --> D[setUseFallback true\nuseFallback=true, dataLoaded=false]
    C --> E[populateEntities API fetch]
    E -- success --> F[setDataLoaded true\ndataLoaded=true]
    E -- catch error --> G[log error only\ndataLoaded=false FOREVER]
    F --> H{Render skeletons?}
    D --> H
    G --> H
    H -- top-right status\ndataLoaded check only --> I[dataLoaded=false → skeleton\n⚠ stuck on D and G paths]
    H -- bottom stats\n!dataLoaded and !useFallback --> J[useFallback=true → real content\n!useFallback=false → skeleton\n⚠ stuck on G path]
    H -- legend panel\ndataLoaded check only --> K[dataLoaded=false → LegendCardSkeleton\n⚠ stuck on D and G paths]
    H -- dataLoaded=true F path --> L[All real content shown ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component Mount\nuseFallback=true, dataLoaded=false] --> B[useEffect: init Cesium]
    B -- success --> C[setUseFallback false\nuseFallback=false, dataLoaded=false]
    B -- throws --> D[setUseFallback true\nuseFallback=true, dataLoaded=false]
    C --> E[populateEntities API fetch]
    E -- success --> F[setDataLoaded true\ndataLoaded=true]
    E -- catch error --> G[log error only\ndataLoaded=false FOREVER]
    F --> H{Render skeletons?}
    D --> H
    G --> H
    H -- top-right status\ndataLoaded check only --> I[dataLoaded=false → skeleton\n⚠ stuck on D and G paths]
    H -- bottom stats\n!dataLoaded and !useFallback --> J[useFallback=true → real content\n!useFallback=false → skeleton\n⚠ stuck on G path]
    H -- legend panel\ndataLoaded check only --> K[dataLoaded=false → LegendCardSkeleton\n⚠ stuck on D and G paths]
    H -- dataLoaded=true F path --> L[All real content shown ✓]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/EarthTwin.tsx`, line 255-257 ([link](https://github.com/7-blocks/kepler/blob/9ab290e205b34ec34c94d70292b648ee5ac5960c/frontend/src/components/EarthTwin.tsx#L255-L257)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Skeleton loaders persist indefinitely on API fetch failure**

   `populateEntities` swallows fetch errors without ever calling `setDataLoaded(true)`. When this path is taken (network error, API down, etc.) `useFallback` is `false` (Cesium init succeeded), so all three new skeleton guards — the top-right status (`dataLoaded ? real : skeleton`), the bottom stats (`!dataLoaded && !useFallback ? skeleton : real`), and the legend panel (`dataLoaded ? real : skeleton`) — are stuck permanently in skeleton state, leaving users staring at a pulsing animation over a live Cesium globe with no way to recover. Adding `setDataLoaded(true)` in this catch block, or resetting to zeroed-out counts, would unblock all three skeletons on failure.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/components/EarthTwin.tsx
   Line: 255-257

   Comment:
   **Skeleton loaders persist indefinitely on API fetch failure**

   `populateEntities` swallows fetch errors without ever calling `setDataLoaded(true)`. When this path is taken (network error, API down, etc.) `useFallback` is `false` (Cesium init succeeded), so all three new skeleton guards — the top-right status (`dataLoaded ? real : skeleton`), the bottom stats (`!dataLoaded && !useFallback ? skeleton : real`), and the legend panel (`dataLoaded ? real : skeleton`) — are stuck permanently in skeleton state, leaving users staring at a pulsing animation over a live Cesium globe with no way to recover. Adding `setDataLoaded(true)` in this catch block, or resetting to zeroed-out counts, would unblock all three skeletons on failure.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/components/EarthTwin.tsx:255-257
**Skeleton loaders persist indefinitely on API fetch failure**

`populateEntities` swallows fetch errors without ever calling `setDataLoaded(true)`. When this path is taken (network error, API down, etc.) `useFallback` is `false` (Cesium init succeeded), so all three new skeleton guards — the top-right status (`dataLoaded ? real : skeleton`), the bottom stats (`!dataLoaded && !useFallback ? skeleton : real`), and the legend panel (`dataLoaded ? real : skeleton`) — are stuck permanently in skeleton state, leaving users staring at a pulsing animation over a live Cesium globe with no way to recover. Adding `setDataLoaded(true)` in this catch block, or resetting to zeroed-out counts, would unblock all three skeletons on failure.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Skeleton loaders persistence fix"](https://github.com/7-blocks/kepler/commit/9ab290e205b34ec34c94d70292b648ee5ac5960c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44539833)</sub>

<!-- /greptile_comment -->