### PR TITLE
fix: correct database lookups for NORAD IDs

### DIFF
--- a/backend/api/v1/endpoints/catalog.py
+++ b/backend/api/v1/endpoints/catalog.py
@@ -142,6 +142,9 @@ def list_space_objects(
 @router.get("/objects/{catalog_number}", response_model=APIResponse[Dict[str, Any]])
 def get_space_object(catalog_number: str, db: MongoSession = Depends(get_db)):
     """Get a single space object by NORAD catalog number."""
+    if catalog_number.isdecimal():
+        catalog_number = str(int(catalog_number))
+        
     doc = db.db["satellites"].find_one({"noradId": catalog_number}, {"_id": 0})
     if not doc:
         doc = db.db["debris"].find_one({"noradId": catalog_number}, {"_id": 0})

--- a/backend/api/v1/endpoints/satellites.py
+++ b/backend/api/v1/endpoints/satellites.py
@@ -92,11 +92,12 @@ def get_satellites(
 def get_satellite_telemetry(satellite_id: str, db: MongoSession = Depends(get_db)):
     """Return telemetry records for a satellite (looked up by noradId or int id)."""
     # Try numeric id first, then treat as noradId string
-    flt = {}
-    try:
-        flt = {"id": int(satellite_id)}
-    except ValueError:
-        flt = {"noradId": satellite_id}
+    flt = {"$or": [{"noradId": satellite_id}]}
+    if satellite_id.isdecimal():
+        flt["$or"].extend([
+            {"id": int(satellite_id)},
+            {"noradId": str(int(satellite_id))}
+        ])
 
     sat = db.db["satellites"].find_one(flt, {"_id": 0})
     if not sat:


### PR DESCRIPTION
## **User description**
This PR fixes two bugs that could cause false 404s when querying by NORAD ID:\n1. In the telemetry endpoint, a purely numeric string would pass the `int()` cast without raising a `ValueError`, causing the fallback `noradId` query to never execute.\n2. In the catalog endpoint, unnormalized strings with leading zeros (e.g., '0025544') would fail to match the canonical stored format in MongoDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved satellite and space object lookup for numeric catalog and satellite IDs.
  * Numeric identifiers with leading zeros or other non-canonical formatting now match the correct records.
  * Enhanced telemetry retrieval to support both numeric and NORAD identifier formats consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix satellite lookups for numeric NORAD IDs**

### What Changed
- Satellite telemetry now finds records when the ID is entered as a plain number, including values with leading zeros
- Catalog object pages now treat numeric NORAD IDs in a consistent format before searching
- These lookups are less likely to return a false “not found” result for valid satellite IDs

### Impact
`✅ Fewer false 404s for satellite pages`
`✅ More reliable telemetry lookup by NORAD ID`
`✅ Fewer failed catalog searches for leading-zero IDs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two false-404 bugs in NORAD ID lookups: in the telemetry endpoint, numeric strings were previously routed only to the integer `id` field and never reached the `noradId` string index; in the catalog endpoint, zero-padded inputs (e.g. `0025544`) failed to match the canonical (non-padded) format stored in MongoDB.

- **`satellites.py`**: Replaces the `try/int()/except ValueError` pattern with an `$or` filter that always includes `{\"noradId\": satellite_id}` and, for decimal strings, additionally tries `{\"id\": int(satellite_id)}` and `{\"noradId\": str(int(satellite_id))}`, correctly covering both the numeric-id case and the zero-padded noradId case.
- **`catalog.py`**: Normalises `catalog_number` via `str(int(…))` before any DB or Space-Track query when the input is a pure decimal string, stripping leading zeros so the lookup matches the canonical stored format.

<h3>Confidence Score: 4/5</h3>

The two targeted bug fixes are logically correct and the new lookup paths are strictly additive — no existing successful lookups are broken.

Both endpoints now correctly handle zero-padded NORAD IDs and numeric-string inputs. The only issues found are cosmetic: the error message in the catalog endpoint echoes the normalised ID instead of the caller's original input, and the telemetry endpoint's $or filter has a redundant clause for already-canonical IDs. Neither affects correctness or data integrity.

The NotFoundError message in `catalog.py` would benefit from preserving the original input before normalisation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| backend/api/v1/endpoints/satellites.py | Replaces the try/except int() pattern with a $or filter; fix is correct, though the first $or clause duplicates the third when the input has no leading zeros — harmless redundancy. |
| backend/api/v1/endpoints/catalog.py | Normalises catalog_number in-place before all DB and Space-Track calls; the NotFoundError message will show the normalised ID rather than the user's original zero-padded input. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant CatalogEndpoint as GET /catalog/objects/{id}
    participant TelemetryEndpoint as GET /satellites/{id}/telemetry
    participant MongoDB
    participant SpaceTrack

    Note over CatalogEndpoint: catalog.py (new)
    Client->>CatalogEndpoint: "catalog_number = "0025544""
    CatalogEndpoint->>CatalogEndpoint: isdecimal() → normalize to "25544"
    CatalogEndpoint->>MongoDB: "find_one({noradId: "25544"}) in satellites"
    MongoDB-->>CatalogEndpoint: doc or null
    alt not found in satellites
        CatalogEndpoint->>MongoDB: "find_one({noradId: "25544"}) in debris"
        MongoDB-->>CatalogEndpoint: doc or null
    end
    alt still not found
        CatalogEndpoint->>SpaceTrack: sync_by_catalog("25544")
        SpaceTrack-->>CatalogEndpoint: synced
        CatalogEndpoint->>MongoDB: re-query satellites + debris
        MongoDB-->>CatalogEndpoint: doc or null
    end
    CatalogEndpoint-->>Client: 200 OK or 404

    Note over TelemetryEndpoint: satellites.py (new)
    Client->>TelemetryEndpoint: "satellite_id = "0025544""
    TelemetryEndpoint->>TelemetryEndpoint: build $or filter
    Note right of TelemetryEndpoint: $or: [{noradId:"0025544"},{id:25544},{noradId:"25544"}]
    TelemetryEndpoint->>MongoDB: find_one($or filter) in satellites
    MongoDB-->>TelemetryEndpoint: sat doc or null
    alt found
        TelemetryEndpoint->>MongoDB: find telemetry by satellite_id
        MongoDB-->>TelemetryEndpoint: records
    end
    TelemetryEndpoint-->>Client: 200 OK or 404
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant CatalogEndpoint as GET /catalog/objects/{id}
    participant TelemetryEndpoint as GET /satellites/{id}/telemetry
    participant MongoDB
    participant SpaceTrack

    Note over CatalogEndpoint: catalog.py (new)
    Client->>CatalogEndpoint: "catalog_number = "0025544""
    CatalogEndpoint->>CatalogEndpoint: isdecimal() → normalize to "25544"
    CatalogEndpoint->>MongoDB: "find_one({noradId: "25544"}) in satellites"
    MongoDB-->>CatalogEndpoint: doc or null
    alt not found in satellites
        CatalogEndpoint->>MongoDB: "find_one({noradId: "25544"}) in debris"
        MongoDB-->>CatalogEndpoint: doc or null
    end
    alt still not found
        CatalogEndpoint->>SpaceTrack: sync_by_catalog("25544")
        SpaceTrack-->>CatalogEndpoint: synced
        CatalogEndpoint->>MongoDB: re-query satellites + debris
        MongoDB-->>CatalogEndpoint: doc or null
    end
    CatalogEndpoint-->>Client: 200 OK or 404

    Note over TelemetryEndpoint: satellites.py (new)
    Client->>TelemetryEndpoint: "satellite_id = "0025544""
    TelemetryEndpoint->>TelemetryEndpoint: build $or filter
    Note right of TelemetryEndpoint: $or: [{noradId:"0025544"},{id:25544},{noradId:"25544"}]
    TelemetryEndpoint->>MongoDB: find_one($or filter) in satellites
    MongoDB-->>TelemetryEndpoint: sat doc or null
    alt found
        TelemetryEndpoint->>MongoDB: find telemetry by satellite_id
        MongoDB-->>TelemetryEndpoint: records
    end
    TelemetryEndpoint-->>Client: 200 OK or 404
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/api/v1/endpoints/catalog.py`, line 156-160 ([link](https://github.com/7-blocks/kepler/blob/44fe2e08c55f206e271729217e2852752d8d109b/backend/api/v1/endpoints/catalog.py#L156-L160)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> To pair with the suggestion above — the `NotFoundError` message should reference `original_catalog_number` so the error reflects what the caller actually sent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/api/v1/endpoints/catalog.py
   Line: 156-160

   Comment:
   To pair with the suggestion above — the `NotFoundError` message should reference `original_catalog_number` so the error reflects what the caller actually sent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
backend/api/v1/endpoints/catalog.py:143-146
The in-place reassignment of `catalog_number` means the `NotFoundError` message will show the normalised value (e.g. `"25544"`) even when the caller sent `"0025544"`. Stashing the original before normalising makes the error message match the user's actual input.

```suggestion
def get_space_object(catalog_number: str, db: MongoSession = Depends(get_db)):
    """Get a single space object by NORAD catalog number."""
    original_catalog_number = catalog_number
    if catalog_number.isdecimal():
        catalog_number = str(int(catalog_number))
```

### Issue 2 of 3
backend/api/v1/endpoints/catalog.py:156-160
To pair with the suggestion above — the `NotFoundError` message should reference `original_catalog_number` so the error reflects what the caller actually sent.

```suggestion
    if not doc:
        raise NotFoundError(
            f"Object '{original_catalog_number}' was not found in the local catalog or on Space-Track.",
            details={"resource": "SpaceObject", "identifier": original_catalog_number},
        )
```

### Issue 3 of 3
backend/api/v1/endpoints/satellites.py:95-100
**Redundant `$or` clause for already-normalised inputs**

When `satellite_id` has no leading zeros (the common case, e.g. `"25544"`), `str(int(satellite_id))` equals `satellite_id` itself, so the first clause `{"noradId": satellite_id}` and the third clause `{"noradId": str(int(satellite_id))}` are identical — MongoDB evaluates the same index key twice. The redundancy is harmless but a minor inefficiency on the hot path for every decimal ID that is already in canonical form.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: correct database lookups for NORAD ..."](https://github.com/7-blocks/kepler/commit/44fe2e08c55f206e271729217e2852752d8d109b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44635561)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->