### PR TITLE
Redesign Header to Match New Design & Fix Hero Section Overlap

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,6 +82,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -789,27 +790,6 @@
       "resolved": "https://registry.npmjs.org/@dotenvx/primitives/-/primitives-0.8.0.tgz",
       "integrity": "sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -2101,6 +2081,7 @@
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2111,6 +2092,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2121,6 +2103,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2189,6 +2172,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2513,6 +2497,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2759,6 +2744,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2860,6 +2846,7 @@
       "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.142.0.tgz",
       "integrity": "sha512-Z6mBxdeBS0lEXM7WAQgG8Q0FovXYAJpZsMOSWgd7dH28Ov+djJxWOlUMiG8jOai0TzeOYdYsMLgnYb2uB/aI/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "workspaces": [
         "packages/engine",
         "packages/widgets",
@@ -3270,6 +3257,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3359,6 +3347,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
       "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -3716,6 +3705,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4563,6 +4553,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4626,6 +4617,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6298,6 +6290,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6307,6 +6300,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6319,6 +6313,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6342,6 +6337,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6448,7 +6444,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7300,6 +7297,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7484,6 +7482,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7669,6 +7668,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { MainLayout } from '@/components/layouts/MainLayout';
 import { MarketingLayout } from '@/components/layouts/MarketingLayout';
 import { LandingPage } from '@/pages/LandingPage';
 import { AboutPage } from '@/pages/AboutPage';
+import { ProductPage, SolutionsPage, DevelopersPage, DocsPage, SignInPage } from '@/pages/PlaceholderPage';
 import { Dashboard } from '@/pages/Dashboard';
 import { SpaceTraffic } from '@/pages/SpaceTraffic';
 import { Satellites } from '@/pages/Satellites';
