### PR TITLE
feat: add custom 404 not found page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { CollisionCenter } from '@/pages/CollisionCenter';
 import { AIAgents } from '@/pages/AIAgents';
 import { MissionPlanner } from '@/pages/MissionPlanner';
 import { Settings } from '@/pages/Settings';
+import { NotFound } from '@/pages/NotFound';
 
 function App() {
   return (
@@ -34,6 +35,9 @@ function App() {
         <Route path="/ai-agents" element={<Navigate to="/dashboard/ai-agents" replace />} />
         <Route path="/mission-planner" element={<Navigate to="/dashboard/mission-planner" replace />} />
         <Route path="/settings" element={<Navigate to="/dashboard/settings" replace />} />
+
+        {/* Catch-all 404 */}
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { MaterialIcon } from "@/components/MaterialIcon";
+
+/**
+ * Kepler — 404 Not Found Page
+ * -----------------------------------------------------------------------
+ * Matches the app's dashboard design system (designSystem.ts / index.css
+ * theme tokens): deep space background, technical grid, glass panels,
+ * Space Grotesk / IBM Plex Sans type, cyan glow accents.
+ * -----------------------------------------------------------------------
+ */
+
+interface DebrisFieldProps {
+  prefersReducedMotion: boolean;
+}
+
+function DebrisField({ prefersReducedMotion }: DebrisFieldProps) {
+  const orbits = [
+    { rx: 220, ry: 80, rotate: -15, dur: 30, dot: "#00e5ff", label: "SIG-LOST" },
+    { rx: 300, ry: 115, rotate: 10, dur: 42, dot: "#00e5ff", label: "ROUTE-404" },
+    { rx: 160, ry: 55, rotate: 24, dur: 20, dot: "#FF9500", label: "OOB" },
+  ];
+
+  return (
+    <div
+      aria-hidden="true"
+      className="absolute inset-0 flex items-center justify-center overflow-hidden pointer-events-none z-0"
+    >
+      <svg viewBox="-400 -200 800 400" className="w-[min(1000px,140%)] h-auto opacity-70">
+        <circle cx="0" cy="0" r="8" fill="#c3f5ff" opacity="0.5" />
+        {orbits.map((o, i) => (
+          <g key={i} transform={`rotate(${o.rotate})`}>
+            <ellipse
+              cx="0"
+              cy="0"
+              rx={o.rx}
+              ry={o.ry}
+              fill="none"
+              stroke="#1F2937"
+              strokeWidth="1"
+            />
+            <g>
+              {!prefersReducedMotion && (
+                <animateTransform
+                  attributeName="transform"
+                  type="rotate"
+                  from="0 0 0"
+                  to="360 0 0"
+                  dur={`${o.dur}s`}
+                  repeatCount="indefinite"
+                />
+              )}
+              <circle cx={o.rx} cy="0" r="3" fill={o.dot} />
+              <text
+                x={o.rx + 8}
+                y="4"
+                fontFamily="IBM Plex Sans, monospace"
+                fontSize="9"
+                fill={o.dot}
+                opacity="0.85"
+              >
+                {o.label}
+              </text>
+            </g>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+export const NotFound: React.FC = () => {
+  const navigate = useNavigate();
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mediaQuery.matches);
+    const listener = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mediaQuery.addEventListener("change", listener);
+    return () => mediaQuery.removeEventListener("change", listener);
+  }, []);
+
+  return (
+    <div className="relative min-h-screen w-full bg-background technical-grid text-on-surface overflow-hidden flex items-center justify-center px-6">
+      <DebrisField prefersReducedMotion={prefersReducedMotion} />
+
+      <div className="relative z-10 max-w-lg w-full text-center">
+        <div className="glass-panel rounded-xl px-8 py-10 sm:px-12 sm:py-14 glow-cyan">
+          <div className="inline-flex items-center gap-2 font-technical-data text-xs text-primary-container border border-border-panel rounded-full px-3.5 py-1.5 mb-8 bg-surface">
+            <MaterialIcon name="satellite_alt" className="text-sm" />
+            TELEMETRY SIGNAL LOST
+          </div>
+
+          <h1 className="font-display-lg font-bold text-7xl sm:text-8xl text-primary tracking-tight leading-none">
+            404
+          </h1>
+
+          <h2 className="font-headline-lg text-lg sm:text-xl text-text-satellite font-bold tracking-tight mt-4 uppercase">
+            Object Not Found In Orbit
+          </h2>
+
+          <p className="font-body-ui text-sm text-on-surface-variant leading-relaxed mt-3 max-w-sm mx-auto">
+            The route you requested doesn't correspond to any tracked page.
+            It may have decayed, been renamed, or never existed in this
+            catalog.
+          </p>
+
+          <button
+            onClick={() => navigate("/dashboard")}
+            className="mt-9 inline-flex items-center gap-2 font-body-ui font-semibold text-sm text-on-primary bg-primary-container hover:opacity-90 rounded-lg px-6 py-3 cursor-pointer transition-opacity duration-150"
+          >
+            <MaterialIcon name="dashboard" className="text-base" />
+            Return to Dashboard
+          </button>
+        </div>
+
+        <p className="font-technical-data text-[11px] text-text-muted mt-6">
+          ERROR CODE: KPLR-404 · REQUESTED PATH NOT IN CATALOG
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## **User description**
Closes #44

## Description
Adds a custom 404 Not Found page matching Kepler's existing dashboard design system, replacing the default framework 404 page.

- New `frontend/src/pages/NotFound.tsx` — deep-space background with technical grid, glass panel, animated orbital debris field SVG, Space Grotesk/IBM Plex Sans typography, and cyan glow accents consistent with the rest of the app
- Displays a clear "Object Not Found In Orbit" message and error code
- "Return to Dashboard" button navigates back to `/dashboard`
- Added catch-all `<Route path="*" element={<NotFound />} />` in `App.tsx` so any invalid route renders this page
- Fully responsive — verified at 375px, 768px, and 1440px widths
- Respects `prefers-reduced-motion` for the animated orbit paths

## Related Issue
Closes #44

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [ ] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings
<!-- attach your recording/screenshots here -->

## Breaking Changes
None. This only adds a new route for previously-unmatched paths; no existing routes or components are modified.




___

## **CodeAnt-AI Description**
**Add a custom 404 page for unknown routes**

### What Changed
- Unknown URLs now open a branded 404 page instead of the default framework error page
- The new page shows a clear “Object Not Found In Orbit” message, error code, and a button that takes users back to the dashboard
- Motion on the page respects reduced-motion settings for users who prefer less animation

### Impact
`✅ Clearer error pages`
`✅ Easier recovery from bad links`
`✅ Fewer confusing dead-end routes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated 404 page for unmatched routes.
  * Included a clear button to return to the dashboard.
  * Added a responsive visual design with animations that respect reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a custom 404 page (`NotFound.tsx`) styled to match Kepler's dashboard design system, and wires it into the router as a top-level catch-all route. The page includes an animated SVG debris field, `prefers-reduced-motion` support, and a "Return to Dashboard" button.

- The top-level `<Route path=\"*\">` only catches paths that have no matching parent route. Paths nested under `/dashboard` (e.g., `/dashboard/nonexistent`) silently match the `/dashboard` parent and render `MainLayout` with an empty outlet instead of the 404 page — a nested wildcard child is needed to cover this case.
- The SVG `animateTransform` rotates the debris dot in a circle of radius `rx` rather than following the underlying ellipse (semi-axes `rx`/`ry`); the dot diverges visibly from the orbital path at all angles except 0° and 180°.

<h3>Confidence Score: 3/5</h3>

The new 404 page itself is safe, but the routing gap means an entire class of invalid URLs displays a broken-looking empty dashboard shell instead of the intended error page.

The catch-all route does not cover invalid paths nested under /dashboard/. Any URL like /dashboard/anything-invalid matches the parent route, and MainLayout renders with a blank content area — the sidebar, header, and all their side-effects run normally, but users see no content and receive no error feedback. This is an observable, reproducible gap in the feature as described by the PR.

frontend/src/App.tsx needs a <Route path="*" element={<NotFound />} /> added as a child of the /dashboard route to close the gap.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/App.tsx | Adds the NotFound import and top-level catch-all route, but the route doesn't cover unmatched paths under the nested /dashboard parent, leaving those paths blank rather than showing 404. |
| frontend/src/pages/NotFound.tsx | New 404 page that matches the app design system; well-structured with reduced-motion support, though the animated orbital dots trace circles rather than the ellipse paths they overlay. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant BrowserRouter
    participant Routes
    participant MainLayout
    participant NotFound

    User->>BrowserRouter: Navigate to /unknown-path
    BrowserRouter->>Routes: Match /unknown-path
    Routes->>NotFound: "path="*" matches"
    NotFound-->>User: Renders 404 page

    User->>BrowserRouter: Navigate to /dashboard/nonexistent
    BrowserRouter->>Routes: Match /dashboard/nonexistent
    Routes->>MainLayout: "path="/dashboard" matches (parent)"
    MainLayout->>MainLayout: No child route matches nonexistent
    MainLayout-->>User: Renders shell with empty Outlet (NotFound not shown)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant BrowserRouter
    participant Routes
    participant MainLayout
    participant NotFound

    User->>BrowserRouter: Navigate to /unknown-path
    BrowserRouter->>Routes: Match /unknown-path
    Routes->>NotFound: "path="*" matches"
    NotFound-->>User: Renders 404 page

    User->>BrowserRouter: Navigate to /dashboard/nonexistent
    BrowserRouter->>Routes: Match /dashboard/nonexistent
    Routes->>MainLayout: "path="/dashboard" matches (parent)"
    MainLayout->>MainLayout: No child route matches nonexistent
    MainLayout-->>User: Renders shell with empty Outlet (NotFound not shown)
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/App.tsx`, line 19-28 ([link](https://github.com/7-blocks/kepler/blob/eaa8a2c47632bb471c942a5a1091ab67b1df149e/frontend/src/App.tsx#L19-L28)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Invalid dashboard sub-paths silently render an empty shell**

   The top-level `<Route path="*">` only catches paths with no parent match. Because `/dashboard` already matches as a parent route, any URL like `/dashboard/nonexistent` causes `MainLayout` to render with `<Outlet>` returning `null` — the sidebar and header appear, but the content area is empty. The `NotFound` page is never shown for these cases. A nested wildcard is needed as the last child of the `/dashboard` route to cover this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/App.tsx
   Line: 19-28

   Comment:
   **Invalid dashboard sub-paths silently render an empty shell**

   The top-level `<Route path="*">` only catches paths with no parent match. Because `/dashboard` already matches as a parent route, any URL like `/dashboard/nonexistent` causes `MainLayout` to render with `<Outlet>` returning `null` — the sidebar and header appear, but the content area is empty. The `NotFound` page is never shown for these cases. A nested wildcard is needed as the last child of the `/dashboard` route to cover this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
frontend/src/App.tsx:19-28
**Invalid dashboard sub-paths silently render an empty shell**

The top-level `<Route path="*">` only catches paths with no parent match. Because `/dashboard` already matches as a parent route, any URL like `/dashboard/nonexistent` causes `MainLayout` to render with `<Outlet>` returning `null` — the sidebar and header appear, but the content area is empty. The `NotFound` page is never shown for these cases. A nested wildcard is needed as the last child of the `/dashboard` route to cover this gap.

### Issue 2 of 2
frontend/src/pages/NotFound.tsx:43-65
**Animated dot traces a circle, not the ellipse orbital path**

The `animateTransform` rotates the inner `<g>` around `(0, 0)`, so the dot at `cx={o.rx} cy=0` traces a perfect circle of radius `rx`. The ellipse it's supposed to follow has semi-axes `rx` and `ry` (e.g., 220 × 80 for the first orbit). After a 90° rotation the dot sits at `(0, 220)` in the tilted coordinate space, far outside the `ry=80` ellipse path. If this divergence is intentional as an approximate visual effect, a brief comment would clarify intent for future maintainers.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add custom 404 not found page"](https://github.com/7-blocks/kepler/commit/eaa8a2c47632bb471c942a5a1091ab67b1df149e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44721719)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->


## ScreenShots

<img width="1440" height="900" alt="desktop" src="https://github.com/user-attachments/assets/84611ba8-ae58-4296-94af-99a581f366e1" />

### Desktop View

<img width="375" height="812" alt="mobile" src="https://github.com/user-attachments/assets/32fceafd-3129-415b-b76f-8e5baaa84db8" />

### Mobile View


<img width="768" height="1024" alt="tablet" src="https://github.com/user-attachments/assets/b574b50e-56dd-4aac-ad2d-7fea097a66ef" />

###  Tablet View