### PR TITLE
feat: add database seed script for sample satellite data

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,28 @@ http://localhost:5173
 
 ---
 
+## 11. Database Seeding
+
+To quickly populate the local MongoDB database with realistic sample satellite, telemetry, and conjunction records for development, testing, and demonstration, use the seeding script:
+
+```bash
+cd backend
+PYTHONPATH=. python scripts/seed_db.py --count 50 --clear
+```
+
+### Seeding Options
+- `--count` / `-c` (default `50`): Number of satellite records to generate.
+- `--clear` / `-x`: Drops existing satellite, debris, telemetry, and conjunction records from MongoDB before seeding.
+
+### Configuration
+By default, the script connects to the URI specified in the `.env` file or defaults to `mongodb://localhost:27017/orbital_guardian`. You can configure a custom MongoDB connection string by setting the `MONGODB_URI` environment variable:
+
+```bash
+MONGODB_URI=mongodb://localhost:27017/custom_db PYTHONPATH=. python scripts/seed_db.py --count 100 --clear
+```
+
+---
+
 # 🧪 Running Tests
 
 Backend

--- a/backend/scripts/seed_db.py
+++ b/backend/scripts/seed_db.py
@@ -108,298 +108,317 @@ def generate_tle(norad_id: str, incl: float, ecc: float, mean_motion: float) -> 
 
 def seed_database(count: int, clear: bool):
     """Seed the database with organizations, satellites, debris, telemetry, and conjunctions."""
-    print("🔌 Connecting to MongoDB...")
+    db = None
     try:
+        print("🔌 Connecting to MongoDB...")
         db = SessionLocal()
         client = get_mongo_client()
         db_name = uri_db_name(settings.MONGODB_URI)
         mongo_db = client[db_name]
         print(f"✅ Successfully connected to MongoDB database: '{db_name}'")
-    except Exception as e:
-        print(f"❌ Error connecting to database: {e}")
-        sys.exit(1)
 
