### PR TITLE
Added technologies page with /tech routes pointing to the page (#55)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "gsap": "^3.15.0",
         "lucide-react": "^1.17.0",
         "motion": "^12.42.2",
+        "next-themes": "^0.4.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.77.0",
@@ -5625,6 +5626,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-releases": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "gsap": "^3.15.0",
     "lucide-react": "^1.17.0",
     "motion": "^12.42.2",
+    "next-themes": "^0.4.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.77.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { Settings } from '@/pages/Settings';
 import { Toaster } from 'sonner';
 import { toastOptions } from './constants/toast';
 import { NotFound } from '@/pages/NotFound';
+import { Technologies } from './pages/Technologies';
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
         <Route element={<MarketingLayout />}>
           <Route path="/" element={<LandingPage />} />
           <Route path="/about" element={<AboutPage />} />
+          <Route path="tech" element={<Technologies />} />
         </Route>
         <Route path="/dashboard" element={<MainLayout />}>
           <Route index element={<Dashboard />} />

--- a/frontend/src/components/ui/TechLogo.tsx
+++ b/frontend/src/components/ui/TechLogo.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+
+interface TechLogoProps {
+  name: string;
+  slug?: string;
+  colorHex: string;
+  accentClass: string;
+}
+
+export function TechLogo({ name, slug, colorHex, accentClass }: TechLogoProps) {
+  const [failed, setFailed] = useState(false);
+  const initials = name
+    .replace(/[^a-zA-Z0-9 ]/g, "")
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+
+  return (
+    <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border ${accentClass}`}>
+      {!slug || failed ? (
+        <span className="font-[JetBrains_Mono] text-[11px] font-semibold">{initials}</span>
+      ) : (
+        <img
+          src={`https://cdn.simpleicons.org/${slug}/${colorHex}`}
+          alt={`${name} logo`}
+          width={20}
+          height={20}
+          loading="lazy"
+          onError={() => setFailed(true)}
+          className="h-5 w-5"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/magic-card.tsx
+++ b/frontend/src/components/ui/magic-card.tsx
@@ -1,0 +1,220 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  motion,
+  useMotionTemplate,
+  useMotionValue,
+  useSpring,
+} from "motion/react"
+import { useTheme } from "next-themes"
+
+import { cn } from "@/lib/utils"
+
+interface MagicCardBaseProps {
+  children?: React.ReactNode
+  className?: string
+  gradientSize?: number
+  gradientFrom?: string
+  gradientTo?: string
+}
+
+interface MagicCardGradientProps extends MagicCardBaseProps {
+  mode?: "gradient"
+
+  gradientColor?: string
+  gradientOpacity?: number
+
+  glowFrom?: never
+  glowTo?: never
+  glowAngle?: never
+  glowSize?: never
+  glowBlur?: never
+  glowOpacity?: never
+}
+
+interface MagicCardOrbProps extends MagicCardBaseProps {
+  mode: "orb"
+
+  glowFrom?: string
+  glowTo?: string
+  glowAngle?: number
+  glowSize?: number
+  glowBlur?: number
+  glowOpacity?: number
+
+  gradientColor?: never
+  gradientOpacity?: never
+}
+
+type MagicCardProps = MagicCardGradientProps | MagicCardOrbProps
+type ResetReason = "enter" | "leave" | "global" | "init"
+
+function isOrbMode(props: MagicCardProps): props is MagicCardOrbProps {
+  return props.mode === "orb"
+}
+
+export function MagicCard(props: MagicCardProps) {
+  const {
+    children,
+    className,
+    gradientSize = 200,
+    gradientColor = "#262626",
+    gradientOpacity = 0.8,
+    gradientFrom = "#9E7AFF",
+    gradientTo = "#FE8BBB",
+    mode = "gradient",
+  } = props
+
+  const glowFrom = isOrbMode(props) ? (props.glowFrom ?? "#ee4f27") : "#ee4f27"
+  const glowTo = isOrbMode(props) ? (props.glowTo ?? "#6b21ef") : "#6b21ef"
+  const glowAngle = isOrbMode(props) ? (props.glowAngle ?? 90) : 90
+  const glowSize = isOrbMode(props) ? (props.glowSize ?? 420) : 420
+  const glowBlur = isOrbMode(props) ? (props.glowBlur ?? 60) : 60
+  const glowOpacity = isOrbMode(props) ? (props.glowOpacity ?? 0.9) : 0.9
+  const { theme, systemTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  const isDarkTheme = useMemo(() => {
+    if (!mounted) return true
+    const currentTheme = theme === "system" ? systemTheme : theme
+    return currentTheme === "dark"
+  }, [theme, systemTheme, mounted])
+
+  const mouseX = useMotionValue(-gradientSize)
+  const mouseY = useMotionValue(-gradientSize)
+
+  const orbX = useSpring(mouseX, { stiffness: 250, damping: 30, mass: 0.6 })
+  const orbY = useSpring(mouseY, { stiffness: 250, damping: 30, mass: 0.6 })
+  const orbVisible = useSpring(0, { stiffness: 300, damping: 35 })
+
+  const modeRef = useRef(mode)
+  const glowOpacityRef = useRef(glowOpacity)
+  const gradientSizeRef = useRef(gradientSize)
+
+  useEffect(() => {
+    modeRef.current = mode
+  }, [mode])
+
+  useEffect(() => {
+    glowOpacityRef.current = glowOpacity
+  }, [glowOpacity])
+
+  useEffect(() => {
+    gradientSizeRef.current = gradientSize
+  }, [gradientSize])
+
+  const reset = useCallback(
+    (reason: ResetReason = "leave") => {
+      const currentMode = modeRef.current
+
+      if (currentMode === "orb") {
+        if (reason === "enter") orbVisible.set(glowOpacityRef.current)
+        else orbVisible.set(0)
+        return
+      }
+
+      const off = -gradientSizeRef.current
+      mouseX.set(off)
+      mouseY.set(off)
+    },
+    [mouseX, mouseY, orbVisible]
+  )
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect()
+      mouseX.set(e.clientX - rect.left)
+      mouseY.set(e.clientY - rect.top)
+    },
+    [mouseX, mouseY]
+  )
+
+  useEffect(() => {
+    reset("init")
+  }, [reset])
+
+  useEffect(() => {
+    const handleGlobalPointerOut = (e: PointerEvent) => {
+      if (!e.relatedTarget) reset("global")
+    }
+    const handleBlur = () => reset("global")
+    const handleVisibility = () => {
+      if (document.visibilityState !== "visible") reset("global")
+    }
+
+    window.addEventListener("pointerout", handleGlobalPointerOut)
+    window.addEventListener("blur", handleBlur)
+    document.addEventListener("visibilitychange", handleVisibility)
+
+    return () => {
+      window.removeEventListener("pointerout", handleGlobalPointerOut)
+      window.removeEventListener("blur", handleBlur)
+      document.removeEventListener("visibilitychange", handleVisibility)
+    }
+  }, [reset])
+
+  return (
+    <motion.div
+      className={cn(
+        "group relative isolate overflow-hidden rounded-[inherit] border border-transparent",
+        className
+      )}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={() => reset("leave")}
+      onPointerEnter={() => reset("enter")}
+      style={{
+        background: useMotionTemplate`
+          linear-gradient(var(--color-background) 0 0) padding-box,
+          radial-gradient(${gradientSize}px circle at ${mouseX}px ${mouseY}px,
+            ${gradientFrom},
+            ${gradientTo},
+            var(--color-border) 100%
+          ) border-box
+        `,
+      }}
+    >
+      <div className="bg-background absolute inset-px z-20 rounded-[inherit]" />
+
+      {mode === "gradient" && (
+        <motion.div
+          suppressHydrationWarning
+          className="pointer-events-none absolute inset-px z-30 rounded-[inherit] opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+          style={{
+            background: useMotionTemplate`
+              radial-gradient(${gradientSize}px circle at ${mouseX}px ${mouseY}px,
+                ${gradientColor},
+                transparent 100%
+              )
+            `,
+            opacity: gradientOpacity,
+          }}
+        />
+      )}
+
+      {mode === "orb" && (
+        <motion.div
+          suppressHydrationWarning
+          aria-hidden="true"
+          className="pointer-events-none absolute z-30"
+          style={{
+            width: glowSize,
+            height: glowSize,
+            x: orbX,
+            y: orbY,
+            translateX: "-50%",
+            translateY: "-50%",
+            borderRadius: 9999,
+            filter: `blur(${glowBlur}px)`,
+            opacity: orbVisible,
+            background: `linear-gradient(${glowAngle}deg, ${glowFrom}, ${glowTo})`,
+
+            mixBlendMode: isDarkTheme ? "screen" : "multiply",
+            willChange: "transform, opacity",
+          }}
+        />
+      )}
+      <div className="relative z-40">{children}</div>
+    </motion.div>
+  )
+}

