### PR TITLE
feat: add Search by NORAD ID endpoint

### DIFF
--- a/backend/api/v1/endpoints/satellites.py
+++ b/backend/api/v1/endpoints/satellites.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Dict, Any
 import datetime
 
 from database.session import get_db, MongoSession
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import NotFoundError, BadRequestError
 from schemas.api_schemas import APIResponse, PaginationSchema
 
 router = APIRouter()
@@ -81,6 +81,27 @@ def get_satellites(
         message=f"Satellite fleet records retrieved — {total} total",
         data=data,
         pagination=PaginationSchema(page=page, size=size, total=total, pages=pages),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /satellites/norad/{norad_id}
+# ---------------------------------------------------------------------------
+
+@router.get("/norad/{norad_id}", response_model=APIResponse[dict])
+def get_satellite_by_norad_id(norad_id: str, db: MongoSession = Depends(get_db)):
+    """Search for a satellite using its NORAD Catalog ID."""
+    if not norad_id.isdecimal() or int(norad_id) <= 0:
+        raise BadRequestError(message="NORAD ID must be a positive integer")
+
+    sat = db.db["satellites"].find_one({"noradId": str(int(norad_id))}, {"_id": 0})
+    if not sat:
+        raise NotFoundError(resource="Satellite", identifier=norad_id)
+
+    return APIResponse(
+        success=True,
+        message="Satellite found",
+        data=_serialize_satellite(sat),
     )
 
 


### PR DESCRIPTION
## **User description**
Closes #24

___

## **CodeAnt-AI Description**
**Add satellite lookup by NORAD ID with clear validation**

### What Changed
- Added a new satellite search endpoint that returns a single satellite when given its NORAD Catalog ID
- Rejects invalid NORAD IDs up front with a clear message when the value is not a positive integer
- Returns a not-found response when no satellite matches the provided NORAD ID

### Impact
`✅ Faster satellite lookups`
`✅ Clearer invalid ID errors`
`✅ Fewer empty search results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve a satellite by its NORAD ID (`GET /satellites/norad/{norad_id}`).
  * Validates that the NORAD ID is a positive integer and returns a clear “bad request” response for invalid input.
  * Returns a “not found” response when no satellite matches the provided NORAD ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `GET /satellites/norad/{norad_id}` endpoint that returns a single satellite by its NORAD Catalog ID, with upfront validation rejecting non-positive-integer inputs and a clear 404 when no match is found. The previous review flags (`isdigit()` vs `isdecimal()` and leading-zero normalization) have both been addressed in this version.

- Adds `GET /norad/{norad_id}` to the satellites router with `isdecimal()` validation and `str(int(norad_id))` normalization before the MongoDB query.
- Imports and raises `BadRequestError` for invalid IDs and `NotFoundError` for missing satellites, following the existing exception hierarchy.
- Route is registered before `/{satellite_id}/telemetry`, so FastAPI's static-prefix matching correctly handles `/norad/…` paths without ambiguity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new endpoint is narrowly scoped, correctly validates its input using isdecimal(), normalizes leading zeros before querying, and follows the existing exception-handling contract without introducing new dependencies or touching existing routes.

The change is a single additive endpoint. Input validation correctly uses isdecimal(), the query normalizes the NORAD ID with str(int()), and previous review concerns have been addressed. Route ordering is safe, no existing behavior is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| backend/api/v1/endpoints/satellites.py | Adds the /norad/{norad_id} endpoint with correct isdecimal() validation, leading-zero normalization via str(int(norad_id)), and proper exception types; route ordering is safe. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant FastAPI as FastAPI Router
    participant Validator as Validation Layer
    participant MongoDB

    Client->>FastAPI: "GET /api/v1/satellites/norad/{norad_id}"
    FastAPI->>Validator: "norad_id.isdecimal() and int(norad_id) > 0?"
    alt "Invalid (non-decimal or <= 0)"
        Validator-->>Client: 400 BadRequestError NORAD ID must be a positive integer
    else Valid
        Validator->>MongoDB: "find_one({noradId: str(int(norad_id))}, {_id: 0})"
        alt No document found
            MongoDB-->>FastAPI: null
            FastAPI-->>Client: 404 NotFoundError Satellite not found
        else Document found
            MongoDB-->>FastAPI: satellite document
            FastAPI->>FastAPI: _serialize_satellite(sat)
            FastAPI-->>Client: 200 APIResponse success with data
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant FastAPI as FastAPI Router
    participant Validator as Validation Layer
    participant MongoDB

    Client->>FastAPI: "GET /api/v1/satellites/norad/{norad_id}"
    FastAPI->>Validator: "norad_id.isdecimal() and int(norad_id) > 0?"
    alt "Invalid (non-decimal or <= 0)"
        Validator-->>Client: 400 BadRequestError NORAD ID must be a positive integer
    else Valid
        Validator->>MongoDB: "find_one({noradId: str(int(norad_id))}, {_id: 0})"
        alt No document found
            MongoDB-->>FastAPI: null
            FastAPI-->>Client: 404 NotFoundError Satellite not found
        else Document found
            MongoDB-->>FastAPI: satellite document
            FastAPI->>FastAPI: _serialize_satellite(sat)
            FastAPI-->>Client: 200 APIResponse success with data
        end
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["feat: add Search by NORAD ID endpoint"](https://github.com/7-blocks/kepler/commit/53d7bd8ff817d4248f067af7f113ffc360ed4184) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44624842)</sub>

<!-- /greptile_comment -->