-    if clear:
-        print("🧹 Clearing existing database collections...")
-        collections_to_clear = [
-            "satellites",
-            "debris",
-            "orbitalElements",
-            "telemetry",
-            "conjunctions",
-            "organizations"
+        if clear:
+            print("🧹 Clearing existing database collections...")
+            collections_to_clear = [
+                "satellites",
+                "debris",
+                "orbitalElements",
+                "telemetry",
+                "conjunctions",
+                "organizations"
+            ]
+            for col_name in collections_to_clear:
+                mongo_db[col_name].delete_many({})
+                # Reset counters
+                mongo_db["counters"].delete_one({"_id": col_name})
+                print(f"   - Cleared collection '{col_name}' and its auto-increment counters")
+
+        # 1. Seed Organizations
+        print("🏢 Seeding default organizations...")
+        orgs_to_create = [
+            {"name": "NASA", "description": "National Aeronautics and Space Administration"},
+            {"name": "ISRO", "description": "Indian Space Research Organisation"},
+            {"name": "ESA", "description": "European Space Agency"},
+            {"name": "SpaceX", "description": "Space Exploration Technologies Corp."},
+            {"name": "OneWeb", "description": "Eutelsat OneWeb Satellite Network"},
         ]
-        for col_name in collections_to_clear:
-            mongo_db[col_name].delete_many({})
-            # Reset counters
-            mongo_db["counters"].delete_one({"_id": col_name})
-            print(f"   - Cleared collection '{col_name}' and its auto-increment counters")
-
-    # 1. Seed Organizations
-    print("🏢 Seeding default organizations...")
-    orgs_to_create = [
-        {"name": "NASA", "description": "National Aeronautics and Space Administration"},
-        {"name": "ISRO", "description": "Indian Space Research Organisation"},
-        {"name": "ESA", "description": "European Space Agency"},
-        {"name": "SpaceX", "description": "Space Exploration Technologies Corp."},
-        {"name": "OneWeb", "description": "Eutelsat OneWeb Satellite Network"},
-    ]
-    
-    seeded_orgs = []
-    for org_data in orgs_to_create:
-        # Check if already exists
-        existing = db.query(Organization).filter(Organization.name == org_data["name"]).first()
-        if not existing:
-            org = Organization(
-                name=org_data["name"],
-                description=org_data["description"],
-                created_at=datetime.datetime.utcnow().isoformat()
-            )
-            db.add(org)
-            db.commit()
-            db.refresh(org)
-            seeded_orgs.append(org)
-            print(f"   + Created organization: {org.name} (ID: {org.id})")
-        else:
-            seeded_orgs.append(existing)
-            print(f"   • Organization {existing.name} already exists (ID: {existing.id})")
-
-    # Helper list of generated norad IDs to ensure uniqueness
-    used_norad_ids = set()
-
-    # 2. Seed Satellites
-    print(f"🛰️ Generating {count} satellite records...")
-    satellites_list = []
-    for i in range(count):
-        # Choose country and name
-        country = random.choice(list(SATELLITE_NAMES.keys()))
-        prefix = random.choice(SATELLITE_NAMES[country])
-        suffix = f"-{random.randint(100, 999)}" if prefix in ["STARLINK", "SENTINEL", "YAOGAN"] else f" {random.randint(1, 20)}"
-        name = f"{prefix}{suffix}"
         
-        # Unique NORAD ID
-        norad_id = str(random.randint(10000, 49999))
-        while norad_id in used_norad_ids:
-            norad_id = str(random.randint(10000, 49999))
-        used_norad_ids.add(norad_id)
-
-        # Orbital elements
-        inclination = random.uniform(50.0, 105.0)  # Common LEO inclinations
-        eccentricity = random.uniform(0.0001, 0.01) # Near circular LEO orbits
-        mean_motion = random.uniform(14.0, 16.2)    # 14 to 16.2 orbits per day
-        semimajor = calculate_semimajor_axis(mean_motion)
-        period = 1440.0 / mean_motion
-        epoch = datetime.datetime.utcnow() - datetime.timedelta(days=random.uniform(0, 5))
-        launch_date = (datetime.date.today() - datetime.timedelta(days=random.randint(100, 5000))).isoformat()
-        
-        tle1, tle2 = generate_tle(norad_id, inclination, eccentricity, mean_motion)
-        
-        # Link to a random organization
-        org = random.choice(seeded_orgs)
-
-        # Create SpaceObject first to replicate ORM relationship correctly
-        space_obj = SpaceObject(
-            noradId=norad_id,
-            objectName=name,
-            objectType="PAYLOAD",
-            cospar_id=f"{random.randint(2010, 2026)}-{random.randint(1, 100):03d}{random.choice(['A', 'B', 'C'])}",
-            epoch=epoch.isoformat(),
-            inclination=inclination,
-            eccentricity=eccentricity,
-            semimajor_axis=semimajor,
-            period=period,
-            mean_motion=mean_motion,
-            tle_line1=tle1,
-            tle_line2=tle2,
-            updated_at=datetime.datetime.utcnow().isoformat()
-        )
-        db.add(space_obj)
-        db.commit()
-        db.refresh(space_obj)
-
-        # Now create Satellite linked to SpaceObject and Organization
-        sat = Satellite(
-            noradId=norad_id,
-            objectName=name,
-            objectType="PAYLOAD",
-            countryCode=country,
-            launchDate=launch_date,
-            epoch=epoch.isoformat(),
-            inclination=inclination,
-            eccentricity=eccentricity,
-            meanMotion=mean_motion,
-            source="seed_script",
-            createdAt=datetime.datetime.utcnow().isoformat(),
-            updatedAt=datetime.datetime.utcnow().isoformat(),
-            space_object_id=space_obj.id,
-            organization_id=org.id,
-            status=random.choice(["ACTIVE", "ACTIVE", "ACTIVE", "DEGRADED", "INACTIVE"]),
-            fuel_percentage=random.uniform(15.0, 100.0),
-            dry_mass=random.uniform(150.0, 1800.0),
-            propellant_mass=random.uniform(20.0, 800.0),
-            operational_mode=random.choice(["NORMAL", "NORMAL", "NORMAL", "SAFE", "STANDBY"]),
-            semimajor_axis=semimajor,
-            period=period,
-            tle_line1=tle1,
-            tle_line2=tle2
-        )
-        db.add(sat)
-        db.commit()
-        db.refresh(sat)
-        satellites_list.append(sat)
-
-    print(f"   + Seeded {len(satellites_list)} satellite and space object records.")
-
-    # 3. Seed Telemetry
-    print("📈 Seeding telemetry log history for satellites...")
-    telemetry_count = 0
-    for sat in satellites_list:
-        # Generate 5 telemetry points over the last 50 minutes for each active satellite
-        if sat.status in ["ACTIVE", "DEGRADED"]:
-            base_altitude = sat.semimajor_axis - 6378.1  # Semi-major axis minus Earth radius
-            base_velocity = 7.5  # Typical LEO velocity in km/s
-            
-            for j in range(5):
-                ts = datetime.datetime.utcnow() - datetime.timedelta(minutes=10 * j)
-                tel = Telemetry(
-                    satellite_id=str(sat.id),
-                    timestamp=ts,
-                    altitude_km=base_altitude + random.uniform(-2.0, 2.0),
-                    velocity_kms=base_velocity + random.uniform(-0.1, 0.1),
-                    temperature_c=random.uniform(-5.0, 35.0),
-                    battery_charge=max(0.0, min(100.0, sat.fuel_percentage + random.uniform(-5.0, 5.0))),
-                    neural_load=random.uniform(10.0, 90.0)
+        seeded_orgs = []
+        for org_data in orgs_to_create:
+            # Check if already exists
+            existing = db.query(Organization).filter(Organization.name == org_data["name"]).first()
+            if not existing:
+                org = Organization(
+                    name=org_data["name"],
+                    description=org_data["description"],
+                    created_at=datetime.datetime.utcnow().isoformat()
                 )
-                db.add(tel)
-                telemetry_count += 1
-            db.commit()
-    print(f"   + Seeded {telemetry_count} telemetry data points.")
+                db.add(org)
+                db.commit()
+                db.refresh(org)
+                seeded_orgs.append(org)
+                print(f"   + Created organization: {org.name} (ID: {org.id})")
+            else:
+                seeded_orgs.append(existing)
+                print(f"   • Organization {existing.name} already exists (ID: {existing.id})")
 
-    # 4. Seed Debris
-    debris_count = max(5, count // 2)
-    print(f"☄️ Generating {debris_count} space debris records...")
-    debris_list = []
-    for i in range(debris_count):
-        # Choose debris name
-        base_name = random.choice(DEBRIS_NAMES)
-        name = f"{base_name} [#{random.randint(1000, 9999)}]"
+        # Helper list of generated norad IDs to ensure uniqueness
+        used_norad_ids = set()
         
-        # Unique NORAD ID
-        norad_id = str(random.randint(50000, 89999))
-        while norad_id in used_norad_ids:
-            norad_id = str(random.randint(50000, 89999))
-        used_norad_ids.add(norad_id)
+        # Pre-load existing NORAD IDs from the database if not clearing to avoid unique index crashes
+        if not clear:
+            print("🔍 Pre-loading existing NORAD IDs from database to avoid duplicates...")
+            try:
+                for sat_doc in mongo_db["satellites"].find({}, {"noradId": 1}):
+                    if sat_doc.get("noradId"):
+                        used_norad_ids.add(sat_doc["noradId"])
+                for debris_doc in mongo_db["debris"].find({}, {"noradId": 1}):
+                    if debris_doc.get("noradId"):
+                        used_norad_ids.add(debris_doc["noradId"])
+                print(f"   - Loaded {len(used_norad_ids)} existing NORAD IDs.")
+            except Exception as e:
+                print(f"   ⚠️ Warning: Could not pre-load existing NORAD IDs: {e}")
 
-        inclination = random.uniform(50.0, 110.0)
-        eccentricity = random.uniform(0.0005, 0.05)
-        mean_motion = random.uniform(13.5, 16.5)
-        semimajor = calculate_semimajor_axis(mean_motion)
-        period = 1440.0 / mean_motion
-        epoch = datetime.datetime.utcnow() - datetime.timedelta(days=random.uniform(0, 10))
-        
-        tle1, tle2 = generate_tle(norad_id, inclination, eccentricity, mean_motion)
-
-        # Create SpaceObject for Debris
-        space_obj = SpaceObject(
-            noradId=norad_id,
-            objectName=name,
-            objectType="DEBRIS",
-            cospar_id=None,
-            epoch=epoch.isoformat(),
-            inclination=inclination,
-            eccentricity=eccentricity,
-            semimajor_axis=semimajor,
-            period=period,
-            mean_motion=mean_motion,
-            tle_line1=tle1,
-            tle_line2=tle2,
-            updated_at=datetime.datetime.utcnow().isoformat()
-        )
-        db.add(space_obj)
-        db.commit()
-        db.refresh(space_obj)
-
-        # Create Debris record linked to SpaceObject
-        deb = Debris(
-            noradId=norad_id,
-            objectName=name,
-            epoch=epoch.isoformat(),
-            inclination=inclination,
-            eccentricity=eccentricity,
-            meanMotion=mean_motion,
-            source="seed_script",
-            createdAt=datetime.datetime.utcnow().isoformat(),
-            space_object_id=space_obj.id,
-            size_category=random.choice(["SMALL", "MEDIUM", "LARGE"]),
-            radar_cross_section=random.uniform(0.01, 15.0),
-            average_mass=random.uniform(0.5, 200.0),
-            semimajor_axis=semimajor,
-            period=period,
-            tle_line1=tle1,
-            tle_line2=tle2
-        )
-        db.add(deb)
-        db.commit()
-        db.refresh(deb)
-        debris_list.append(deb)
-        
-    print(f"   + Seeded {len(debris_list)} space debris records.")
-
-    # 5. Seed Conjunctions (Collisions)
-    print("💥 Seeding sample orbital conjunctions (collisions)...")
-    conjunctions_count = 0
-    # Create up to 5 conjunction events between seeded satellites and debris
-    num_conjunctions = min(5, len(satellites_list), len(debris_list))
-    
-    for i in range(num_conjunctions):
-        sat = satellites_list[i]
-        deb = debris_list[i]
-        
-        miss_distance = random.uniform(10.0, 800.0)
-        prob = random.uniform(0.001, 0.45)
-        # Determine risk level based on miss distance & probability
-        if miss_distance < 50.0 or prob > 0.1:
-            risk_level = "CRITICAL"
-        elif miss_distance < 150.0 or prob > 0.01:
-            risk_level = "HIGH"
-        elif miss_distance < 500.0 or prob > 0.001:
-            risk_level = "MEDIUM"
-        else:
-            risk_level = "LOW"
+        # 2. Seed Satellites
+        print(f"🛰️ Generating {count} satellite records...")
+        satellites_list = []
+        for i in range(count):
+            # Choose country and name
+            country = random.choice(list(SATELLITE_NAMES.keys()))
+            prefix = random.choice(SATELLITE_NAMES[country])
+            suffix = f"-{random.randint(100, 999)}" if prefix in ["STARLINK", "SENTINEL", "YAOGAN"] else f" {random.randint(1, 20)}"
+            name = f"{prefix}{suffix}"
             
-        tca = datetime.datetime.utcnow() + datetime.timedelta(hours=random.uniform(4, 72))
-        
-        conj = CollisionPrediction(
-            primaryObject=sat.noradId,
-            secondaryObject=deb.noradId,
-            missDistance=miss_distance,
-            riskScore=prob,
-            conjunctionTime=tca,
-            createdAt=datetime.datetime.utcnow(),
-            object_a_id=sat.space_object_id,
-            object_b_id=deb.space_object_id,
-            probability=prob,
-            tca=tca,
-            miss_distance_m=miss_distance,
-            relative_velocity_kms=random.uniform(8.0, 15.0),
-            risk_level=risk_level,
-            status="PENDING",
-            created_at=datetime.datetime.utcnow()
-        )
-        db.add(conj)
-        conjunctions_count += 1
-        
-    db.commit()
-    print(f"   + Seeded {conjunctions_count} collision conjunction alerts.")
+            # Unique NORAD ID
+            norad_id = str(random.randint(10000, 49999))
+            while norad_id in used_norad_ids:
+                norad_id = str(random.randint(10000, 49999))
+            used_norad_ids.add(norad_id)
 
-    print("\n🎉 Database Seeding Completed Successfully!")
-    print(f"   - Seeded {len(seeded_orgs)} Organizations")
-    print(f"   - Seeded {len(satellites_list)} Satellites")
-    print(f"   - Seeded {telemetry_count} Telemetry Records")
-    print(f"   - Seeded {len(debris_list)} Debris Records")
-    print(f"   - Seeded {conjunctions_count} Conjunction Predictions")
-    
-    db.close()
+            # Orbital elements
+            inclination = random.uniform(50.0, 105.0)  # Common LEO inclinations
+            eccentricity = random.uniform(0.0001, 0.01) # Near circular LEO orbits
+            mean_motion = random.uniform(14.0, 16.2)    # 14 to 16.2 orbits per day
+            semimajor = calculate_semimajor_axis(mean_motion)
+            period = 1440.0 / mean_motion
+            epoch = datetime.datetime.utcnow() - datetime.timedelta(days=random.uniform(0, 5))
+            launch_date = (datetime.date.today() - datetime.timedelta(days=random.randint(100, 5000))).isoformat()
+            
+            tle1, tle2 = generate_tle(norad_id, inclination, eccentricity, mean_motion)
+            
+            # Link to a random organization
+            org = random.choice(seeded_orgs)
+
+            # Create SpaceObject first to replicate ORM relationship correctly
+            space_obj = SpaceObject(
+                noradId=norad_id,
+                objectName=name,
+                objectType="PAYLOAD",
+                cospar_id=f"{random.randint(2010, 2026)}-{random.randint(1, 100):03d}{random.choice(['A', 'B', 'C'])}",
+                epoch=epoch.isoformat(),
+                inclination=inclination,
+                eccentricity=eccentricity,
+                semimajor_axis=semimajor,
+                period=period,
+                mean_motion=mean_motion,
+                tle_line1=tle1,
+                tle_line2=tle2,
+                updated_at=datetime.datetime.utcnow().isoformat()
+            )
+            db.add(space_obj)
+            db.commit()
+            db.refresh(space_obj)
+
+            # Now create Satellite linked to SpaceObject and Organization
+            # Make the first satellite deterministically ACTIVE so telemetry tests pass without flakiness
+            status_val = "ACTIVE" if i == 0 else random.choice(["ACTIVE", "ACTIVE", "ACTIVE", "DEGRADED", "INACTIVE"])
+            sat = Satellite(
+                noradId=norad_id,
+                objectName=name,
+                objectType="PAYLOAD",
+                countryCode=country,
+                launchDate=launch_date,
+                epoch=epoch.isoformat(),
+                inclination=inclination,
+                eccentricity=eccentricity,
+                meanMotion=mean_motion,
+                source="seed_script",
+                createdAt=datetime.datetime.utcnow().isoformat(),
+                updatedAt=datetime.datetime.utcnow().isoformat(),
+                space_object_id=space_obj.id,
+                organization_id=org.id,
+                status=status_val,
+                fuel_percentage=random.uniform(15.0, 100.0),
+                dry_mass=random.uniform(150.0, 1800.0),
+                propellant_mass=random.uniform(20.0, 800.0),
+                operational_mode=random.choice(["NORMAL", "NORMAL", "NORMAL", "SAFE", "STANDBY"]),
+                semimajor_axis=semimajor,
+                period=period,
+                tle_line1=tle1,
+                tle_line2=tle2
+            )
+            db.add(sat)
+            db.commit()
+            db.refresh(sat)
+            satellites_list.append(sat)
+
+        print(f"   + Seeded {len(satellites_list)} satellite and space object records.")
+
+        # 3. Seed Telemetry
+        print("📈 Seeding telemetry log history for satellites...")
+        telemetry_count = 0
+        for sat in satellites_list:
+            # Generate 5 telemetry points over the last 50 minutes for each active satellite
+            if sat.status in ["ACTIVE", "DEGRADED"]:
+                base_altitude = sat.semimajor_axis - 6378.1  # Semi-major axis minus Earth radius
+                base_velocity = 7.5  # Typical LEO velocity in km/s
+                
+                for j in range(5):
+                    ts = datetime.datetime.utcnow() - datetime.timedelta(minutes=10 * j)
+                    tel = Telemetry(
+                        satellite_id=str(sat.id),
+                        timestamp=ts,
+                        altitude_km=base_altitude + random.uniform(-2.0, 2.0),
+                        velocity_kms=base_velocity + random.uniform(-0.1, 0.1),
+                        temperature_c=random.uniform(-5.0, 35.0),
+                        battery_charge=max(0.0, min(100.0, sat.fuel_percentage + random.uniform(-5.0, 5.0))),
+                        neural_load=random.uniform(10.0, 90.0)
+                    )
+                    db.add(tel)
+                    telemetry_count += 1
+                db.commit()
+        print(f"   + Seeded {telemetry_count} telemetry data points.")
+
+        # 4. Seed Debris
+        debris_count = max(5, count // 2)
+        print(f"☄️ Generating {debris_count} space debris records...")
+        debris_list = []
+        for i in range(debris_count):
+            # Choose debris name
+            base_name = random.choice(DEBRIS_NAMES)
+            name = f"{base_name} [#{random.randint(1000, 9999)}]"
+            
+            # Unique NORAD ID
+            norad_id = str(random.randint(50000, 89999))
+            while norad_id in used_norad_ids:
+                norad_id = str(random.randint(50000, 89999))
+            used_norad_ids.add(norad_id)
+
+            inclination = random.uniform(50.0, 110.0)
+            eccentricity = random.uniform(0.0005, 0.05)
+            mean_motion = random.uniform(13.5, 16.5)
+            semimajor = calculate_semimajor_axis(mean_motion)
+            period = 1440.0 / mean_motion
+            epoch = datetime.datetime.utcnow() - datetime.timedelta(days=random.uniform(0, 10))
+            
+            tle1, tle2 = generate_tle(norad_id, inclination, eccentricity, mean_motion)
+
+            # Create SpaceObject for Debris
+            space_obj = SpaceObject(
+                noradId=norad_id,
+                objectName=name,
+                objectType="DEBRIS",
+                cospar_id=None,
+                epoch=epoch.isoformat(),
+                inclination=inclination,
+                eccentricity=eccentricity,
+                semimajor_axis=semimajor,
+                period=period,
+                mean_motion=mean_motion,
+                tle_line1=tle1,
+                tle_line2=tle2,
+                updated_at=datetime.datetime.utcnow().isoformat()
+            )
+            db.add(space_obj)
+            db.commit()
+            db.refresh(space_obj)
+
+            # Create Debris record linked to SpaceObject
+            deb = Debris(
+                noradId=norad_id,
+                objectName=name,
+                epoch=epoch.isoformat(),
+                inclination=inclination,
+                eccentricity=eccentricity,
+                meanMotion=mean_motion,
+                source="seed_script",
+                createdAt=datetime.datetime.utcnow().isoformat(),
+                space_object_id=space_obj.id,
+                size_category=random.choice(["SMALL", "MEDIUM", "LARGE"]),
+                radar_cross_section=random.uniform(0.01, 15.0),
+                average_mass=random.uniform(0.5, 200.0),
+                semimajor_axis=semimajor,
+                period=period,
+                tle_line1=tle1,
+                tle_line2=tle2
+            )
+            db.add(deb)
+            db.commit()
+            db.refresh(deb)
+            debris_list.append(deb)
+            
+        print(f"   + Seeded {len(debris_list)} space debris records.")
+
+        # 5. Seed Conjunctions (Collisions)
+        print("💥 Seeding sample orbital conjunctions (collisions)...")
+        conjunctions_count = 0
+        # Create up to 5 conjunction events between seeded satellites and debris
+        num_conjunctions = min(5, len(satellites_list), len(debris_list))
+        
+        for i in range(num_conjunctions):
+            sat = satellites_list[i]
+            deb = debris_list[i]
+            
+            miss_distance = random.uniform(10.0, 800.0)
+            prob = random.uniform(0.001, 0.45)
+            # Determine risk level based on miss distance & probability
+            if miss_distance < 50.0 or prob > 0.1:
+                risk_level = "CRITICAL"
+            elif miss_distance < 150.0 or prob > 0.01:
+                risk_level = "HIGH"
+            elif miss_distance < 500.0 or prob > 0.001:
+                risk_level = "MEDIUM"
+            else:
+                risk_level = "LOW"
+                
+            tca = datetime.datetime.utcnow() + datetime.timedelta(hours=random.uniform(4, 72))
+            
+            conj = CollisionPrediction(
+                primaryObject=sat.noradId,
+                secondaryObject=deb.noradId,
+                missDistance=miss_distance,
+                riskScore=prob,
+                conjunctionTime=tca,
+                createdAt=datetime.datetime.utcnow(),
+                object_a_id=sat.space_object_id,
+                object_b_id=deb.space_object_id,
+                probability=prob,
+                tca=tca,
+                miss_distance_m=miss_distance,
+                relative_velocity_kms=random.uniform(8.0, 15.0),
+                risk_level=risk_level,
+                status="PENDING",
+                created_at=datetime.datetime.utcnow()
+            )
+            db.add(conj)
+            conjunctions_count += 1
+            
+        db.commit()
+        print(f"   + Seeded {conjunctions_count} collision conjunction alerts.")
+
+        print("\n🎉 Database Seeding Completed Successfully!")
+        print(f"   - Seeded {len(seeded_orgs)} Organizations")
+        print(f"   - Seeded {len(satellites_list)} Satellites")
+        print(f"   - Seeded {telemetry_count} Telemetry Records")
+        print(f"   - Seeded {len(debris_list)} Debris Records")
+        print(f"   - Seeded {conjunctions_count} Conjunction Predictions")
+
+    except Exception as e:
+        print(f"❌ Error during database seeding: {e}")
+        raise e
+    finally:
+        if db:
+            db.close()
 
 
 def main():
@@ -424,7 +443,11 @@ def main():
         print("❌ Error: Count must be a positive integer.")
         sys.exit(1)
 
-    seed_database(count=args.count, clear=args.clear)
+    try:
+        seed_database(count=args.count, clear=args.clear)
+    except Exception as e:
+        print(f"❌ Seeding process failed: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/seed_db.py
+++ b/backend/scripts/seed_db.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python
+"""
+Kepler Database Seeding Script
+===============================
+Populates the MongoDB database with realistic sample satellite, organization,
+telemetry, and conjunction records for local development and testing.
+"""
+
+import os
+import sys
+import argparse
+import random
+import datetime
+import math
+
+# Add backend directory to system path to resolve imports correctly
+current_dir = os.path.dirname(os.path.abspath(__file__))
+backend_dir = os.path.dirname(current_dir)
+if backend_dir not in sys.path:
+    sys.path.insert(0, backend_dir)
+
+from app.core.config import settings
+from database.session import SessionLocal, get_mongo_client, uri_db_name
+from models.db_models import (
+    Satellite,
+    Debris,
+    SpaceObject,
+    Organization,
+    Telemetry,
+    CollisionPrediction,
+    Role,
+    User
+)
+
+# Realistic satellite names by country
+SATELLITE_NAMES = {
+    "US": ["GPS", "IRIDIUM", "STARLINK", "LANDSAT", "NOAA", "AURA", "TERRA", "GOES", "AEOLUS"],
+    "IN": ["CARTOSAT", "RESOURCESAT", "INSAT", "RISAT", "GSAT", "EOS", "OCEANSAT", "MOM"],
+    "CN": ["YAOGAN", "BEIDOU", "SHIYAN", "FENGYUN", "GAOFEN", "TIANHUI", "QUEQIAO"],
+    "RU": ["COSMOS", "GLONASS", "SOYUZ", "METEOR", "RESURS", "ELEKTRO", "LUCH"],
+    "ESA": ["SENTINEL", "METEOSAT", "ENVISAT", "CRYOSAT", "PROBA", "SOLAR-ORBITER"],
+    "JP": ["ALOS", "HIMAWARI", "GCOM", "ASNARO", "QZSS", "IBUKI", "ARASE"],
+    "CA": ["RADARSAT", "CASSIOPE", "SCISAT", "M3MSAT"],
+}
+
+DEBRIS_NAMES = [
+    "FENGYUN 1C DEBRIS",
+    "COSMOS 2251 DEBRIS",
+    "IRIDIUM 33 DEBRIS",
+    "DELTA 2 ROCKET BODY DEBRIS",
+    "TITAN 3C DEBRIS",
+    "CZ-4B DEBRIS",
+    "PEASASAT DEBRIS",
+    "SL-8 ROCKET BODY DEBRIS",
+    "ASAT TEST DEBRIS",
+    "SPUTNIK DEBRIS",
+]
+
+
+def calculate_semimajor_axis(mean_motion_revday: float) -> float:
+    """Convert mean motion (rev/day) to semi-major axis (km)."""
+    if mean_motion_revday <= 0:
+        return 6778.0
+    n_rads = mean_motion_revday * 2 * math.pi / 86400.0
+    return (398600.4418 / (n_rads ** 2)) ** (1.0 / 3.0)
+
+
+def generate_tle(norad_id: str, incl: float, ecc: float, mean_motion: float) -> tuple[str, str]:
+    """Generate mock TLE lines with valid checksums for a given satellite profile."""
+    nid = str(norad_id).zfill(5)
+    
+    # Generate international designator (COSPAR ID)
+    year = str(random.randint(15, 26))
+    launch_num = str(random.randint(1, 99)).zfill(3)
+    piece = random.choice(["A", "B", "C", "D"])
+    cospar = f"{year}{launch_num}{piece}"
+    
+    # Generate epoch day
+    epoch_day = f"{random.randint(1, 365):03d}.{random.randint(10000000, 99999999)}"
+    
+    def calculate_checksum(line: str) -> int:
+        c = 0
+        for char in line[:68]:
+            if char.isdigit():
+                c += int(char)
+            elif char == "-":
+                c += 1
+        return c % 10
+
+    # Line 1 format
+    line1 = f"1 {nid}U {cospar:<8} {year}{epoch_day:>12}  .00002182  00000-0  10000-3 0  999"
+    line1 = line1[:68].ljust(68)
+    line1 = f"{line1}{calculate_checksum(line1)}"
+    
+    # Line 2 format
+    raan = random.uniform(0, 360)
+    arg_p = random.uniform(0, 360)
+    mean_anomaly = random.uniform(0, 360)
+    ecc_str = f"{int(ecc * 10000000):07d}"[:7]
+    rev_num = random.randint(1000, 99999)
+    
+    line2 = f"2 {nid} {incl:8.4f} {raan:8.4f} {ecc_str} {arg_p:8.4f} {mean_anomaly:8.4f} {mean_motion:11.8f}{rev_num:5d}"
+    line2 = line2[:68].ljust(68)
+    line2 = f"{line2}{calculate_checksum(line2)}"
+    
+    return line1, line2
+
+
+def seed_database(count: int, clear: bool):
+    """Seed the database with organizations, satellites, debris, telemetry, and conjunctions."""
+    print("🔌 Connecting to MongoDB...")
+    try:
+        db = SessionLocal()
+        client = get_mongo_client()
+        db_name = uri_db_name(settings.MONGODB_URI)
+        mongo_db = client[db_name]
+        print(f"✅ Successfully connected to MongoDB database: '{db_name}'")
+    except Exception as e:
+        print(f"❌ Error connecting to database: {e}")
+        sys.exit(1)
+
+    if clear:
+        print("🧹 Clearing existing database collections...")
+        collections_to_clear = [
+            "satellites",
+            "debris",
+            "orbitalElements",
+            "telemetry",
+            "conjunctions",
+            "organizations"
+        ]
+        for col_name in collections_to_clear:
+            mongo_db[col_name].delete_many({})
+            # Reset counters
+            mongo_db["counters"].delete_one({"_id": col_name})
+            print(f"   - Cleared collection '{col_name}' and its auto-increment counters")
+
+    # 1. Seed Organizations
+    print("🏢 Seeding default organizations...")
+    orgs_to_create = [
+        {"name": "NASA", "description": "National Aeronautics and Space Administration"},
+        {"name": "ISRO", "description": "Indian Space Research Organisation"},
+        {"name": "ESA", "description": "European Space Agency"},
+        {"name": "SpaceX", "description": "Space Exploration Technologies Corp."},
+        {"name": "OneWeb", "description": "Eutelsat OneWeb Satellite Network"},
+    ]
+    
+    seeded_orgs = []
+    for org_data in orgs_to_create:
+        # Check if already exists
+        existing = db.query(Organization).filter(Organization.name == org_data["name"]).first()
+        if not existing:
+            org = Organization(
+                name=org_data["name"],
+                description=org_data["description"],
+                created_at=datetime.datetime.utcnow().isoformat()
+            )
+            db.add(org)
+            db.commit()
+            db.refresh(org)
+            seeded_orgs.append(org)
+            print(f"   + Created organization: {org.name} (ID: {org.id})")
+        else:
+            seeded_orgs.append(existing)
+            print(f"   • Organization {existing.name} already exists (ID: {existing.id})")
+
+    # Helper list of generated norad IDs to ensure uniqueness
+    used_norad_ids = set()
+
+    # 2. Seed Satellites
+    print(f"🛰️ Generating {count} satellite records...")
+    satellites_list = []
+    for i in range(count):
+        # Choose country and name
+        country = random.choice(list(SATELLITE_NAMES.keys()))
+        prefix = random.choice(SATELLITE_NAMES[country])
+        suffix = f"-{random.randint(100, 999)}" if prefix in ["STARLINK", "SENTINEL", "YAOGAN"] else f" {random.randint(1, 20)}"
+        name = f"{prefix}{suffix}"
+        
+        # Unique NORAD ID
+        norad_id = str(random.randint(10000, 49999))
+        while norad_id in used_norad_ids:
+            norad_id = str(random.randint(10000, 49999))
+        used_norad_ids.add(norad_id)
+
+        # Orbital elements
+        inclination = random.uniform(50.0, 105.0)  # Common LEO inclinations
+        eccentricity = random.uniform(0.0001, 0.01) # Near circular LEO orbits
+        mean_motion = random.uniform(14.0, 16.2)    # 14 to 16.2 orbits per day
+        semimajor = calculate_semimajor_axis(mean_motion)
+        period = 1440.0 / mean_motion
+        epoch = datetime.datetime.utcnow() - datetime.timedelta(days=random.uniform(0, 5))
+        launch_date = (datetime.date.today() - datetime.timedelta(days=random.randint(100, 5000))).isoformat()
+        
+        tle1, tle2 = generate_tle(norad_id, inclination, eccentricity, mean_motion)
+        
+        # Link to a random organization
+        org = random.choice(seeded_orgs)
+
+        # Create SpaceObject first to replicate ORM relationship correctly
+        space_obj = SpaceObject(
+            noradId=norad_id,
+            objectName=name,
+            objectType="PAYLOAD",
+            cospar_id=f"{random.randint(2010, 2026)}-{random.randint(1, 100):03d}{random.choice(['A', 'B', 'C'])}",
+            epoch=epoch.isoformat(),
+            inclination=inclination,
+            eccentricity=eccentricity,
+            semimajor_axis=semimajor,
+            period=period,
+            mean_motion=mean_motion,
+            tle_line1=tle1,
+            tle_line2=tle2,
+            updated_at=datetime.datetime.utcnow().isoformat()
+        )
+        db.add(space_obj)
+        db.commit()
+        db.refresh(space_obj)
+
+        # Now create Satellite linked to SpaceObject and Organization
+        sat = Satellite(
+            noradId=norad_id,
+            objectName=name,
+            objectType="PAYLOAD",
+            countryCode=country,
+            launchDate=launch_date,
+            epoch=epoch.isoformat(),
+            inclination=inclination,
+            eccentricity=eccentricity,
+            meanMotion=mean_motion,
+            source="seed_script",
+            createdAt=datetime.datetime.utcnow().isoformat(),
+            updatedAt=datetime.datetime.utcnow().isoformat(),
+            space_object_id=space_obj.id,
+            organization_id=org.id,
+            status=random.choice(["ACTIVE", "ACTIVE", "ACTIVE", "DEGRADED", "INACTIVE"]),
+            fuel_percentage=random.uniform(15.0, 100.0),
+            dry_mass=random.uniform(150.0, 1800.0),
+            propellant_mass=random.uniform(20.0, 800.0),
+            operational_mode=random.choice(["NORMAL", "NORMAL", "NORMAL", "SAFE", "STANDBY"]),
+            semimajor_axis=semimajor,
+            period=period,
+            tle_line1=tle1,
+            tle_line2=tle2
+        )
+        db.add(sat)
+        db.commit()
+        db.refresh(sat)
+        satellites_list.append(sat)
+
+    print(f"   + Seeded {len(satellites_list)} satellite and space object records.")
+
+    # 3. Seed Telemetry
+    print("📈 Seeding telemetry log history for satellites...")
+    telemetry_count = 0
+    for sat in satellites_list:
+        # Generate 5 telemetry points over the last 50 minutes for each active satellite
+        if sat.status in ["ACTIVE", "DEGRADED"]:
+            base_altitude = sat.semimajor_axis - 6378.1  # Semi-major axis minus Earth radius
+            base_velocity = 7.5  # Typical LEO velocity in km/s
+            
+            for j in range(5):
+                ts = datetime.datetime.utcnow() - datetime.timedelta(minutes=10 * j)
+                tel = Telemetry(
+                    satellite_id=str(sat.id),
+                    timestamp=ts,
+                    altitude_km=base_altitude + random.uniform(-2.0, 2.0),
+                    velocity_kms=base_velocity + random.uniform(-0.1, 0.1),
+                    temperature_c=random.uniform(-5.0, 35.0),
+                    battery_charge=max(0.0, min(100.0, sat.fuel_percentage + random.uniform(-5.0, 5.0))),
+                    neural_load=random.uniform(10.0, 90.0)
+                )
+                db.add(tel)
+                telemetry_count += 1
+            db.commit()
+    print(f"   + Seeded {telemetry_count} telemetry data points.")
+
+    # 4. Seed Debris
+    debris_count = max(5, count // 2)
+    print(f"☄️ Generating {debris_count} space debris records...")
+    debris_list = []
+    for i in range(debris_count):
+        # Choose debris name
+        base_name = random.choice(DEBRIS_NAMES)
+        name = f"{base_name} [#{random.randint(1000, 9999)}]"
+        
+        # Unique NORAD ID
+        norad_id = str(random.randint(50000, 89999))
+        while norad_id in used_norad_ids:
+            norad_id = str(random.randint(50000, 89999))
+        used_norad_ids.add(norad_id)
+
+        inclination = random.uniform(50.0, 110.0)
+        eccentricity = random.uniform(0.0005, 0.05)
+        mean_motion = random.uniform(13.5, 16.5)
+        semimajor = calculate_semimajor_axis(mean_motion)
+        period = 1440.0 / mean_motion
+        epoch = datetime.datetime.utcnow() - datetime.timedelta(days=random.uniform(0, 10))
+        
+        tle1, tle2 = generate_tle(norad_id, inclination, eccentricity, mean_motion)
+
+        # Create SpaceObject for Debris
+        space_obj = SpaceObject(
+            noradId=norad_id,
+            objectName=name,
+            objectType="DEBRIS",
+            cospar_id=None,
+            epoch=epoch.isoformat(),
+            inclination=inclination,
+            eccentricity=eccentricity,
+            semimajor_axis=semimajor,
+            period=period,
+            mean_motion=mean_motion,
+            tle_line1=tle1,
+            tle_line2=tle2,
+            updated_at=datetime.datetime.utcnow().isoformat()
+        )
+        db.add(space_obj)
+        db.commit()
+        db.refresh(space_obj)
+
+        # Create Debris record linked to SpaceObject
+        deb = Debris(
+            noradId=norad_id,
+            objectName=name,
+            epoch=epoch.isoformat(),
+            inclination=inclination,
+            eccentricity=eccentricity,
+            meanMotion=mean_motion,
+            source="seed_script",
+            createdAt=datetime.datetime.utcnow().isoformat(),
+            space_object_id=space_obj.id,
+            size_category=random.choice(["SMALL", "MEDIUM", "LARGE"]),
+            radar_cross_section=random.uniform(0.01, 15.0),
+            average_mass=random.uniform(0.5, 200.0),
+            semimajor_axis=semimajor,
+            period=period,
+            tle_line1=tle1,
+            tle_line2=tle2
+        )
+        db.add(deb)
+        db.commit()
+        db.refresh(deb)
+        debris_list.append(deb)
+        
+    print(f"   + Seeded {len(debris_list)} space debris records.")
+
+    # 5. Seed Conjunctions (Collisions)
+    print("💥 Seeding sample orbital conjunctions (collisions)...")
+    conjunctions_count = 0
+    # Create up to 5 conjunction events between seeded satellites and debris
+    num_conjunctions = min(5, len(satellites_list), len(debris_list))
+    
+    for i in range(num_conjunctions):
+        sat = satellites_list[i]
+        deb = debris_list[i]
+        
+        miss_distance = random.uniform(10.0, 800.0)
+        prob = random.uniform(0.001, 0.45)
+        # Determine risk level based on miss distance & probability
+        if miss_distance < 50.0 or prob > 0.1:
+            risk_level = "CRITICAL"
+        elif miss_distance < 150.0 or prob > 0.01:
+            risk_level = "HIGH"
+        elif miss_distance < 500.0 or prob > 0.001:
+            risk_level = "MEDIUM"
+        else:
+            risk_level = "LOW"
+            
+        tca = datetime.datetime.utcnow() + datetime.timedelta(hours=random.uniform(4, 72))
+        
+        conj = CollisionPrediction(
+            primaryObject=sat.noradId,
+            secondaryObject=deb.noradId,
+            missDistance=miss_distance,
+            riskScore=prob,
+            conjunctionTime=tca,
+            createdAt=datetime.datetime.utcnow(),
+            object_a_id=sat.space_object_id,
+            object_b_id=deb.space_object_id,
+            probability=prob,
+            tca=tca,
+            miss_distance_m=miss_distance,
+            relative_velocity_kms=random.uniform(8.0, 15.0),
+            risk_level=risk_level,
+            status="PENDING",
+            created_at=datetime.datetime.utcnow()
+        )
+        db.add(conj)
+        conjunctions_count += 1
+        
+    db.commit()
+    print(f"   + Seeded {conjunctions_count} collision conjunction alerts.")
+
+    print("\n🎉 Database Seeding Completed Successfully!")
+    print(f"   - Seeded {len(seeded_orgs)} Organizations")
+    print(f"   - Seeded {len(satellites_list)} Satellites")
+    print(f"   - Seeded {telemetry_count} Telemetry Records")
+    print(f"   - Seeded {len(debris_list)} Debris Records")
+    print(f"   - Seeded {conjunctions_count} Conjunction Predictions")
+    
+    db.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Seed Kepler MongoDB database with sample satellite, organization, and collision data."
+    )
+    parser.add_argument(
+        "--count", "-c",
+        type=int,
+        default=50,
+        help="Number of satellites to generate (default: 50)"
+    )
+    parser.add_argument(
+        "--clear", "-x",
+        action="store_true",
+        help="Clear existing satellite, debris, telemetry, and conjunction records before seeding"
+    )
+    args = parser.parse_args()
+
+    # Validate count
+    if args.count <= 0:
+        print("❌ Error: Count must be a positive integer.")
+        sys.exit(1)
+
+    seed_database(count=args.count, clear=args.clear)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -22,6 +22,9 @@ class FakeCollection:
     def delete_one(self, filter_dict):
         pass
 
+    def find(self, filter_dict=None, projection=None):
+        return self.docs
+
 
 class FakeDb:
     def __init__(self):
@@ -135,3 +138,23 @@ def test_seed_database_execution(mock_session_local, mock_mongo_client):
     
     # Conjunctions seeded: min(5, len(satellites), len(debris)) = min(5, 10, 5) = 5
     assert len(fake_db["conjunctions"].docs) == 5
+
+
+@patch("scripts.seed_db.get_mongo_client")
+@patch("scripts.seed_db.SessionLocal")
+def test_seed_database_no_clear(mock_session_local, mock_mongo_client):
+    fake_db = FakeDb()
+    mock_mongo_client.return_value = fake_db.client
+    
+    # Pre-populate some existing IDs in the collection
+    fake_db["satellites"].docs = [{"noradId": "12345"}, {"noradId": "67890"}]
+    fake_db["debris"].docs = [{"noradId": "11111"}]
+    
+    fake_session = FakeSession(fake_db)
+    mock_session_local.return_value = fake_session
+    
+    # Run seed script without clear
+    seed_database(count=5, clear=False)
+    
+    # Assert it completed without crash and new unique IDs are generated
+    assert len(fake_db["satellites"].docs) > 2

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -132,8 +132,11 @@ def test_seed_database_execution(mock_session_local, mock_mongo_client):
     assert len(fake_db["orbitalElements"].docs) == 15
     
     # Telemetry should be created for each active/degraded satellite
-    # Since status can be ACTIVE, DEGRADED or INACTIVE, let's verify telemetry is seeded
-    assert len(fake_db["telemetry"].docs) > 0
+    eligible = sum(
+        doc["status"] in {"ACTIVE", "DEGRADED"}
+        for doc in fake_db["satellites"].docs
+    )
+    assert len(fake_db["telemetry"].docs) == eligible * 5
     # Telemetry count should be 5 * active/degraded satellites
     
     # Conjunctions seeded: min(5, len(satellites), len(debris)) = min(5, 10, 5) = 5

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,0 +1,137 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import datetime
+
+from scripts.seed_db import seed_database, calculate_semimajor_axis, generate_tle
+
+
+class FakeCollection:
+    def __init__(self):
+        self.docs = []
+
+    def delete_many(self, filter_dict):
+        self.docs = []
+
+    def insert_one(self, doc):
+        self.docs.append(doc)
+
+    def find_one_and_update(self, filter, update, **kwargs):
+        # Mock counter generator
+        return {"seq": len(self.docs) + 1}
+
+    def delete_one(self, filter_dict):
+        pass
+
+
+class FakeDb:
+    def __init__(self):
+        self.collections = {
+            "satellites": FakeCollection(),
+            "debris": FakeCollection(),
+            "orbitalElements": FakeCollection(),
+            "telemetry": FakeCollection(),
+            "conjunctions": FakeCollection(),
+            "organizations": FakeCollection(),
+            "counters": FakeCollection(),
+        }
+        self.db = self.collections
+        self.client = MagicMock()
+        self.client.admin.command.return_value = {"ok": 1}
+
+    def __getitem__(self, name):
+        return self.collections[name]
+
+
+class FakeSession:
+    def __init__(self, fake_db):
+        self.db = fake_db
+        self.pending_adds = []
+
+    def query(self, model_class):
+        # Simple mock query object
+        query_mock = MagicMock()
+        query_mock.filter.return_value.first.return_value = None
+        query_mock.first.return_value = None
+        return query_mock
+
+    def add(self, obj):
+        obj._session = self
+        self.pending_adds.append(obj)
+
+    def commit(self):
+        for obj in self.pending_adds:
+            col_name = obj.__tablename__
+            doc = obj._to_dict()
+            if obj.id is None:
+                # generate mock ID
+                new_id = len(self.db.collections[col_name].docs) + 1
+                obj.id = new_id
+                doc["id"] = new_id
+                doc["_id"] = new_id
+            self.db.collections[col_name].insert_one(doc)
+        self.pending_adds = []
+
+    def refresh(self, obj):
+        if obj.id is None:
+            obj.id = 1
+
+    def close(self):
+        pass
+
+
+def test_calculate_semimajor_axis():
+    # Mean motion 0 or negative
+    assert calculate_semimajor_axis(0) == 6778.0
+    assert calculate_semimajor_axis(-1) == 6778.0
+    
+    # Typical LEO mean motion
+    axis = calculate_semimajor_axis(15.5)
+    assert 6500.0 < axis < 7500.0
+
+
+def test_generate_tle():
+    line1, line2 = generate_tle("25544", 51.64, 0.001, 15.5)
+    
+    # Check lines format
+    assert line1.startswith("1 25544U")
+    assert line2.startswith("2 25544")
+    
+    # Check length (must be 69 characters including checksum)
+    assert len(line1) == 69
+    assert len(line2) == 69
+    
+    # Check standard checksum digit
+    assert line1[-1].isdigit()
+    assert line2[-1].isdigit()
+
+
+@patch("scripts.seed_db.get_mongo_client")
+@patch("scripts.seed_db.SessionLocal")
+def test_seed_database_execution(mock_session_local, mock_mongo_client):
+    fake_db = FakeDb()
+    mock_mongo_client.return_value = fake_db.client
+    
+    fake_session = FakeSession(fake_db)
+    mock_session_local.return_value = fake_session
+    
+    # Run seed script for 10 satellites
+    # This will clear collections and populate them
+    seed_database(count=10, clear=True)
+    
+    # Verify collections size
+    # 5 organizations created
+    assert len(fake_db["organizations"].docs) == 5
+    # 10 satellites and 10 space objects (satellites) created
+    assert len(fake_db["satellites"].docs) == 10
+    # count // 2 debris = 5 debris created. 
+    # Total space objects in orbitalElements = 10 satellites + 5 debris = 15
+    assert len(fake_db["debris"].docs) == 5
+    assert len(fake_db["orbitalElements"].docs) == 15
+    
+    # Telemetry should be created for each active/degraded satellite
+    # Since status can be ACTIVE, DEGRADED or INACTIVE, let's verify telemetry is seeded
+    assert len(fake_db["telemetry"].docs) > 0
+    # Telemetry count should be 5 * active/degraded satellites
+    
+    # Conjunctions seeded: min(5, len(satellites), len(debris)) = min(5, 10, 5) = 5
+    assert len(fake_db["conjunctions"].docs) == 5


### PR DESCRIPTION
## **User description**
## Description
Created a standalone database seed script (`seed_db.py`) to generate realistic and randomized satellite, space debris, telemetry logs, and conjunction predictions in MongoDB. Added comprehensive unit tests and documented setup instructions in the README.

## Related Issue
Fixes #31

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [x] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings
(N/A)

## Breaking Changes
None

---

## ECSoC26 Submission
- [ ] `ECSoC26-L1` – Beginner
- [x] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

___

## **CodeAnt-AI Description**
**Add a database seed script for realistic satellite sample data**

### What Changed
- Added a script to populate MongoDB with sample organizations, satellites, space debris, telemetry, and collision alerts for local development and demos
- Added options to control how many satellites are created and to clear existing seeded records before running
- Added tests for the orbit math, TLE generation, and a full seed run
- Documented how to run the seeding script and configure the database connection

### Impact
`✅ Faster local setup`
`✅ Easier demo data generation`
`✅ Fewer manual test records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a database seeding tool that populates local MongoDB with sample satellites, telemetry, debris, and collision predictions.
  * Added options to control the number of records and clear existing data before seeding.
  * Added support for configuring the MongoDB connection through `MONGODB_URI`.

* **Documentation**
  * Added Getting Started instructions covering database seeding and available command options.

* **Tests**
  * Added automated coverage for generated orbital data, TLE records, and seeded database contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a standalone database seed script (`backend/scripts/seed_db.py`) that populates MongoDB with sample organizations, satellites, space debris, telemetry logs, and conjunction predictions for local development. It also adds unit tests and a README section documenting CLI options and environment variable configuration.

- **Seed script**: creates SpaceObject + model records for each satellite and debris item, seeds telemetry for active/degraded satellites, and generates up to 5 conjunction events with risk classification.
- **Tests**: cover `calculate_semimajor_axis`, `generate_tle`, a full seeded run, and a no-clear incremental run — but the no-clear test's `mongo_db` is a disconnected `MagicMock`, so the NORAD deduplication path it is supposed to exercise is never reached.
- **Unfixed from prior review**: `satellite_id=str(sat.id)` stores a string FK in telemetry while the ORM layer indexes by integer `id`, causing every `telemetry→satellite` relationship lookup to silently return `None`.

<h3>Confidence Score: 3/5</h3>

Not ready to merge — the telemetry satellite foreign key is stored as a string while the ORM resolves it as an integer, silently breaking every telemetry relationship lookup.

The satellite_id type mismatch is still present in the diff and silently breaks every telemetry-to-satellite relationship lookup produced by this script. Combined with the --clear user orphaning issue also still present, this script needs another pass before the seeded data is reliable.

backend/scripts/seed_db.py — the telemetry seeding block at line 226 still stores satellite_id as str(sat.id); this needs to be corrected to sat.id (integer) before the script produces usable linked data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| backend/scripts/seed_db.py | Seed script with logic bugs: satellite_id stored as string (unfixed from previous review), risk_level "LOW" dead code, and partially-effective NORAD deduplication. |
| backend/tests/test_seed.py | Tests have a structural gap: mongo_db used for pre-loading existing NORAD IDs is a disconnected MagicMock, not FakeDb, so test_seed_database_no_clear doesn't actually validate deduplication. |
| README.md | Adds a "Database Seeding" section with clear usage instructions, CLI options, and environment variable documentation. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[seed_database called] --> B{--clear flag?}
    B -- Yes --> C[Drop satellites, debris, orbitalElements,\ntelemetry, conjunctions, organizations\n+ reset counters]
    B -- No --> D[Pre-load existing NORAD IDs\nfrom satellites + debris collections]
    C --> E[Seed 5 Organizations\ncheck for existing by name]
    D --> E
    E --> F[Generate N Satellites\nSpaceObject + Satellite per record\nunique NORAD ID 10000-49999]
    F --> G[Seed Telemetry\n5 points per ACTIVE/DEGRADED satellite]
    G --> H[Generate N/2 Debris\nSpaceObject + Debris per record\nunique NORAD ID 50000-89999]
    H --> I[Seed Conjunctions\nmin-5 satellite-debris pairs\nrisk level based on miss_distance + prob]
    I --> J[db.commit + db.close]
    J --> K[Print summary]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[seed_database called] --> B{--clear flag?}
    B -- Yes --> C[Drop satellites, debris, orbitalElements,\ntelemetry, conjunctions, organizations\n+ reset counters]
    B -- No --> D[Pre-load existing NORAD IDs\nfrom satellites + debris collections]
    C --> E[Seed 5 Organizations\ncheck for existing by name]
    D --> E
    E --> F[Generate N Satellites\nSpaceObject + Satellite per record\nunique NORAD ID 10000-49999]
    F --> G[Seed Telemetry\n5 points per ACTIVE/DEGRADED satellite]
    G --> H[Generate N/2 Debris\nSpaceObject + Debris per record\nunique NORAD ID 50000-89999]
    H --> I[Seed Conjunctions\nmin-5 satellite-debris pairs\nrisk level based on miss_distance + prob]
    I --> J[db.commit + db.close]
    J --> K[Print summary]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["test: apply CodeRabbit suggestion for ex..."](https://github.com/7-blocks/kepler/commit/7644544b6e7d2bee23649de434341a97e4fb8a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44755497)</sub>

<!-- /greptile_comment -->