@@ -29,6 +30,11 @@ function App() {
           <Route path="/" element={<LandingPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="tech" element={<Technologies />} />
+          <Route path="/product" element={<ProductPage />} />
+          <Route path="/solutions" element={<SolutionsPage />} />
+          <Route path="/developers" element={<DevelopersPage />} />
+          <Route path="/docs" element={<DocsPage />} />
+          <Route path="/signin" element={<SignInPage />} />
         </Route>
         <Route path="/dashboard" element={<MainLayout />}>
           <Route index element={<Dashboard />} />

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -39,7 +39,7 @@ export function Hero() {
 
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,#05070C_0%,rgba(5,7,12,0.85)_38%,rgba(5,7,12,0.25)_62%,transparent_85%)] sm:bg-[linear-gradient(90deg,#05070C_0%,rgba(5,7,12,0.85)_38%,rgba(5,7,12,0.25)_62%,transparent_85%)]" />
 
-      <div className="relative z-10 mx-auto w-full max-w-[1280px] px-6 sm:px-8 lg:px-10">
+      <div className="relative z-10 mx-auto w-full max-w-[1280px] px-6 sm:px-8 lg:px-10 pt-[120px] sm:pt-[160px] pb-12">
         <div className="max-w-[620px]">
           <motion.div
             initial="hidden"

--- a/frontend/src/components/layouts/MarketingLayout.tsx
+++ b/frontend/src/components/layouts/MarketingLayout.tsx
@@ -37,23 +37,26 @@ const footerLinkClass =
   "font-body-ui text-[13px] text-[#8892A6] hover:text-[#E7EBF3] no-underline transition-ui";
 
 const navLinks = [
-  { label: "Product", to: "/#product" },
-  { label: "How it works", to: "/#how-it-works" },
-  { label: "About", to: "/about" },
-  { label: "Contact", to: "/#contact" },
+  { label: "Product", to: "/product" },
+  { label: "Solutions", to: "/solutions" },
+  { label: "Developers", to: "/developers" },
+  { label: "Docs", to: "/docs" },
+  { label: "Dashboard", to: "/dashboard" },
 ];
 
 function BrandMark() {
   return (
-    <Link to="/" className="flex items-center gap-2.5 no-underline shrink-0">
-      <img
-        src="/Logo.svg"
-        alt=""
-        width={28}
-        height={28}
-        className="h-7 w-7 object-contain"
-      />
-      <span className="font-necosmic text-[15px] text-white tracking-wide">
+    <Link to="/" className="flex items-center gap-2.5 no-underline shrink-0 group">
+      <div className="relative flex items-center justify-center h-8 w-8 rounded-xl bg-black transition-transform group-hover:scale-105 shadow-sm">
+        <img
+          src="/Logo.svg"
+          alt=""
+          width={20}
+          height={20}
+          className="h-5 w-5 object-contain"
+        />
+      </div>
+      <span className="font-necosmic text-[16px] text-[#0C1220] tracking-wide font-medium">
         Kepler
       </span>
     </Link>
@@ -71,46 +74,42 @@ function MarketingNavBar() {
   }, [location.pathname, location.hash]);
 
   const linkClass = (active?: boolean) =>
-    `font-body-ui text-[13px] sm:text-sm transition-ui no-underline px-1 ${
-      active ? "text-white" : "text-white/65 hover:text-white"
+    `relative font-body-ui text-[14px] font-medium transition-all no-underline px-3 py-2 rounded-full ${
+      active 
+        ? "text-[#0C1220] bg-gray-100" 
+        : "text-[#5F6A80] hover:text-[#0C1220] hover:bg-gray-50"
     }`;
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-[100] flex justify-center pointer-events-none">
+    <header className="fixed top-0 left-0 right-0 z-[100] flex justify-center pointer-events-none pt-4 sm:pt-6">
       <motion.div
         initial={reduce ? false : { y: -28, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-        className="marketing-nav-notch pointer-events-auto w-[min(100%,720px)] sm:w-[min(92%,760px)]"
+        className="pointer-events-auto w-[calc(100%-32px)] max-w-[1100px] mx-auto bg-white/95 backdrop-blur-md rounded-full border border-black/[0.04] shadow-[0_8px_32px_rgba(0,0,0,0.06)]"
       >
-        <div className="flex items-center justify-between gap-3 px-4 sm:px-6 py-3 sm:py-3.5">
+        <div className="flex items-center justify-between gap-3 px-3 py-2 sm:py-2.5 sm:px-4">
           <BrandMark />
 
-          <nav className="hidden md:flex items-center gap-6 lg:gap-8">
-            {navLinks.map((l) =>
-              l.to === "/about" ? (
-                <NavLink
-                  key={l.label}
-                  to={l.to}
-                  className={({ isActive }) => linkClass(isActive)}
-                >
-                  {l.label}
-                </NavLink>
-              ) : (
-                <Link key={l.label} to={l.to} className={linkClass()}>
-                  {l.label}
-                </Link>
-              )
-            )}
+          <nav className="hidden md:flex items-center gap-1 absolute left-1/2 -translate-x-1/2">
+            {navLinks.map((l) => (
+              <NavLink
+                key={l.label}
+                to={l.to}
+                className={({ isActive }) => linkClass(isActive)}
+              >
+                {l.label}
+              </NavLink>
+            ))}
           </nav>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <button
               type="button"
-              onClick={() => navigate("/dashboard")}
-              className="font-body-ui font-semibold text-[13px] text-black bg-white hover:bg-white/90 border-none rounded-full px-4 sm:px-5 py-2 cursor-pointer transition-ui whitespace-nowrap"
+              onClick={() => navigate("/signin")}
+              className="hidden sm:inline-flex font-body-ui font-medium text-[14px] text-white bg-[#7E56D9] hover:bg-[#6941C6] border border-transparent rounded-full px-5 py-2 cursor-pointer transition-all shadow-[0_2px_8px_rgba(126,86,217,0.3)] hover:shadow-[0_4px_12px_rgba(126,86,217,0.4)] hover:-translate-y-0.5 active:translate-y-0"
             >
-              Launch
+              Sign In
             </button>
 
             <button
@@ -118,61 +117,82 @@ function MarketingNavBar() {
               aria-label={menuOpen ? "Close menu" : "Open menu"}
               aria-expanded={menuOpen}
               onClick={() => setMenuOpen((o) => !o)}
-              className="md:hidden flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-white/5 text-white cursor-pointer"
+              className="md:hidden flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-gray-50 text-[#0C1220] cursor-pointer hover:bg-gray-100 transition-colors"
             >
               <span className="sr-only">Menu</span>
-              <span className="flex flex-col gap-1.5" aria-hidden="true">
+              <span className="flex flex-col gap-[5px]" aria-hidden="true">
                 <span
-                  className={`block h-px w-3.5 bg-white transition-ui ${
-                    menuOpen ? "translate-y-[3.5px] rotate-45" : ""
+                  className={`block h-[1.5px] w-[18px] bg-current transition-transform duration-300 ${
+                    menuOpen ? "translate-y-[6.5px] rotate-45" : ""
                   }`}
                 />
                 <span
-                  className={`block h-px w-3.5 bg-white transition-ui ${
-                    menuOpen ? "-translate-y-[3.5px] -rotate-45" : ""
+                  className={`block h-[1.5px] w-[18px] bg-current transition-opacity duration-300 ${
+                    menuOpen ? "opacity-0" : ""
+                  }`}
+                />
+                <span
+                  className={`block h-[1.5px] w-[18px] bg-current transition-transform duration-300 ${
+                    menuOpen ? "-translate-y-[6.5px] -rotate-45" : ""
                   }`}
                 />
               </span>
             </button>
           </div>
         </div>
+      </motion.div>
 
-        <AnimatePresence>
-          {menuOpen && (
+      <AnimatePresence>
+        {menuOpen && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="fixed inset-0 bg-[#0C1220]/40 backdrop-blur-sm z-[-1] pointer-events-auto md:hidden"
+              onClick={() => setMenuOpen(false)}
+            />
             <motion.nav
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: "auto", opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.25 }}
-              className="md:hidden overflow-hidden border-t border-white/10"
+              initial={{ opacity: 0, y: -10, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -10, scale: 0.95 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="absolute top-full mt-3 left-4 right-4 bg-white rounded-3xl p-4 shadow-xl border border-black/[0.04] md:hidden pointer-events-auto z-10"
             >
-              <div className="flex flex-col gap-1 px-5 py-3 pb-4">
-                {navLinks.map((l) =>
-                  l.to === "/about" ? (
-                    <NavLink
-                      key={l.label}
-                      to={l.to}
-                      className={({ isActive }) =>
-                        `${linkClass(isActive)} py-2`
-                      }
-                    >
-                      {l.label}
-                    </NavLink>
-                  ) : (
-                    <Link
-                      key={l.label}
-                      to={l.to}
-                      className={`${linkClass()} py-2`}
-                    >
-                      {l.label}
-                    </Link>
-                  )
-                )}
+              <div className="flex flex-col gap-1">
+                {navLinks.map((l) => (
+                  <NavLink
+                    key={l.label}
+                    to={l.to}
+                    className={({ isActive }) =>
+                      `font-body-ui text-[15px] font-medium transition-all px-4 py-3 rounded-2xl ${
+                        isActive
+                          ? "text-[#0C1220] bg-gray-50"
+                          : "text-[#5F6A80] hover:text-[#0C1220] hover:bg-gray-50"
+                      }`
+                    }
+                  >
+                    {l.label}
+                  </NavLink>
+                ))}
+                <div className="mt-2 pt-3 border-t border-gray-100 px-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      navigate("/signin");
+                    }}
+                    className="w-full font-body-ui font-medium text-[15px] text-white bg-[#7E56D9] hover:bg-[#6941C6] rounded-2xl px-5 py-3.5 transition-colors text-center"
+                  >
+                    Sign In
+                  </button>
+                </div>
               </div>
             </motion.nav>
-          )}
-        </AnimatePresence>
-      </motion.div>
+          </>
+        )}
+      </AnimatePresence>
     </header>
   );
 }

--- a/frontend/src/pages/PlaceholderPage.tsx
+++ b/frontend/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { motion } from "framer-motion";
+
+interface PlaceholderPageProps {
+  title: string;
+  description: string;
+}
+
+export const PlaceholderPage: React.FC<PlaceholderPageProps> = ({ title, description }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-[#0C1220] flex items-center justify-center p-6 text-[#E7EBF3] selection:bg-[#4FE0C8]/30 pt-[calc(var(--header-height,80px)+2rem)]">
+      <div
+        className="pointer-events-none absolute inset-0 opacity-40 mix-blend-screen"
+        style={{
+          background: "radial-gradient(ellipse 60% 80% at 50% 0%, rgba(79,224,200,0.1), transparent 70%)",
+        }}
+      />
+      
+      <motion.div 
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+        className="max-w-2xl w-full text-center relative z-10"
+      >
+        <div className="inline-flex items-center justify-center h-16 w-16 rounded-2xl bg-white/5 border border-white/10 mb-8 shadow-[0_0_40px_rgba(79,224,200,0.1)]">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-[#4FE0C8]">
+            <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path>
+            <polyline points="14 2 14 8 20 8"></polyline>
+          </svg>
+        </div>
+        
+        <h1 className="font-display-lg text-4xl sm:text-5xl font-bold mb-4 tracking-tight text-white">
+          {title}
+        </h1>
+        
+        <p className="font-body-ui text-lg text-[#8892A6] mb-12 max-w-lg mx-auto leading-relaxed">
+          {description}
+        </p>
+        
+        <button
+          onClick={() => navigate("/")}
+          className="inline-flex items-center gap-2 px-6 py-3 bg-white text-black font-semibold rounded-full hover:bg-white/90 transition-all hover:gap-3 focus:outline-none focus:ring-2 focus:ring-[#4FE0C8] focus:ring-offset-2 focus:ring-offset-[#0C1220]"
+        >
+          <ArrowLeft size={18} />
+          <span>Back to Home</span>
+        </button>
+      </motion.div>
+    </div>
+  );
+};
+
+export const ProductPage = () => <PlaceholderPage title="Product" description="Explore our orbital intelligence platform features and capabilities." />;
+export const SolutionsPage = () => <PlaceholderPage title="Solutions" description="Tailored solutions for satellite operators and space traffic management." />;
+export const DevelopersPage = () => <PlaceholderPage title="Developers" description="API documentation, SDKs, and resources for developers building with Kepler." />;
+export const DocsPage = () => <PlaceholderPage title="Documentation" description="Comprehensive guides and references for the Kepler platform." />;
+export const SignInPage = () => <PlaceholderPage title="Sign In" description="Sign in to your Kepler account to access the dashboard." />;


### PR DESCRIPTION
## Description

This PR redesigns the website header to match the latest design mockup and resolves the hero section overlap caused by the fixed header.

### Changes Made

* Redesigned the header with a white rounded container.
* Updated logo placement to match the new design.
* Centered navigation links with improved spacing and typography.
* Restyled the **Sign In** button with the new purple rounded appearance.
* Updated the header height and padding for better visual consistency.
* Added appropriate top spacing to the hero section to prevent content from being hidden beneath the fixed header.
* Ensured the updated header remains fully responsive across desktop, tablet, and mobile devices.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Related Issue

Fixes #60

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have updated the documentation if needed
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [x] New and existing tests pass locally

## Screenshots 
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/e54e5388-c3e7-49a6-8614-74f1e4e9c442" />

## Additional Notes

This PR focuses on aligning the header with the latest UI design while improving the overall user experience by eliminating the hero section overlap. The implementation preserves responsiveness across all supported screen sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routes for Product, Solutions, Developers, Docs, and Sign In pages.
  * Added styled placeholder pages with navigation back to the home page.
  * Updated navigation links to use dedicated routes.
  * Replaced the primary “Launch” action with a “Sign In” button.
  * Improved mobile navigation with an overlay and animated menu panel.

* **Style**
  * Refined branding, navigation states, and logo presentation.
  * Adjusted hero spacing for improved page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR redesigns the marketing header from a dark pill-style navbar into a white rounded container with centered navigation, a purple "Sign In" CTA, and an improved mobile drawer with backdrop overlay. It also adds top padding to the Hero section to prevent content from hiding beneath the fixed header, and introduces five new placeholder pages for the updated nav links.

- **Header redesign**: The `MarketingNavBar` is rebuilt with `bg-white/95 backdrop-blur-md rounded-full`, centered nav links via absolute positioning, a purple "Sign In" button replacing the old "Launch" CTA, and a new three-bar animated hamburger with a full-screen backdrop on mobile.
- **Hero overlap fix**: `pt-[120px] sm:pt-[160px] pb-12` is added to the Hero content wrapper; the values overshoot the actual header height (~60–72px) and will leave visible extra blank space above the hero text.
- **Placeholder routes**: Five new routes (`/product`, `/solutions`, `/developers`, `/docs`, `/signin`) each render a generic `PlaceholderPage`; the `/signin` route in particular replaces the previously functional `/dashboard` shortcut with a dead-end page that has no authentication path.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that the Sign In button now leads to a dead-end placeholder rather than any auth flow, and that the hero section has more top clearance than the header actually requires.

The visual redesign is well-structured and the responsiveness logic is sound. The nav absolute-positioning pattern works at all current breakpoints due to the pill being centered in a full-width header, so there is no runtime breakage. The more notable concern is the `/signin` route: the old header sent users directly to `/dashboard`, but the new Sign In button routes to a placeholder page with no authentication mechanism, silently removing the only user path to the app. The hero padding overshoot is cosmetic but noticeably adds blank space on mobile.

`PlaceholderPage.tsx` deserves a second look — particularly `SignInPage`, which replaced a functional dashboard shortcut with a page that offers users no way to authenticate or navigate to the app. `MarketingLayout.tsx` should have `relative` added to the pill container to make the centered nav's positioning intent explicit.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/layouts/MarketingLayout.tsx | Full header redesign — new pill-shaped white navbar, centered nav via absolute positioning without a `relative` anchor on the pill container, nav links updated to new routes, mobile drawer replaced with a modal-style overlay, and the "Launch" CTA replaced with "Sign In" navigating to `/signin`. |
| frontend/src/components/Hero.tsx | Added `pt-[120px] sm:pt-[160px] pb-12` to the content wrapper to clear the fixed header; padding values are larger than the actual header height (~60–72px), creating noticeable extra blank space above the hero text. |
| frontend/src/pages/PlaceholderPage.tsx | New file exporting five placeholder pages (Product, Solutions, Developers, Docs, SignIn); background gradient overlay uses `absolute inset-0` without `relative` on the parent, and `SignInPage` provides no authentication mechanism. |
| frontend/src/App.tsx | Adds five new routes (`/product`, `/solutions`, `/developers`, `/docs`, `/signin`) inside the `MarketingLayout` wrapper, all pointing to the new placeholder pages. |
| frontend/package-lock.json | Metadata-only changes: adds `"peer": true` annotations to several packages and removes two optional `@emnapi` entries; no version changes to any dependencies. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits site] --> B[MarketingLayout renders]
    B --> C[MarketingNavBar fixed header]
    C --> D{Screen size?}
    D -- md+ desktop --> E[Pill navbar with centered absolute nav]
    D -- mobile --> F[Hamburger button]
    F --> G[Mobile drawer + backdrop overlay]
    E --> H{Nav link clicked}
    G --> H
    H -- /product --> I[ProductPage placeholder]
    H -- /solutions --> J[SolutionsPage placeholder]
    H -- /developers --> K[DevelopersPage placeholder]
    H -- /docs --> L[DocsPage placeholder]
    H -- /dashboard --> M[Dashboard app]
    H -- Sign In button --> N[SignInPage placeholder]
    N --> O[Back to Home button only - no auth form]
    style N fill:#ffd6d6,stroke:#cc0000
    style O fill:#ffd6d6,stroke:#cc0000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User visits site] --> B[MarketingLayout renders]
    B --> C[MarketingNavBar fixed header]
    C --> D{Screen size?}
    D -- md+ desktop --> E[Pill navbar with centered absolute nav]
    D -- mobile --> F[Hamburger button]
    F --> G[Mobile drawer + backdrop overlay]
    E --> H{Nav link clicked}
    G --> H
    H -- /product --> I[ProductPage placeholder]
    H -- /solutions --> J[SolutionsPage placeholder]
    H -- /developers --> K[DevelopersPage placeholder]
    H -- /docs --> L[DocsPage placeholder]
    H -- /dashboard --> M[Dashboard app]
    H -- Sign In button --> N[SignInPage placeholder]
    N --> O[Back to Home button only - no auth form]
    style N fill:#ffd6d6,stroke:#cc0000
    style O fill:#ffd6d6,stroke:#cc0000
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
frontend/src/components/layouts/MarketingLayout.tsx:94
**Nav absolute positioning lacks a `relative` anchor**

The `<nav>` uses `absolute left-1/2 -translate-x-1/2` but its closest ancestor that creates a positioning context is the `<header>` (`fixed`), not the pill `motion.div`. `motion.div` has no `position: relative`, so `left: 50%` is 50% of the full viewport, not 50% of the pill. It currently renders correctly only because the pill itself is centered within the full-width header — but if the pill's centering ever changes (e.g. left-aligned layout, padding offset) the nav will misalign. Adding `relative` to the `motion.div` pins the positioning to the pill and makes the intent explicit.

### Issue 2 of 4
frontend/src/pages/PlaceholderPage.tsx:14-21
**Background overlay escapes its container without `relative` on the parent**

The inner `<div className="pointer-events-none absolute inset-0 ...">` is positioned relative to the nearest positioned ancestor, which here is NOT the outer wrapper div (it has no positioning class). The element will be positioned relative to the viewport (or a higher ancestor), causing the gradient to potentially bleed into the header and footer areas rendered by `MarketingLayout`. Adding `relative` to the outer container div fixes the containment.

### Issue 3 of 4
frontend/src/pages/PlaceholderPage.tsx:59-60
**`SignInPage` provides no authentication path**

The "Sign In" button in the header now navigates to `/signin`, which renders a `PlaceholderPage` with a document icon and a single "Back to Home" button. There is no login form, redirect to an auth provider, or any mechanism to actually authenticate. Users who click "Sign In" will land on a dead-end page with no actionable path forward. This is especially notable because the old header routed users directly to `/dashboard` — this PR replaces that functional navigation with a non-functional placeholder.

### Issue 4 of 4
frontend/src/components/Hero.tsx:42
**Hero top padding substantially overshoots the actual header height**

The new header height is approximately `pt-4` (16px) + pill height (~44px) ≈ 60px on mobile and `pt-6` (24px) + pill (~48px) ≈ 72px on `sm:+`. Using `pt-[120px]` / `pt-[160px]` adds roughly 48–88px of extra blank space above the hero content on top of the clearance already provided by the flex centering. The `PlaceholderPage` already uses a `--header-height` CSS variable approach as a fallback (`var(--header-height, 80px)`); a consistent approach here — or simply tighter values like `pt-[80px] sm:pt-[96px]` — would remove the visual gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Redesign Header to Match New Design &amp; Fi..."](https://github.com/7-blocks/kepler/commit/e233902b67c1ca5ddcd3aed9f0d8c2e3bd9bd003) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45066045)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->