### PR TITLE
Fix TypeScript to recognize global variables (#45)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^24.12.3",
+        "@types/node": "^24.13.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -2094,9 +2094,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^24.12.3",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -4,14 +4,13 @@
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "module": "esnext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "node"],
     "skipLibCheck": true,
     "baseUrl": ".",
     "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"]
     },
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Description

TypeScript to recognize Node.js global variables

## Related Issue

Fixes #45 

## Checklist

- [X] I have read the contributing guidelines
- [X] My code follows the project guidelines
- [X] I have completed testing of my changes
- [X] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings

<!-- If applicable, add screenshots to help explain your changes -->

## Breaking Changes

No Breaking Changes

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [ ] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js type definitions used during development.
  * Improved TypeScript support for Node.js-specific types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@types/node` from `^24.12.3` to `^24.13.3` and adds `"node"` to the `types` array in `tsconfig.app.json` to expose Node.js globals to the browser application's TypeScript compilation.

- `tsconfig.node.json` already declares `"types": ["node"]` and includes `vite.config.ts`, which is the correct place for Node.js globals used by the build tooling (`__dirname`, `path`).
- Adding `"node"` to `tsconfig.app.json` overlays Node.js type declarations onto browser code, creating a known conflict between the `DOM` lib's `setTimeout` (returns `number`) and `@types/node`'s `setTimeout` (returns `NodeJS.Timeout`), which can break component code that holds timer IDs as `number`.
- The `@types/node` patch version bump in `package.json` and `package-lock.json` is unproblematic.

<h3>Confidence Score: 3/5</h3>

The tsconfig.app.json change places Node.js types into the browser app compilation, which conflicts with DOM types and should be reverted; the @types/node version bump is safe.

The core change — adding "node" to tsconfig.app.json — is the wrong fix for the underlying issue. Node.js types are already correctly scoped to build tooling via tsconfig.node.json. Introducing them into the browser app config creates a real type conflict on setTimeout/setInterval return types (DOM says number, Node.js says NodeJS.Timeout) that will surface as compilation errors in any component that stores a timer ID. The @types/node bump is routine and fine on its own.

frontend/tsconfig.app.json requires attention — the "node" entry in types should be removed. frontend/tsconfig.node.json already contains the correct Node.js types setup and does not need changes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/tsconfig.app.json | Adds "node" to types array in the browser app tsconfig; Node.js types are already present in tsconfig.node.json for build tooling, and adding them here introduces a DOM/Node.js global type conflict (e.g., setTimeout return type) |
| frontend/package.json | Minor patch bump of @types/node from ^24.12.3 to ^24.13.3 — routine update, no issues |
| frontend/package-lock.json | Lock file updated to reflect @types/node version bump from 24.13.1 to 24.13.3 — consistent with package.json change |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tsconfig.json\nroot references] --> B[tsconfig.app.json\nsrc/ browser code]
    A --> C[tsconfig.node.json\nvite.config.ts]

    B --> D["lib: [ES2023, DOM]\ntypes: [vite/client, node] ← NEW"]
    C --> E["types: [node] ← already existed"]

    D --> F["DOM globals: setTimeout → number\nNode globals: setTimeout → NodeJS.Timeout\n⚠️ Type conflict"]
    E --> G["Node globals: __dirname, path\n✅ Correct placement"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tsconfig.json\nroot references] --> B[tsconfig.app.json\nsrc/ browser code]
    A --> C[tsconfig.node.json\nvite.config.ts]

    B --> D["lib: [ES2023, DOM]\ntypes: [vite/client, node] ← NEW"]
    C --> E["types: [node] ← already existed"]

    D --> F["DOM globals: setTimeout → number\nNode globals: setTimeout → NodeJS.Timeout\n⚠️ Type conflict"]
    E --> G["Node globals: __dirname, path\n✅ Correct placement"]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/tsconfig.app.json:7
**Node types added to the wrong tsconfig**

`tsconfig.node.json` already includes `"types": ["node"]` and is the correct place for Node.js globals — it covers `vite.config.ts` where `__dirname` and `path` are used. Adding `"node"` here (the browser app config) makes all Node.js globals available in `src/` code, so TypeScript will not warn if a developer accidentally uses `Buffer`, `__dirname`, or `process.env` directly in browser components that have no runtime access to them. More concretely, mixing `DOM` lib (which types `setTimeout` as returning `number`) with `@types/node` (which types it as returning `NodeJS.Timeout`) creates an overload conflict — code like `const id: number = setTimeout(...)` will fail to compile in components.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["nodeJS types fixed"](https://github.com/7-blocks/kepler/commit/c2d2dab9f9c29b9192263d30faa4c34b7038287c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44781589)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->