### PR TITLE
Fixed broken packages file, Added Class consistency and consistent tr… (#56)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "^12.40.0",
         "gsap": "^3.15.0",
         "lucide-react": "^1.17.0",
+        "motion": "^12.42.2",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.77.0",
@@ -4514,6 +4515,30 @@
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
       "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^12.40.0",
     "gsap": "^3.15.0",
     "lucide-react": "^1.17.0",
+    "motion": "^12.42.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.77.0",

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -488,7 +488,7 @@ export const EarthTwin: React.FC = () => {
             <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
             </>
           ) }
-            <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block transition-opacity duration-500 ${dataLoaded ? 'opacity-100' : 'opacity-0'}`}>
+            <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block transition-ui ${dataLoaded ? 'opacity-100' : 'opacity-0'}`}>
               WEATHER: {stats.weatherIndex} · DATA SOURCE: SPACE-TRACK / NASA DONKI
             </p>
 
@@ -529,7 +529,7 @@ export const EarthTwin: React.FC = () => {
           <div className="flex gap-1.5 md:gap-2 pointer-events-auto">
             <button
               onClick={() => setShowLegend(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-all active:scale-95 cursor-pointer border ${
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
                 showLegend ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
               }`}
             >
@@ -537,7 +537,7 @@ export const EarthTwin: React.FC = () => {
             </button>
             <button
               onClick={() => setShowDensity(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-all active:scale-95 cursor-pointer border ${
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
                 showDensity ? 'bg-status-warning text-bg-deep-space border-status-warning' : 'border-status-warning/50 text-status-warning hover:bg-status-warning/10'
               }`}
             >
@@ -545,7 +545,7 @@ export const EarthTwin: React.FC = () => {
             </button>
             <button
               onClick={() => setShowRiskOverlay(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-all active:scale-95 cursor-pointer border ${
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
                 showRiskOverlay ? 'bg-status-emergency text-white border-status-emergency' : 'border-status-emergency/50 text-status-emergency hover:bg-status-emergency/10'
               }`}
             >

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import { Particles } from "@/components/ui/particles";
 import { Globe } from "@/components/ui/globe";
 import { OrbitSatellites } from "@/components/ui/OrbitSatellites";
 import { ShimmerButton } from "@/components/ui/shimmer-button";
+import { Link } from "react-router-dom";
 
 const TELEMETRY = [
   { label: "OBJECTS TRACKED", value: "34,900+" },
@@ -81,12 +82,14 @@ export function Hero() {
             variants={fadeUp}
             className="mt-8 flex flex-wrap items-center gap-4"
           >
-            <ShimmerButton shimmerColor="#4CDfF0">
-              <span className="inline-flex items-center gap-2">
-                Continue to dashboard
-                <ArrowRight size={15} />
-              </span>
-            </ShimmerButton>
+            <Link to="/dashboard">
+              <ShimmerButton shimmerColor="#4CDfF0">
+                <span className="inline-flex items-center gap-2">
+                  Continue to dashboard
+                  <ArrowRight size={15} />
+                </span>
+              </ShimmerButton>
+        </Link>
             <a
               href="https://github.com/7-Blocks/Kepler"
               target="_blank"

--- a/frontend/src/components/layouts/MainLayout.tsx
+++ b/frontend/src/components/layouts/MainLayout.tsx
@@ -91,7 +91,7 @@ export const MainLayout: React.FC = () => {
 
         {/* Left Navigation Sidebar */}
         <aside
-          className={`fixed inset-y-0 left-0 flex flex-col h-full bg-bg-deep-space border-r border-border-panel transition-all duration-300 z-50 md:relative ${
+          className={`fixed inset-y-0 left-0 flex flex-col h-full bg-bg-deep-space border-r border-border-panel transition-ui z-50 md:relative ${
             mobileSidebarOpen ? 'translate-x-0 w-64' : '-translate-x-full md:translate-x-0'
           } ${!mobileSidebarOpen && sidebarCollapsed ? 'md:w-20' : 'md:w-64'}`}
         >
@@ -115,7 +115,7 @@ export const MainLayout: React.FC = () => {
                   toggleSidebar();
                 }
               }}
-              className="p-1.5 rounded border border-border-panel hover:bg-surface-variant/50 transition-colors text-primary-container"
+              className="p-1.5 rounded border border-border-panel hover:bg-surface-variant/50 transition-ui text-primary-container"
             >
               <MaterialIcon name={!mobileSidebarOpen && sidebarCollapsed ? 'chevron_right' : 'chevron_left'} className="text-sm" />
             </button>
@@ -129,7 +129,7 @@ export const MainLayout: React.FC = () => {
                 to={item.path}
                 end={item.path === '/dashboard'}
                 className={({ isActive }) =>
-                  `flex items-center px-3 py-3 min-h-[44px] transition-all duration-200 group border-r-2 ${isActive
+                  `flex items-center px-3 py-3 min-h-[44px] transition-ui group border-r-2 ${isActive
                     ? 'text-primary-container bg-primary-fixed-dim/10 border-primary-container'
                     : 'text-on-surface-variant hover:text-primary hover:bg-surface-variant/40 border-transparent'
                   }`
@@ -137,11 +137,11 @@ export const MainLayout: React.FC = () => {
               >
                 <MaterialIcon
                   name={item.icon}
-                  className={`mr-4 transition-all ${location.pathname === item.path ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-on-surface-variant group-hover:text-primary'
+                  className={`mr-4 transition-ui ${location.pathname === item.path ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-on-surface-variant group-hover:text-primary'
                     }`}
                 />
                 {(mobileSidebarOpen || !sidebarCollapsed) && (
-                  <span className="font-technical-data text-technical-data font-medium transition-opacity duration-300">
+                  <span className="font-technical-data text-technical-data font-medium transition-ui">
                     {item.name}
                   </span>
                 )}
@@ -174,7 +174,7 @@ export const MainLayout: React.FC = () => {
             <div className="flex items-center gap-2 sm:gap-4 flex-1">
               <button
                 onClick={() => setMobileSidebarOpen(true)}
-                className="md:hidden p-1 text-primary hover:text-primary-container transition-colors cursor-pointer mr-2 shrink-0"
+                className="md:hidden p-1 text-primary hover:text-primary-container transition-ui cursor-pointer mr-2 shrink-0"
               >
                 <MaterialIcon name="menu" className="text-xl" />
               </button>
@@ -184,7 +184,7 @@ export const MainLayout: React.FC = () => {
                 <input
                   type="text"
                   placeholder="ID / TLE SEARCH"
-                  className="bg-surface-container-low w-full border-b border-primary/30 text-primary font-technical-data text-[12px] pl-8 pr-2 sm:pr-16 py-1 focus:outline-none focus:border-primary-container transition-all placeholder:text-primary/30"
+                  className="bg-surface-container-low w-full border-b border-primary/30 text-primary font-technical-data text-[12px] pl-8 pr-2 sm:pr-16 py-1 focus:outline-none focus:border-primary-container transition-ui placeholder:text-primary/30"
                 />
                 <span className="hidden sm:block absolute right-2 text-[9px] text-primary/40 font-mono">CMD+K</span>
               </div>
@@ -204,14 +204,14 @@ export const MainLayout: React.FC = () => {
               <div className="flex items-center gap-4">
                 <button
                   onClick={toggleRightDrawer}
-                  className={`transition-colors cursor-pointer p-2 min-w-[44px] min-h-[44px] flex items-center justify-center ${rightDrawerOpen ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-primary hover:text-primary-fixed'}`}
+                  className={`transition-ui cursor-pointer p-2 min-w-[44px] min-h-[44px] flex items-center justify-center ${rightDrawerOpen ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-primary hover:text-primary-fixed'}`}
                 >
                   <MaterialIcon name="monitor_heart" />
                 </button>
-                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-colors p-2 min-w-[44px] min-h-[44px] flex items-center justify-center">
+                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-ui p-2 min-w-[44px] min-h-[44px] flex items-center justify-center">
                   <MaterialIcon name="schedule" />
                 </button>
-                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-colors p-2 min-w-[44px] min-h-[44px] flex items-center justify-center">
+                <button className="text-primary hover:text-primary-fixed cursor-pointer transition-ui p-2 min-w-[44px] min-h-[44px] flex items-center justify-center">
                   <MaterialIcon name="account_circle" />
                 </button>
               </div>
@@ -246,7 +246,7 @@ export const MainLayout: React.FC = () => {
                     </div>
                     <button
                       onClick={toggleRightDrawer}
-                      className="text-on-surface-variant hover:text-primary transition-colors"
+                      className="text-on-surface-variant hover:text-primary transition-ui"
                     >
                       <MaterialIcon name="close" />
                     </button>
@@ -258,7 +258,7 @@ export const MainLayout: React.FC = () => {
                       <button
                         key={tab}
                         onClick={() => setActiveDrawerTab(tab)}
-                        className={`flex-1 py-3 text-[10px] font-label-caps font-bold transition-all flex flex-col items-center gap-1 border-b ${activeDrawerTab === tab
+                        className={`flex-1 py-3 text-[10px] font-label-caps font-bold transition-ui flex flex-col items-center gap-1 border-b ${activeDrawerTab === tab
                             ? 'text-primary-container border-primary-container'
                             : 'text-on-surface-variant hover:bg-surface-container-high/40 border-transparent'
                           }`}
@@ -288,10 +288,10 @@ export const MainLayout: React.FC = () => {
                             Orbital probability mapping is complete for sector 7G. New conjunction threat window detected in 4.2 hours.
                           </p>
                           <div className="mt-3 flex gap-2">
-                            <button className="bg-primary-container/20 border border-primary-container text-primary-container text-[10px] px-2.5 py-1 hover:bg-primary-container hover:text-bg-deep-space transition-all font-technical-data">
+                            <button className="bg-primary-container/20 border border-primary-container text-primary-container text-[10px] px-2.5 py-1 hover:bg-primary-container hover:text-bg-deep-space transition-ui font-technical-data">
                               DISMISS
                             </button>
-                            <button className="bg-primary-container text-bg-deep-space text-[10px] px-2.5 py-1 font-bold font-technical-data hover:bg-primary-fixed-dim transition-all">
+                            <button className="bg-primary-container text-bg-deep-space text-[10px] px-2.5 py-1 font-bold font-technical-data hover:bg-primary-fixed-dim transition-ui">
                               VIEW DETAILS
                             </button>
                           </div>
@@ -359,9 +359,9 @@ export const MainLayout: React.FC = () => {
                         value={assistantInput}
                         onChange={(e) => setAssistantInput(e.target.value)}
                         placeholder="ASK AI COMMAND..."
-                        className="w-full bg-surface-container-low border border-border-panel text-[11px] font-technical-data px-3 py-3 focus:outline-none focus:border-primary-container transition-all pr-10"
+                        className="w-full bg-surface-container-low border border-border-panel text-[11px] font-technical-data px-3 py-3 focus:outline-none focus:border-primary-container transition-ui pr-10"
                       />
-                      <button type="submit" className="absolute right-2 top-1/2 -translate-y-1/2 text-primary-container hover:text-primary transition-colors">
+                      <button type="submit" className="absolute right-2 top-1/2 -translate-y-1/2 text-primary-container hover:text-primary transition-ui">
                         <MaterialIcon name="send" className="text-lg" />
                       </button>
                     </div>

--- a/frontend/src/components/layouts/MarketingLayout.tsx
+++ b/frontend/src/components/layouts/MarketingLayout.tsx
@@ -34,7 +34,7 @@ function useScrollToHash() {
 }
 
 const footerLinkClass =
-  "font-body-ui text-[13px] text-[#8892A6] hover:text-[#E7EBF3] no-underline transition-colors duration-150";
+  "font-body-ui text-[13px] text-[#8892A6] hover:text-[#E7EBF3] no-underline transition-ui";
 
 const navLinks = [
   { label: "Product", to: "/#product" },
@@ -71,7 +71,7 @@ function MarketingNavBar() {
   }, [location.pathname, location.hash]);
 
   const linkClass = (active?: boolean) =>
-    `font-body-ui text-[13px] sm:text-sm transition-colors duration-150 no-underline px-1 ${
+    `font-body-ui text-[13px] sm:text-sm transition-ui no-underline px-1 ${
       active ? "text-white" : "text-white/65 hover:text-white"
     }`;
 
@@ -108,7 +108,7 @@ function MarketingNavBar() {
             <button
               type="button"
               onClick={() => navigate("/dashboard")}
-              className="font-body-ui font-semibold text-[13px] text-black bg-white hover:bg-white/90 border-none rounded-full px-4 sm:px-5 py-2 cursor-pointer transition-colors duration-150 whitespace-nowrap"
+              className="font-body-ui font-semibold text-[13px] text-black bg-white hover:bg-white/90 border-none rounded-full px-4 sm:px-5 py-2 cursor-pointer transition-ui whitespace-nowrap"
             >
               Launch
             </button>
@@ -123,12 +123,12 @@ function MarketingNavBar() {
               <span className="sr-only">Menu</span>
               <span className="flex flex-col gap-1.5" aria-hidden="true">
                 <span
-                  className={`block h-px w-3.5 bg-white transition-transform ${
+                  className={`block h-px w-3.5 bg-white transition-ui ${
                     menuOpen ? "translate-y-[3.5px] rotate-45" : ""
                   }`}
                 />
                 <span
-                  className={`block h-px w-3.5 bg-white transition-transform ${
+                  className={`block h-px w-3.5 bg-white transition-ui ${
                     menuOpen ? "-translate-y-[3.5px] -rotate-45" : ""
                   }`}
                 />
@@ -227,7 +227,7 @@ function MarketingFooter() {
             </p>
             <Link
               to="/dashboard"
-              className="inline-flex items-center font-body-ui font-semibold text-[13px] text-black bg-white hover:bg-white/90 no-underline rounded-full px-5 py-2.5 transition-colors duration-150"
+              className="inline-flex items-center font-body-ui font-semibold text-[13px] text-black bg-white hover:bg-white/90 no-underline rounded-full px-5 py-2.5 transition-ui"
             >
               Launch Dashboard
             </Link>

--- a/frontend/src/components/ui/globe.tsx
+++ b/frontend/src/components/ui/globe.tsx
@@ -107,7 +107,7 @@ export function Globe({
     >
       <canvas
         className={cn(
-          "size-full opacity-0 transition-opacity duration-500 contain-[layout_paint_size]"
+          "size-full opacity-0 transition-ui contain-[layout_paint_size]"
         )}
         ref={canvasRef}
         onPointerDown={(e) => {

--- a/frontend/src/components/ui/shimmer-button.tsx
+++ b/frontend/src/components/ui/shimmer-button.tsx
@@ -43,7 +43,7 @@ export const ShimmerButton = React.forwardRef<
         }
         className={cn(
           "group relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border border-white/10 px-6 py-3 whitespace-nowrap text-white [background:var(--bg)]",
-          "transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px",
+          "transform-gpu transition-ui ease-in-out active:translate-y-px",
           className
         )}
         ref={ref}
@@ -72,7 +72,7 @@ export const ShimmerButton = React.forwardRef<
             "rounded-2xl px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]",
 
             // transition
-            "transform-gpu transition-all duration-300 ease-in-out",
+            "transform-gpu transition-ui ease-in-out",
 
             // on hover
             "group-hover:shadow-[inset_0_-6px_10px_#ffffff3f]",

--- a/frontend/src/pages/AIAgents.tsx
+++ b/frontend/src/pages/AIAgents.tsx
@@ -115,7 +115,7 @@ export const AIAgents: React.FC = () => {
               return (
                 <div
                   key={run.id}
-                  className={`glass-panel p-3 border-l-2 hover:bg-surface-variant/20 transition-all cursor-pointer ${
+                  className={`glass-panel p-3 border-l-2 hover:bg-surface-variant/20 transition-ui cursor-pointer ${
                     run.status === 'RUNNING'   ? 'border-l-primary-container' :
                     run.status === 'COMPLETED' ? 'border-l-status-success' :
                     'border-l-status-emergency'
@@ -261,13 +261,13 @@ export const AIAgents: React.FC = () => {
             <button
               onClick={exportLogs}
               disabled={allDecisions.length === 0}
-              className="flex-1 py-2 bg-primary-container text-bg-deep-space text-[10px] font-bold uppercase tracking-widest hover:brightness-110 transition-all cursor-pointer disabled:opacity-50"
+              className="flex-1 py-2 bg-primary-container text-bg-deep-space text-[10px] font-bold uppercase tracking-widest hover:brightness-110 transition-ui cursor-pointer disabled:opacity-50"
             >
               Export Logs
             </button>
             <button
               onClick={clearTerminal}
-              className="px-3 py-2 border border-border-panel text-on-surface-variant hover:bg-white/5 cursor-pointer transition-colors"
+              className="px-3 py-2 border border-border-panel text-on-surface-variant hover:bg-white/5 cursor-pointer transition-ui"
             >
               <MaterialIcon name="delete" className="text-sm" />
             </button>

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -384,7 +384,7 @@ function WhyKepler() {
               <span className="font-technical-data text-xs sm:text-sm text-[#4FE0C8] pt-1 sm:pt-0">
                 {r.n}
               </span>
-              <h3 className="font-necosmic font-semibold text-xl sm:text-2xl text-[#E7EBF3] m-0 group-hover:text-[#4FE0C8] transition-colors duration-200">
+              <h3 className="font-necosmic font-semibold text-xl sm:text-2xl text-[#E7EBF3] m-0 group-hover:text-[#4FE0C8] transition-ui">
                 {r.label}
               </h3>
               <p className="col-span-2 sm:col-span-1 sm:col-start-3 font-body-ui text-[#8892A6] leading-relaxed m-0 text-sm sm:text-[0.98rem] max-w-none sm:max-w-[48ch]">
@@ -761,7 +761,7 @@ function ClosingCta({ onLaunchDashboard }: { onLaunchDashboard: () => void }) {
             </MagneticButton>
             <Link
               to="/"
-              className="font-body-ui font-semibold text-[15px] text-[#E7EBF3] bg-transparent border border-[#1B2436] hover:border-[#4FE0C8]/50 hover:bg-[#1B2436]/30 rounded-lg px-7 py-3.5 no-underline transition-colors duration-150"
+              className="font-body-ui font-semibold text-[15px] text-[#E7EBF3] bg-transparent border border-[#1B2436] hover:border-[#4FE0C8]/50 hover:bg-[#1B2436]/30 rounded-lg px-7 py-3.5 no-underline transition-ui"
             >
               Back to home
             </Link>

--- a/frontend/src/pages/CollisionCenter.tsx
+++ b/frontend/src/pages/CollisionCenter.tsx
@@ -123,7 +123,7 @@ export const CollisionCenter: React.FC = () => {
           <button
             onClick={() => evaluate.mutate()}
             disabled={evaluate.isPending}
-            className="bg-primary-container text-on-primary font-label-caps text-label-caps px-4 md:px-6 py-2.5 border-b-2 border-primary hover:brightness-110 transition-all flex items-center gap-2 font-bold cursor-pointer drop-shadow-[0_0_10px_rgba(0,229,255,0.4)] disabled:opacity-50 min-h-[44px]"
+            className="bg-primary-container text-on-primary font-label-caps text-label-caps px-4 md:px-6 py-2.5 border-b-2 border-primary hover:brightness-110 transition-ui flex items-center gap-2 font-bold cursor-pointer drop-shadow-[0_0_10px_rgba(0,229,255,0.4)] disabled:opacity-50 min-h-[44px]"
           >
             <MaterialIcon name={evaluate.isPending ? 'sync' : 'bolt'} className={`text-sm ${evaluate.isPending ? 'animate-spin' : ''}`} />
             {evaluate.isPending ? 'SCANNING…' : 'RUN CONJUNCTION SCAN'}
@@ -189,7 +189,7 @@ export const CollisionCenter: React.FC = () => {
                       <tr
                         key={conj.id}
                         onClick={() => setSelectedId(conj.id)}
-                        className={`hover:bg-surface-variant/40 transition-all cursor-pointer ${isSelected ? 'bg-status-emergency/5' : ''}`}
+                        className={`hover:bg-surface-variant/40 transition-ui cursor-pointer ${isSelected ? 'bg-status-emergency/5' : ''}`}
                       >
                         <td className="py-3 px-3 font-semibold text-on-surface text-xs">{conj.object_a?.name ?? '—'}</td>
                         <td className="py-3 px-3 text-on-surface-variant text-xs">{conj.object_b?.name ?? '—'}</td>
@@ -299,14 +299,14 @@ export const CollisionCenter: React.FC = () => {
                 <button
                   onClick={() => updateStatus.mutate({ id: selected.id, status: 'ASSESSED' })}
                   disabled={updateStatus.isPending}
-                  className="flex-1 text-[10px] font-bold text-bg-deep-space bg-primary-container px-4 py-2 hover:bg-primary-fixed-dim transition-all cursor-pointer disabled:opacity-50"
+                  className="flex-1 text-[10px] font-bold text-bg-deep-space bg-primary-container px-4 py-2 hover:bg-primary-fixed-dim transition-ui cursor-pointer disabled:opacity-50"
                 >
                   MARK ASSESSED
                 </button>
                 <button
                   onClick={() => updateStatus.mutate({ id: selected.id, status: 'MITIGATED' })}
                   disabled={updateStatus.isPending}
-                  className="flex-1 text-[10px] font-bold text-primary-container border border-primary-container px-4 py-2 hover:bg-primary-container/10 transition-all cursor-pointer disabled:opacity-50"
+                  className="flex-1 text-[10px] font-bold text-primary-container border border-primary-container px-4 py-2 hover:bg-primary-container/10 transition-ui cursor-pointer disabled:opacity-50"
                 >
                   MARK MITIGATED
                 </button>
@@ -343,7 +343,7 @@ export const CollisionCenter: React.FC = () => {
               {selected && (
                 <button
                   onClick={() => (latestRun ? null : null)}
-                  className="mt-3 text-[10px] font-bold text-primary-container border border-primary-container px-4 py-1.5 hover:bg-primary-container/10 transition-all cursor-pointer"
+                  className="mt-3 text-[10px] font-bold text-primary-container border border-primary-container px-4 py-1.5 hover:bg-primary-container/10 transition-ui cursor-pointer"
                 >
                   TRIGGER AGENT FOR CONJUNCTION {selected.id}
                 </button>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -199,9 +199,9 @@ export const Dashboard: React.FC = () => {
                 {conjunctions.map((conj: Collision) => (
                   <div
                     key={conj.id}
-                    className={`w-64 sm:w-72 shrink-0 glass-panel p-4 border-l-4 ${riskColor(conj.risk_level)} relative overflow-hidden group hover:bg-surface-variant/30 transition-all cursor-pointer`}
+                    className={`w-64 sm:w-72 shrink-0 glass-panel p-4 border-l-4 ${riskColor(conj.risk_level)} relative overflow-hidden group hover:bg-surface-variant/30 transition-ui cursor-pointer`}
                   >
-                    <div className="absolute top-0 right-0 p-2 opacity-10 group-hover:opacity-20 transition-opacity">
+                    <div className="absolute top-0 right-0 p-2 opacity-10 group-hover:opacity-20 transition-ui">
                       <MaterialIcon name="crisis_alert" className={`text-6xl ${riskBarColor(conj.risk_level)}`} />
                     </div>
                     <div className="flex justify-between items-start mb-4">

--- a/frontend/src/pages/Debris.tsx
+++ b/frontend/src/pages/Debris.tsx
@@ -95,7 +95,7 @@ export const Debris: React.FC = () => {
           <button
             onClick={() => syncM.mutate('analyst')}
             disabled={syncM.isPending}
-            className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 cursor-pointer transition-all disabled:opacity-50 min-h-[44px]"
+            className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 cursor-pointer transition-ui disabled:opacity-50 min-h-[44px]"
           >
             <MaterialIcon name={syncM.isPending ? 'sync' : 'cloud_download'} className={`text-sm mr-2 ${syncM.isPending ? 'animate-spin' : ''}`} />
             <span className="font-label-caps text-label-caps">
@@ -138,7 +138,7 @@ export const Debris: React.FC = () => {
           <button
             key={opt.value}
             onClick={() => { setClassFilter(opt.value as Classification | ''); setPage(1); }}
-            className={`px-4 py-2 font-label-caps text-label-caps transition-all cursor-pointer ${
+            className={`px-4 py-2 font-label-caps text-label-caps transition-ui cursor-pointer ${
               classFilter === opt.value
                 ? 'bg-primary-container text-on-primary'
                 : 'border border-border-panel hover:bg-surface-variant/50'
@@ -155,13 +155,13 @@ export const Debris: React.FC = () => {
           <table className="w-full text-left border-collapse">
             <thead className="bg-surface-container-high border-b border-border-panel">
               <tr>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">NAME / NORAD ID</th>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">TYPE</th>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">ALTITUDE</th>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">INCLINATION</th>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">MEAN MOTION</th>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">RISK</th>
-                <th className="p-4 font-label-caps text-label-caps text-on-surface-variant">EPOCH</th>
+                <th className="table-head">NAME / NORAD ID</th>
+                <th className="table-head">TYPE</th>
+                <th className="table-head">ALTITUDE</th>
+                <th className="table-head">INCLINATION</th>
+                <th className="table-head">MEAN MOTION</th>
+                <th className="table-head">RISK</th>
+                <th className="table-head">EPOCH</th>
               </tr>
             </thead>
             {catalogQ.isLoading ? (
@@ -187,7 +187,7 @@ export const Debris: React.FC = () => {
                         <button
                           onClick={() => syncM.mutate('analyst')}
                           disabled={syncM.isPending}
-                          className="font-label-caps text-label-caps text-primary-container border border-primary-container px-4 py-1.5 hover:bg-primary-container/10 transition-all cursor-pointer disabled:opacity-50"
+                          className="font-label-caps text-label-caps text-primary-container border border-primary-container px-4 py-1.5 hover:bg-primary-container/10 transition-ui cursor-pointer disabled:opacity-50"
                         >
                           {syncM.isPending ? 'SYNCING FROM SPACE-TRACK…' : 'SYNC ANALYST DEBRIS FROM SPACE-TRACK'}
                         </button>
@@ -202,12 +202,12 @@ export const Debris: React.FC = () => {
                   const alt  = altFromSMA(obj.semimajor_axis);
                   const risk = riskFromOrbit(obj);
                   return (
-                    <tr key={obj.id} className="hover:bg-primary-container/5 transition-colors">
-                      <td className="p-4">
-                        <div className="font-technical-data font-semibold text-on-surface text-sm">{obj.name}</div>
+                    <tr key={obj.id} className="hover:bg-primary-container/5 transition-ui">
+                      <td>
+                        <div className="table-data-technical font-semibold text-on-surface text-sm">{obj.name}</div>
                         <div className="text-[10px] text-on-surface-variant">NORAD: {obj.catalog_number}</div>
                       </td>
-                      <td className="p-4">
+                      <td>
                         <span className={`font-label-caps text-[9px] px-2 py-0.5 border ${
                           obj.classification === 'DEBRIS'
                             ? 'border-status-emergency/40 text-status-emergency bg-status-emergency/10'
@@ -216,16 +216,16 @@ export const Debris: React.FC = () => {
                           {obj.classification === 'ROCKET_BODY' ? 'ROCKET BODY' : obj.classification}
                         </span>
                       </td>
-                      <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                      <td className="table-data-technical">
                         {alt > 0 ? `${alt.toLocaleString()} km` : '—'}
                       </td>
-                      <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                      <td className="table-data-technical">
                         {obj.inclination != null ? `${obj.inclination.toFixed(2)}°` : '—'}
                       </td>
-                      <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                      <td className="table-data-technical">
                         {obj.mean_motion != null ? `${obj.mean_motion.toFixed(4)} rev/day` : '—'}
                       </td>
-                      <td className="p-4">
+                      <td>
                         <span className={`text-[9px] px-2 py-0.5 font-bold ${
                           risk === 'HIGH'   ? 'bg-status-emergency text-white' :
                           risk === 'MEDIUM' ? 'bg-status-warning text-black' :
@@ -234,7 +234,7 @@ export const Debris: React.FC = () => {
                           {risk}
                         </span>
                       </td>
-                      <td className="p-4 font-technical-data text-[10px] text-on-surface-variant">
+                      <td className="table-data-technical">
                         {obj.epoch ? new Date(obj.epoch).toISOString().substring(0, 10) : '—'}
                       </td>
                     </tr>
@@ -255,14 +255,14 @@ export const Debris: React.FC = () => {
               <button
                 onClick={() => setPage(p => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="px-3 py-1 border border-border-panel font-label-caps text-[10px] hover:bg-surface-variant/50 disabled:opacity-40 cursor-pointer"
+                className="pn-btn"
               >
                 ← PREV
               </button>
               <button
                 onClick={() => setPage(p => Math.min(pagination.pages, p + 1))}
                 disabled={page === pagination.pages}
-                className="px-3 py-1 border border-border-panel font-label-caps text-[10px] hover:bg-surface-variant/50 disabled:opacity-40 cursor-pointer"
+                className="pn-btn"
               >
                 NEXT →
               </button>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -2,34 +2,6 @@ import Hero from "@/components/Hero";
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-/**
- * Kepler — Landing Page
- * -----------------------------------------------------------------------
- * Design tokens
- *   bg          #060A14  deep orbital black
- *   bg-panel    #0C1220  raised panel / nav / footer
- *   line        #1B2436  hairline borders
- *   text        #E7EBF3  primary text
- *   text-dim    #8892A6  secondary text
- *   accent      #4FE0C8  "tracked" telemetry teal (signature color)
- *   warn        #FFB020  "conflict" amber (used sparingly, for CTA + alerts)
- *
- * Type
- *   display: "Space Grotesk" (headlines — geometric, technical, a little cold)
- *   body:    "Inter" (paragraphs, nav, footer)
- *   mono:    "JetBrains Mono" (telemetry labels, coordinates, small data)
- *
- * Signature element
- *   A live orbital field in the hero: thin elliptical paths with small
- *   telemetry dots drifting along them, each carrying a coordinate-style
- *   label. It's the literal subject — space traffic — rendered as the
- *   backdrop rather than an abstract gradient blob.
- *
- * Chrome (nav / footer) lives in MarketingLayout.
- * -----------------------------------------------------------------------
- */
-
-/* Orbital field */
 
 interface OrbitalFieldProps {
   prefersReducedMotion: boolean;
@@ -102,50 +74,6 @@ interface HeroProps {
   prefersReducedMotion: boolean;
 }
 
-function Hero({ onLaunchDashboard, prefersReducedMotion }: HeroProps) {
-  return (
-    <section
-      id="product"
-      className="relative min-h-svh flex items-center justify-center px-6 pt-0 mt-0 pb-16 overflow-hidden"
-    >
-      <OrbitalField prefersReducedMotion={prefersReducedMotion} />
-
-      <div className="relative z-10 max-w-[720px] text-center flex flex-col items-center">
-        <div className="inline-flex items-center font-technical-data text-xs text-[#4FE0C8] border border-[#1B2436] rounded-full px-3.5 py-1.5 mb-7 bg-[#0C1220]">
-          TRACKING 12,400+ OBJECTS · LIVE
-        </div>
-
-        <h1 className="font-display-lg font-bold text-4xl sm:text-5xl md:text-6xl leading-[1.08] text-[#E7EBF3] m-0 tracking-tight">
-          Autonomous traffic control
-          <br />
-          for everything in orbit.
-        </h1>
-
-        <p className="font-body-ui text-[1.05rem] leading-relaxed text-[#8892A6] mt-6 mb-9 max-w-[560px]">
-          Kepler predicts conjunctions, resolves them autonomously, and hands
-          operators a clean, explainable record — before a near-miss ever
-          becomes a headline.
-        </p>
-
-        <div className="flex gap-3 justify-center flex-wrap">
-          <button
-            type="button"
-            onClick={onLaunchDashboard}
-            className="font-body-ui font-semibold text-[15px] text-[#060A14] bg-[#FFB020] hover:bg-[#e59b15] border-none rounded-lg px-6.5 py-3 cursor-pointer transition-colors duration-150"
-          >
-            Launch Dashboard
-          </button>
-          <a
-            href="#how-it-works"
-            className="font-body-ui font-semibold text-[15px] text-[#E7EBF3] bg-transparent border border-[#1B2436] hover:bg-[#1B2436]/30 rounded-lg px-6.5 py-3 text-none transition-colors duration-150"
-          >
-            See how it works
-          </a>
-        </div>
-      </div>
-    </section>
-  );
-}
 
 /* How it works */
 
@@ -257,7 +185,7 @@ export const LandingPage: React.FC = () => {
 
   return (
     <div className="select-none">
-      <Hero onLaunchDashboard={handleLaunch} prefersReducedMotion={prefersReducedMotion} />
+      <Hero />
       <HowItWorks />
       <Reliability />
     </div>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -2,15 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { MaterialIcon } from "@/components/MaterialIcon";
 
-/**
- * Kepler — 404 Not Found Page
- * -----------------------------------------------------------------------
- * Matches the app's dashboard design system (designSystem.ts / index.css
- * theme tokens): deep space background, technical grid, glass panels,
- * Space Grotesk / IBM Plex Sans type, cyan glow accents.
- * -----------------------------------------------------------------------
- */
-
 interface DebrisFieldProps {
   prefersReducedMotion: boolean;
 }
@@ -109,7 +100,7 @@ export const NotFound: React.FC = () => {
 
           <button
             onClick={() => navigate("/dashboard")}
-            className="mt-9 inline-flex items-center gap-2 font-body-ui font-semibold text-sm text-on-primary bg-primary-container hover:opacity-90 rounded-lg px-6 py-3 cursor-pointer transition-opacity duration-150"
+            className="mt-9 inline-flex items-center gap-2 font-body-ui font-semibold text-sm text-on-primary bg-primary-container hover:opacity-90 rounded-lg px-6 py-3 cursor-pointer transition-ui"
           >
             <MaterialIcon name="dashboard" className="text-base" />
             Return to Dashboard

--- a/frontend/src/pages/Satellites.tsx
+++ b/frontend/src/pages/Satellites.tsx
@@ -113,14 +113,14 @@ export const Satellites: React.FC = () => {
             <button
               onClick={() => syncM.mutate(undefined)}
               disabled={syncM.isPending}
-              className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 transition-all cursor-pointer disabled:opacity-50 min-h-[44px]"
+              className="flex items-center px-4 py-2 border border-border-panel bg-surface-container hover:bg-surface-variant/50 transition-ui cursor-pointer disabled:opacity-50 min-h-[44px]"
             >
               <MaterialIcon name={syncM.isPending ? 'sync' : 'cloud_download'} className={`text-sm mr-2 ${syncM.isPending ? 'animate-spin' : ''}`} />
               <span className="font-label-caps text-label-caps">
                 {syncM.isPending ? 'SYNCING…' : 'SYNC SPACE-TRACK'}
               </span>
             </button>
-            <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-all glow-cyan cursor-pointer min-h-[44px]">
+            <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-ui glow-cyan cursor-pointer min-h-[44px]">
               <MaterialIcon name="filter_alt" className="text-sm mr-2" />
               FILTERS
             </button>
@@ -182,7 +182,7 @@ export const Satellites: React.FC = () => {
                           <button
                             onClick={() => syncM.mutate(undefined)}
                             disabled={syncM.isPending}
-                            className="font-label-caps text-label-caps text-primary-container border border-primary-container px-4 py-1.5 hover:bg-primary-container/10 transition-all cursor-pointer disabled:opacity-50"
+                            className="font-label-caps text-label-caps text-primary-container border border-primary-container px-4 py-1.5 hover:bg-primary-container/10 transition-ui cursor-pointer disabled:opacity-50"
                           >
                             {syncM.isPending ? 'SYNCING FROM SPACE-TRACK…' : 'SYNC FROM SPACE-TRACK NOW'}
                           </button>
@@ -201,11 +201,11 @@ export const Satellites: React.FC = () => {
                       <tr
                         key={obj.id}
                         onClick={() => setSelectedSatelliteId(obj.catalog_number)}
-                        className={`hover:bg-primary-container/5 transition-colors group cursor-pointer ${
+                        className={`hover:bg-primary-container/5 transition-ui group cursor-pointer ${
                           isSelected ? 'bg-primary-fixed-dim/5 border-l-2 border-primary-container' : 'opacity-85'
                         }`}
                       >
-                        <td className="p-4">
+                        <td className="table-data">
                           <div className="flex items-center">
                             <span className="w-2 h-2 rounded-full mr-3 bg-status-success" />
                             <div>
@@ -216,7 +216,7 @@ export const Satellites: React.FC = () => {
                             </div>
                           </div>
                         </td>
-                        <td className="p-4">
+                        <td className="table-data">
                           <span className="font-label-caps text-[10px] px-1.5 py-0.5 border border-border-panel text-on-surface-variant bg-surface-container-low">
                             {orbit}
                           </span>
@@ -224,22 +224,22 @@ export const Satellites: React.FC = () => {
                             {alt > 0 ? `${alt.toLocaleString()} km` : '—'}
                           </span>
                         </td>
-                        <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                        <td className="table-data-technical">
                           {obj.inclination != null ? `${obj.inclination.toFixed(2)}°` : '—'}
                         </td>
-                        <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                        <td className="table-data-technical">
                           {obj.eccentricity != null ? obj.eccentricity.toFixed(6) : '—'}
                         </td>
-                        <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                        <td className="table-data-technical">
                           {obj.mean_motion != null ? `${obj.mean_motion.toFixed(4)} rev/day` : '—'}
                         </td>
-                        <td className="p-4 font-technical-data text-[11px] text-on-surface-variant">
+                        <td className="table-data-technical">
                           {obj.period != null ? `${obj.period.toFixed(1)} min` : '—'}
                         </td>
-                        <td className="p-4 text-right">
+                        <td className="table-data text-right">
                           <MaterialIcon
                             name="arrow_forward_ios"
-                            className={`text-on-surface-variant group-hover:text-primary-container transition-all ${isSelected ? 'text-primary-container translate-x-1' : ''}`}
+                            className={`text-on-surface-variant group-hover:text-primary-container transition-ui ${isSelected ? 'text-primary-container translate-x-1' : ''}`}
                           />
                         </td>
                       </tr>
@@ -313,7 +313,7 @@ export const Satellites: React.FC = () => {
               <button
                 onClick={() => syncM.mutate('active')}
                 disabled={syncM.isPending}
-                className="mt-4 w-full py-1.5 bg-bg-deep-space/10 hover:bg-bg-deep-space/20 transition-all font-label-caps text-[10px] border border-bg-deep-space/20 font-bold cursor-pointer disabled:opacity-50"
+                className="mt-4 w-full py-1.5 bg-bg-deep-space/10 hover:bg-bg-deep-space/20 transition-ui font-label-caps text-[10px] border border-bg-deep-space/20 font-bold cursor-pointer disabled:opacity-50"
               >
                 {syncM.isPending ? 'SYNCING…' : 'FORCE SYNC NOW'}
               </button>
@@ -344,7 +344,7 @@ export const Satellites: React.FC = () => {
               </div>
               <button
                 onClick={() => setSelectedSatelliteId(null)}
-                className="text-on-surface-variant hover:text-primary transition-colors cursor-pointer"
+                className="text-on-surface-variant hover:text-primary transition-ui cursor-pointer"
               >
                 <MaterialIcon name="close" />
               </button>
@@ -358,7 +358,7 @@ export const Satellites: React.FC = () => {
                   <button
                     key={tab}
                     onClick={() => setActiveTab(tab)}
-                    className={`flex-1 py-3 text-[10px] font-label-caps font-bold transition-all text-center border-b ${
+                    className={`flex-1 py-3 text-[10px] font-label-caps font-bold transition-ui text-center border-b ${
                       activeTab === tab
                         ? 'text-primary-container border-primary-container'
                         : 'text-on-surface-variant hover:text-on-surface border-transparent'
@@ -453,14 +453,14 @@ export const Satellites: React.FC = () => {
             <div className="p-6 border-t border-border-panel bg-surface-container-low grid grid-cols-2 gap-3 mt-auto">
               <button
                 onClick={() => window.open('https://www.space-track.org', '_blank')}
-                className="py-3 border border-border-panel font-label-caps text-[10px] font-bold hover:bg-surface-variant transition-all cursor-pointer"
+                className="py-3 border border-border-panel font-label-caps text-[10px] font-bold hover:bg-surface-variant transition-ui cursor-pointer"
               >
                 VIEW ON SPACE-TRACK ↗
               </button>
               <button
                 onClick={() => syncM.mutate(undefined)}
                 disabled={syncM.isPending}
-                className="py-3 bg-primary-container text-on-primary font-label-caps text-[10px] font-bold hover:bg-primary transition-all glow-cyan cursor-pointer disabled:opacity-50"
+                className="py-3 bg-primary-container text-on-primary font-label-caps text-[10px] font-bold hover:bg-primary transition-ui glow-cyan cursor-pointer disabled:opacity-50"
               >
                 {syncM.isPending ? 'SYNCING…' : 'REFRESH ORBIT DATA'}
               </button>

--- a/frontend/src/pages/SpaceTraffic.tsx
+++ b/frontend/src/pages/SpaceTraffic.tsx
@@ -14,7 +14,7 @@ export const SpaceTraffic: React.FC = () => {
           </p>
         </div>
         <div className="flex gap-2">
-          <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-all cursor-pointer min-h-[44px]">
+          <button className="flex items-center px-4 py-2 bg-primary-container text-on-primary font-label-caps text-label-caps hover:bg-primary transition-ui cursor-pointer min-h-[44px]">
             <MaterialIcon name="filter_alt" className="text-sm mr-2" />
             REGISTRY FILTER
           </button>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -13,6 +13,7 @@
   font-display: swap;
 }
 
+
 @theme {
   --color-on-primary: #00363d;
   --color-status-emergency: #FF3B30;
@@ -98,18 +99,30 @@
     background-color: #0C1220;
     color: #dfe2eb;
     overflow: hidden;
-    @apply bg-background text-foreground;
   }
   * {
-    @apply border-border outline-ring/50;
-  }
-  html {
-    @apply font-sans;
-  }
+  cursor: url('https://cdn.cursors-4u.net/css-previews/the-alien-e45e01c0-css.webp') 0 0, auto !important;
+}
 }
 
 .transition-ui {
-  transition: all 0.30s cubic-bezier(0.2, 0.8, 0.2, 1);
+  @apply transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)];
+}
+
+.table-head {
+  @apply p-4 font-label-caps text-on-surface-variant;
+}
+
+.table-data {
+  @apply p-4;
+}
+
+.table-data-technical {
+  @apply p-4 font-technical-data text-on-surface-variant;
+}
+
+.pn-btn {
+  @apply px-3 py-1 border border-border-panel font-label-caps text-[10px] hover:bg-surface-variant/50 disabled:opacity-40 cursor-pointer;
 }
 
 .scanlines {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -100,9 +100,6 @@
     color: #dfe2eb;
     overflow: hidden;
   }
-  * {
-  cursor: url('https://cdn.cursors-4u.net/css-previews/the-alien-e45e01c0-css.webp') 0 0, auto !important;
-}
 }
 
 .transition-ui {


### PR DESCRIPTION
## Description

- Fixed broken packages file missing react/motion package missing after recent merge (Couldn't develop the app further if this was not fixed)
- Fixed Hero Section Duplicates as LandingPage was crashing due to same function conflicts 
- Added Style consistentency to tables and containers with repeated element subclasses and Transition consistency across the entire application, from the landing page to every piece of UI that exists (Please Document this or tell me how to, so that we can communicate in the future that whenever a maintainer or contributor has to add transitions, they use the global `transition-ui` class. 

## Related Issue

#56 

## Checklist

- [X] I have read the contributing guidelines
- [X] My code follows the project guidelines
- [X] I have completed testing of my changes
- [X] Documentation has been updated (if applicable)
- [X] `npm run build` finishes without errors <----- Please make sure to add this to the template

## Screenshots / Screen Recordings

<!-- If applicable, add screenshots to help explain your changes -->

## Breaking Changes

No Breaking Changes

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [ ] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the hero “Continue to dashboard” button to navigate to the dashboard via client-side routing.

* **Style**
  * Standardized UI transition behavior across the app using a unified `transition-ui` styling utility, refining hover/active/focus animations and improving responsive weather HUD visibility.
  * Restyled tables, row/cell typography, and pagination controls with shared table header/data styles (notably in Debris and Satellites).
  * Polished transitions on globe, HUD controls, shimmer button, and other interactive elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken `motion` package dependency, removes a duplicate local `Hero` component that was crashing `LandingPage`, and introduces a `transition-ui` utility class applied uniformly across the app. It also extracts shared table/pagination utility classes (`table-head`, `table-data`, `table-data-technical`, `pn-btn`) to reduce repetition.

- **Package fix**: adds `motion@^12.42.2` to `package.json`; note this overlaps with the existing `framer-motion` dependency (they share the same codebase).
- **Hero dedup**: removes the inline `Hero` function from `LandingPage.tsx` and wires the hero CTA button to `/dashboard` via `<Link>`.
- **Style unification**: replaces `transition-all`/`transition-colors` with `transition-ui` across ~18 files, and introduces four shared table cell classes in `index.css`; the `table-data-technical` class omits the original `text-[11px]` size and the `Debris.tsx` TYPE/RISK cells were left without any padding class.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the missing padding on the TYPE and RISK cells and the missing font-size in table-data-technical.

The transition unification and hero fix are clean, but the new table-data-technical utility class silently drops the explicit text-[11px] size that was on every original data cell, and two columns in the Debris table (TYPE and RISK) were left with no padding class at all. These are direct visual regressions on the changed table rows.

frontend/src/styles/index.css (missing font-size in table-data-technical) and frontend/src/pages/Debris.tsx (TYPE and RISK td elements have no padding class).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/styles/index.css | Adds transition-ui, table-head, table-data, table-data-technical, and pn-btn utility classes; removes global html/* baseline rules. table-data-technical is missing text-[11px], silently dropping the compact font size from all technical data cells. |
| frontend/src/pages/Debris.tsx | Refactors table cells to use shared utility classes; TYPE and RISK td elements lost all padding (no class applied), and the NAME column applies table-data-technical to the inner div rather than the td — three of seven columns are misaligned. |
| frontend/src/pages/Satellites.tsx | Replaces inline transition and padding classes with transition-ui, table-data, and table-data-technical; padding is correct but table-data-technical drops the original text-[11px] size from technical data cells. |
| frontend/src/pages/LandingPage.tsx | Removes duplicate local Hero function that conflicted with the imported Hero component; dead HeroProps and OrbitalFieldProps interfaces remain. |
| frontend/src/components/Hero.tsx | Wraps the Continue to dashboard button in a react-router-dom Link so it actually navigates to /dashboard. |
| frontend/package.json | Adds motion@^12.42.2 alongside the existing framer-motion@^12.40.0; these share the same codebase (Motion rebranded from Framer Motion), adding duplication in the dependency tree. |
| frontend/src/components/layouts/MainLayout.tsx | Replaces all transition-all duration-200/300 and transition-colors classes with transition-ui across sidebar, header, and drawer elements; no functional changes. |
| frontend/src/components/ui/globe.tsx | Replaces transition-opacity duration-500 with transition-ui; the globe canvas fade-in shortens from 500 ms to 300 ms and now transitions all properties. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `frontend/src/pages/Debris.tsx`, line 413-416 ([link](https://github.com/7-blocks/kepler/blob/19cbf6fca9881879a172846eab772da76865c693/frontend/src/pages/Debris.tsx#L413-L416)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`table-data-technical` applied to inner `<div>` instead of the `<td>`, leaving the cell itself without padding**

   The original code placed `p-4` on the `<td>`. After this change the `p-4` inside `table-data-technical` is applied to the inner `<div>`, while the `<td>` has no class at all. Every other `<td>` in the same table uses the class directly on the `<td>` — this cell will render with different spacing, misaligning the first column.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/pages/Debris.tsx
   Line: 413-416

   Comment:
   **`table-data-technical` applied to inner `<div>` instead of the `<td>`, leaving the cell itself without padding**

   The original code placed `p-4` on the `<td>`. After this change the `p-4` inside `table-data-technical` is applied to the inner `<div>`, while the `<td>` has no class at all. Every other `<td>` in the same table uses the class directly on the `<td>` — this cell will render with different spacing, misaligning the first column.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `frontend/src/components/ui/globe.tsx`, line 227-230 ([link](https://github.com/7-blocks/kepler/blob/19cbf6fca9881879a172846eab772da76865c693/frontend/src/components/ui/globe.tsx#L227-L230)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Globe fade-in duration unintentionally changes from 500 ms to 300 ms, and now transitions all properties**

   The original class was `transition-opacity duration-500`. After replacing with `transition-ui` the animation becomes `transition-all duration-300`, shortening the fade-in by 40% and enabling all CSS properties to transition. Consider keeping a local `duration-500` override alongside `transition-ui` if the longer fade was intentional.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/components/ui/globe.tsx
   Line: 227-230

   Comment:
   **Globe fade-in duration unintentionally changes from 500 ms to 300 ms, and now transitions all properties**

   The original class was `transition-opacity duration-500`. After replacing with `transition-ui` the animation becomes `transition-all duration-300`, shortening the fade-in by 40% and enabling all CSS properties to transition. Consider keeping a local `duration-500` override alongside `transition-ui` if the longer fade was intentional.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["remove alien cursor for now"](https://github.com/7-blocks/kepler/commit/4b0f0869b951ca968ed3c73403375cd15380e568) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44840676)</sub>

<!-- /greptile_comment -->