--- a/frontend/src/pages/Technologies.tsx
+++ b/frontend/src/pages/Technologies.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+import { MonitorSmartphone, ServerCog, BrainCircuit, RadioTower, Database, Boxes } from "lucide-react";
+import { Particles } from "@/components/ui/particles";
+import { MagicCard } from "@/components/ui/magic-card";
+import { TechLogo } from "@/components/ui/TechLogo";
+
+type Category = "Frontend" | "Backend" | "AI" | "Space APIs" | "Database" | "Infrastructure";
+
+interface TechItem {
+  name: string;
+  description: string;
+  slug?: string;
+  colorHex: string;
+}
+
+interface CategoryMeta {
+  Icon: LucideIcon;
+  glowHex: string;
+  accentClass: string;
+  items: TechItem[];
+}
+
+const CATEGORIES: Record<Category, CategoryMeta> = {
+  Frontend: {
+    Icon: MonitorSmartphone,
+    glowHex: "#4CD6F0",
+    accentClass: "border-[#4CD6F0]/30 bg-[#4CD6F0]/10 text-[#4CD6F0]",
+    items: [
+      { name: "React", slug: "react", colorHex: "4CD6F0", description: "Component-based UI for the dashboard and hero." },
+      { name: "TypeScript", slug: "typescript", colorHex: "4CD6F0", description: "Type safety across the whole frontend." },
+      { name: "Tailwind CSS", slug: "tailwindcss", colorHex: "4CD6F0", description: "Utility-first styling, no custom CSS files." },
+      { name: "Framer Motion", slug: "framer", colorHex: "4CD6F0", description: "Page-load and interaction animation." },
+    ],
+  },
+  Backend: {
+    Icon: ServerCog,
+    glowHex: "#9D7BFF",
+    accentClass: "border-[#9D7BFF]/30 bg-[#9D7BFF]/10 text-[#9D7BFF]",
+    items: [
+      { name: "FastAPI", slug: "fastapi", colorHex: "9D7BFF", description: "Python API layer for orbital computations." },
+      { name: "Node.js", slug: "nodedotjs", colorHex: "9D7BFF", description: "Realtime services and the WebSocket layer." },
+      { name: "Express", slug: "express", colorHex: "9D7BFF", description: "REST routing for the Node services." },
+      { name: "Python", slug: "python", colorHex: "9D7BFF", description: "Core language for the prediction pipeline." },
+    ],
+  },
+  AI: {
+    Icon: BrainCircuit,
+    glowHex: "#FFB454",
+    accentClass: "border-[#FFB454]/30 bg-[#FFB454]/10 text-[#FFB454]",
+    items: [
+      { name: "PyTorch", slug: "pytorch", colorHex: "FFB454", description: "Collision-risk prediction models." },
+      { name: "scikit-learn", slug: "scikitlearn", colorHex: "FFB454", description: "Baseline models and feature pipelines." },
+      { name: "NumPy", slug: "numpy", colorHex: "FFB454", description: "Numerical core for orbital math." },
+      { name: "Pandas", slug: "pandas", colorHex: "FFB454", description: "Telemetry data wrangling." },
+    ],
+  },
+  "Space APIs": {
+    Icon: RadioTower,
+    glowHex: "#5B8DEF",
+    accentClass: "border-[#5B8DEF]/30 bg-[#5B8DEF]/10 text-[#5B8DEF]",
+    items: [
+      { name: "NASA Open APIs", slug: "nasa", colorHex: "5B8DEF", description: "Public spaceflight and imagery data." },
+      { name: "Celestrak", colorHex: "5B8DEF", description: "TLE orbital element sets." },
+      { name: "Space-Track.org", colorHex: "5B8DEF", description: "Authoritative satellite catalog data." },
+    ],
+  },
+  Database: {
+    Icon: Database,
+    glowHex: "#34D399",
+    accentClass: "border-[#34D399]/30 bg-[#34D399]/10 text-[#34D399]",
+    items: [
+      { name: "MongoDB", slug: "mongodb", colorHex: "34D399", description: "Document store for satellite records." },
+      { name: "PostgreSQL", slug: "postgresql", colorHex: "34D399", description: "Relational store for structured telemetry." },
+      { name: "Redis", slug: "redis", colorHex: "34D399", description: "Caching and realtime pub/sub." },
+    ],
+  },
+  Infrastructure: {
+    Icon: Boxes,
+    glowHex: "#FB7185",
+    accentClass: "border-[#FB7185]/30 bg-[#FB7185]/10 text-[#FB7185]",
+    items: [
+      { name: "Docker", slug: "docker", colorHex: "FB7185", description: "Containerized services across environments." },
+      { name: "AWS", slug: "amazonaws", colorHex: "FB7185", description: "Compute and storage backbone." },
+      { name: "Nginx", slug: "nginx", colorHex: "FB7185", description: "Reverse proxy and load balancing." },
+      { name: "GitHub Actions", slug: "githubactions", colorHex: "FB7185", description: "CI/CD for every merged PR." },
+    ],
+  },
+};
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: [0.16, 1, 0.3, 1] as const } },
+};
+
+export function Technologies() {
+  return (
+    <section className="relative w-full overflow-hidden bg-[radial-gradient(120%_60%_at_50%_0%,#0B111F_0%,#05070C_55%)] py-20 font-[Inter] sm:py-28">
+      <Particles className="absolute inset-0" quantity={120} />
+
+      <div className="relative z-10 mx-auto w-full max-w-[1180px] px-6 sm:px-8 lg:px-10">
+        {/* Header */}
+        <div className="mx-auto max-w-[640px] text-center">
+          <div className="mb-5 inline-flex items-center gap-2 font-[JetBrains_Mono] text-xs tracking-[0.2em] text-[#8793AC]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#4CD6F0] shadow-[0_0_8px_#4CD6F0]" />
+            THE STACK
+          </div>
+          <h1 className="m-0 bg-[linear-gradient(100deg,#EAF1FC_20%,#4CD6F0_55%,#9D7BFF_90%)] bg-clip-text font-[Space_Grotesk] text-[clamp(2rem,4.5vw,3rem)] font-bold leading-[1.1] tracking-[-0.02em] text-transparent">
+            What powers Kepler.
+          </h1>
+          <p className="mx-auto mt-4 max-w-[480px] text-[15px] leading-relaxed text-[#A6B0C4] sm:text-[16px]">
+            Every layer, from the models predicting collision risk to the
+            proxy routing traffic — real tools, not a marketing list.
+          </p>
+        </div>
+
+        {/* Category sections */}
+        <div className="mt-16 flex flex-col gap-16 sm:mt-20 sm:gap-20">
+          {(Object.entries(CATEGORIES) as [Category, CategoryMeta][]).map(([category, meta]) => (
+            <div key={category}>
+              <div className="mb-6 flex items-center gap-3">
+                <span className={`flex h-9 w-9 items-center justify-center rounded-lg border ${meta.accentClass}`}>
+                  <meta.Icon size={17} />
+                </span>
+                <h2 className="m-0 font-[Space_Grotesk] text-lg font-semibold text-[#EAF1FC] sm:text-xl">
+                  {category}
+                </h2>
+                <span className="font-[JetBrains_Mono] text-xs text-[#6B7690]">
+                  {String(meta.items.length).padStart(2, "0")}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                {meta.items.map((item) => (
+                  <motion.div
+                    key={item.name}
+                    initial="hidden"
+                    whileInView="show"
+                    viewport={{ once: true, margin: "-40px" }}
+                    variants={fadeUp}
+                  >
+                    <MagicCard gradientColor={meta.glowHex} className="h-full p-5 rounded-lg">
+                      <div className="flex items-start gap-3">
+                        <TechLogo name={item.name} slug={item.slug} colorHex={item.colorHex} accentClass={meta.accentClass} />
+                        <div className="min-w-0">
+                          <div className="truncate text-[14px] font-semibold text-[#EAF1FC]">{item.name}</div>
+                        </div>
+                      </div>
+                      <p className="mt-3 text-[12.5px] leading-relaxed text-[#8793AC]">{item.description}</p>
+                    </MagicCard>
+                  </motion.div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Technologies


### PR DESCRIPTION
## Description

Added Technologies page and it's reusable subcomponents inside `src/components/ui/`

## Related Issue

#55 

## Checklist

- [X] I have read the contributing guidelines
- [X] My code follows the project guidelines
- [X] I have completed testing of my changes
- [X] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/b83e440f-3295-4245-a254-e2957bada61b

## Breaking Changes

No Breaking changes. 

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [ ] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Technologies page at `/tech`, showcasing the technologies powering the product.
  * Added categorized technology cards with descriptions, logos, animated effects, and responsive visual styling.
  * Added fallback initials when technology logos cannot be loaded.
  * Added theme support for the new visual components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `/tech` marketing page that displays the project's technology stack in animated category cards, along with two new reusable UI components (`MagicCard`, `TechLogo`) and the `next-themes` dependency.

- **`magic-card.tsx`** has two bugs that need fixing before merge: `useMotionTemplate` is called inside a short-circuit conditional (`mode === "gradient" && ...`), violating Rules of Hooks and causing a crash if `mode` ever changes at runtime; and `useTheme` from `next-themes` is invoked without a `ThemeProvider` anywhere in the component tree, so theme detection always returns `undefined`.
- **`App.tsx`** registers the route as `path="tech"` (no leading slash) while all sibling marketing routes use absolute paths (`/about`, `/`); this works but is inconsistent.
- Both `Technologies.tsx` and `TechLogo.tsx` include a `"use client"` Next.js directive that is meaningless in this Vite/React SPA.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — `magic-card.tsx` has a hook-ordering bug that will crash the card grid if the `mode` prop changes, and the missing `ThemeProvider` means theme detection is broken by default.

The `MagicCard` component calls `useMotionTemplate` conditionally inside a short-circuit JSX expression, a real hook-ordering defect that causes React to throw whenever `mode` changes between renders. The same file calls `useTheme` from `next-themes` with no `ThemeProvider` mounted anywhere in the app, so theme detection silently returns wrong values. These two independent defects need to be resolved before the component is reliable.

`frontend/src/components/ui/magic-card.tsx` needs the most attention — the hook-ordering defect and the missing provider context both live there.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/ui/magic-card.tsx | New interactive card component with mouse-tracking gradient/orb effects; contains a Rules of Hooks violation and uses `useTheme` without a `ThemeProvider` in the app. |
| frontend/src/App.tsx | Adds `/tech` route under `MarketingLayout`; route path is missing the leading slash present on all sibling routes. |
| frontend/src/pages/Technologies.tsx | New Technologies page with category cards; includes a stale `"use client"` Next.js directive. |
| frontend/src/components/ui/TechLogo.tsx | New logo component fetching icons from cdn.simpleicons.org with an initials fallback; has a stale `"use client"` directive. |
| frontend/package.json | Adds `next-themes` as a runtime dependency; requires a `ThemeProvider` that is absent from the app. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
frontend/src/components/ui/magic-card.tsx:179-193
**Conditional `useMotionTemplate` violates Rules of Hooks**

`useMotionTemplate` is a React hook called inside a short-circuit conditional expression (`mode === "gradient" && (...)`). Because `&&` skips the right-hand side when the left is falsy, this hook is only called when `mode` is `"gradient"`. If a parent ever renders `<MagicCard mode="orb" />` and then switches to `mode="gradient"` (or vice versa), React will throw `"Rendered more hooks than during the previous render"` and crash the component tree. Both `useMotionTemplate` calls should be extracted to the top level of the component.

### Issue 2 of 5
frontend/src/components/ui/magic-card.tsx:8
**`useTheme` called without a `ThemeProvider` in the tree**

`useTheme` from `next-themes` relies on a `ThemeProvider` ancestor. There is no `ThemeProvider` mounted anywhere in this application. Without a provider, the hook returns `{ theme: undefined, systemTheme: undefined }` after mounting, so `currentTheme === "dark"` is always `false` — the orb blend mode falls back to `"multiply"` instead of `"screen"`. A `ThemeProvider` must be added at the app root, or the theme source replaced with an existing mechanism in the project.

### Issue 3 of 5
frontend/src/App.tsx:31
The `tech` route is missing the leading `/` that all other `MarketingLayout` sibling routes use (`"/"`, `"/about"`). While it resolves to `/tech` in practice for pathless layout routes in React Router v6, it is inconsistent with the rest of the codebase.

```suggestion
          <Route path="/tech" element={<Technologies />} />
```

### Issue 4 of 5
frontend/src/pages/Technologies.tsx:1-3
The `"use client"` directive is a Next.js RSC boundary marker. This project is a Vite + React SPA — the directive is treated as an inert string literal and should be removed.

```suggestion
import { motion } from "framer-motion";
```

### Issue 5 of 5
frontend/src/components/ui/TechLogo.tsx:1-3
Same as `Technologies.tsx` — the `"use client"` directive is a no-op in this Vite + React project and should be removed.

```suggestion
import { useState } from "react";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;7-Blocks:main&#39; into main"](https://github.com/7-blocks/kepler/commit/5d35dc545d4b0f87a0b3d920e81fbabd8663fdbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45015812)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->