### PR TITLE
feat: update navbar design for dark theme consistency Closes#71

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,7 +82,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -790,6 +789,27 @@
       "resolved": "https://registry.npmjs.org/@dotenvx/primitives/-/primitives-0.8.0.tgz",
       "integrity": "sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -2081,7 +2101,6 @@
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2092,7 +2111,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2103,7 +2121,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2172,7 +2189,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2497,7 +2513,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2744,7 +2759,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2846,7 +2860,6 @@
       "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.142.0.tgz",
       "integrity": "sha512-Z6mBxdeBS0lEXM7WAQgG8Q0FovXYAJpZsMOSWgd7dH28Ov+djJxWOlUMiG8jOai0TzeOYdYsMLgnYb2uB/aI/A==",
       "license": "Apache-2.0",
-      "peer": true,
       "workspaces": [
         "packages/engine",
         "packages/widgets",
@@ -3257,7 +3270,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3347,7 +3359,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
       "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -3705,7 +3716,6 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4553,7 +4563,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4617,7 +4626,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6290,7 +6298,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6300,7 +6307,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6313,7 +6319,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6337,7 +6342,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6444,8 +6448,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7297,7 +7300,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7482,7 +7484,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7668,7 +7669,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/layouts/MarketingLayout.tsx
+++ b/frontend/src/components/layouts/MarketingLayout.tsx
@@ -56,13 +56,12 @@ function BrandMark() {
           className="h-5 w-5 object-contain"
         />
       </div>
-      <span className="font-necosmic text-[16px] text-[#0C1220] tracking-wide font-medium">
+      <span className="font-necosmic text-[16px] text-white tracking-wide font-medium">
         Kepler
       </span>
     </Link>
   );
 }
-
 function MarketingNavBar() {
   const navigate = useNavigate();
   const reduce = useReducedMotion();
@@ -74,10 +73,10 @@ function MarketingNavBar() {
   }, [location.pathname, location.hash]);
 
   const linkClass = (active?: boolean) =>
-    `relative font-body-ui text-[14px] font-medium transition-all no-underline px-3 py-2 rounded-full ${
-      active 
-        ? "text-[#0C1220] bg-gray-100" 
-        : "text-[#5F6A80] hover:text-[#0C1220] hover:bg-gray-50"
+    `relative font-body-ui text-[14px] font-medium transition-all duration-300 no-underline px-4 py-2 rounded-full ${
+      active
+        ? "text-white bg-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]"
+        : "text-neutral-400 hover:text-white hover:bg-white/5"
     }`;
 
   return (
@@ -86,7 +85,7 @@ function MarketingNavBar() {
         initial={reduce ? false : { y: -28, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-        className="pointer-events-auto w-[calc(100%-32px)] max-w-[1100px] mx-auto bg-white/95 backdrop-blur-md rounded-full border border-black/[0.04] shadow-[0_8px_32px_rgba(0,0,0,0.06)]"
+        className="pointer-events-auto w-[calc(100%-32px)] max-w-[1100px] mx-auto bg-black/40 backdrop-blur-lg rounded-full border border-white/40 shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
       >
         <div className="flex items-center justify-between gap-3 px-3 py-2 sm:py-2.5 sm:px-4">
           <BrandMark />
@@ -107,7 +106,7 @@ function MarketingNavBar() {
             <button
               type="button"
               onClick={() => navigate("/signin")}
-              className="hidden sm:inline-flex font-body-ui font-medium text-[14px] text-white bg-[#7E56D9] hover:bg-[#6941C6] border border-transparent rounded-full px-5 py-2 cursor-pointer transition-all shadow-[0_2px_8px_rgba(126,86,217,0.3)] hover:shadow-[0_4px_12px_rgba(126,86,217,0.4)] hover:-translate-y-0.5 active:translate-y-0"
+              className="hidden sm:inline-flex font-body-ui font-medium text-[14px] text-black bg-white hover:bg-gray-200 border border-transparent rounded-full px-5 py-2 cursor-pointer transition-all duration-300 shadow-[0_0_15px_rgba(255,255,255,0.2)] hover:shadow-[0_0_20px_rgba(255,255,255,0.4)] hover:-translate-y-0.5 active:translate-y-0"
             >
               Sign In
             </button>
@@ -117,7 +116,7 @@ function MarketingNavBar() {
               aria-label={menuOpen ? "Close menu" : "Open menu"}
               aria-expanded={menuOpen}
               onClick={() => setMenuOpen((o) => !o)}
-              className="md:hidden flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-gray-50 text-[#0C1220] cursor-pointer hover:bg-gray-100 transition-colors"
+              className="md:hidden flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white cursor-pointer hover:bg-white/10 transition-colors"
             >
               <span className="sr-only">Menu</span>
               <span className="flex flex-col gap-[5px]" aria-hidden="true">
@@ -149,8 +148,8 @@ function MarketingNavBar() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              className="fixed inset-0 bg-[#0C1220]/40 backdrop-blur-sm z-[-1] pointer-events-auto md:hidden"
+              transition={{ duration: 0.3 }}
+              className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[-1] pointer-events-auto md:hidden"
               onClick={() => setMenuOpen(false)}
             />
             <motion.nav
@@ -158,7 +157,7 @@ function MarketingNavBar() {
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: -10, scale: 0.95 }}
               transition={{ duration: 0.2, ease: "easeOut" }}
-              className="absolute top-full mt-3 left-4 right-4 bg-white rounded-3xl p-4 shadow-xl border border-black/[0.04] md:hidden pointer-events-auto z-10"
+              className="absolute top-full mt-3 left-4 right-4 bg-[#0A0A0A] rounded-3xl p-4 shadow-2xl border border-white/10 md:hidden pointer-events-auto z-10"
             >
               <div className="flex flex-col gap-1">
                 {navLinks.map((l) => (
@@ -168,22 +167,22 @@ function MarketingNavBar() {
                     className={({ isActive }) =>
                       `font-body-ui text-[15px] font-medium transition-all px-4 py-3 rounded-2xl ${
                         isActive
-                          ? "text-[#0C1220] bg-gray-50"
-                          : "text-[#5F6A80] hover:text-[#0C1220] hover:bg-gray-50"
+                          ? "text-white bg-white/10"
+                          : "text-neutral-400 hover:text-white hover:bg-white/5"
                       }`
                     }
                   >
                     {l.label}
                   </NavLink>
                 ))}
-                <div className="mt-2 pt-3 border-t border-gray-100 px-1">
+                <div className="mt-2 pt-3 border-t border-white/10 px-1">
                   <button
                     type="button"
                     onClick={() => {
                       setMenuOpen(false);
                       navigate("/signin");
                     }}
-                    className="w-full font-body-ui font-medium text-[15px] text-white bg-[#7E56D9] hover:bg-[#6941C6] rounded-2xl px-5 py-3.5 transition-colors text-center"
+                    className="w-full font-body-ui font-medium text-[15px] text-black bg-white hover:bg-gray-200 rounded-2xl px-5 py-3.5 transition-colors text-center shadow-[0_0_15px_rgba(255,255,255,0.1)]"
                   >
                     Sign In
                   </button>

--- a/frontend/src/components/layouts/MarketingLayout.tsx
+++ b/frontend/src/components/layouts/MarketingLayout.tsx
@@ -85,7 +85,7 @@ function MarketingNavBar() {
         initial={reduce ? false : { y: -28, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-        className="pointer-events-auto w-[calc(100%-32px)] max-w-[1100px] mx-auto bg-black/40 backdrop-blur-lg rounded-full border border-white/40 shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
+        className="pointer-events-auto w-[calc(100%-32px)] max-w-[900px] mx-auto bg-black/40 backdrop-blur-lg rounded-full border border-white/40 shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
       >
         <div className="flex items-center justify-between gap-3 px-3 py-2 sm:py-2.5 sm:px-4">
           <BrandMark />


### PR DESCRIPTION
## **User description**
## Description

Updated the MarketingNavBar component to align with the platform's dark space theme.

Replaced the white solid background with a dark glassmorphic effect (bg-black/40 with backdrop-blur-lg).

Added distinct active states using grayish backgrounds and inner shadows to clarify the user's current page.

Improved hover states for better visual feedback.

Updated the "Sign In" button to a high-contrast white-on-black style to match modern dark UI trends.

Slightly reduced the navbar size from 1100px to 900px

## Related Issue

Fixes #71

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [ ] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings
Before:
<img width="1900" height="904" alt="Screenshot 2026-07-17 193416" src="https://github.com/user-attachments/assets/ba8cd71a-654c-43f7-98c9-b25df63d615b" />
<img width="415" height="664" alt="image" src="https://github.com/user-attachments/assets/c73c0169-1ba1-49aa-9be2-d0e0685cd305" />


After:
<img width="1904" height="902" alt="Screenshot 2026-07-17 193245" src="https://github.com/user-attachments/assets/5dc64903-6241-4a7a-987d-0b8f4a509911" />
<img width="440" height="703" alt="image" src="https://github.com/user-attachments/assets/9379afea-df04-4a37-9136-27d5dfac4911" />

Glossy effect:
<img width="1239" height="187" alt="image" src="https://github.com/user-attachments/assets/a50f694c-c15b-4f42-a975-eb93a2229e9b" />



## Breaking Changes

None. This is purely a frontend UI/UX enhancement and does not alter core routing or application logic.

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [x] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced


___

## **CodeAnt-AI Description**
**Refresh the marketing navbar for the dark theme**

### What Changed
- Updated the top marketing navbar to use a dark glass-style look with brighter text and links that fit the site’s dark theme
- Active and hover states now stand out more clearly on both desktop and mobile
- The Sign In button now uses a light, high-contrast style in the desktop and mobile menus
- The mobile menu overlay and dropdown now match the darker visual style and feel more consistent with the rest of the page

### Impact
`✅ Clearer navigation on dark pages`
`✅ Easier to spot the current page`
`✅ More consistent mobile menu styling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated marketing navigation styling for improved light/dark theme consistency.
  * Refreshed desktop and mobile headers with darker translucent backgrounds, enhanced blur, and updated borders and shadows.
  * Restyled navigation links, menu controls, and “Sign In” buttons for clearer contrast and consistent hover states.
  * Updated the mobile menu overlay and dropdown appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reskins the `MarketingNavBar` component from a light/white floating pill to a dark glassmorphic style (`bg-black/40 + backdrop-blur-lg`), updates all link, button, and overlay colours to match the existing dark-space page theme, and reduces the navbar max-width from 1100 px to 900 px.

- **Navbar restyle**: background, border, text, and shadow values across desktop nav, mobile hamburger button, mobile overlay, and mobile drawer are all updated consistently to a dark/semi-transparent palette; the Sign-In CTA changes from purple to white-on-black.
- **package-lock.json**: unrelated lock-file drift is bundled into the PR — `\"peer\": true` is stripped from ~15 existing packages and two new optional `@emnapi` packages appear, likely from a local `npm install` under a different npm version.

<h3>Confidence Score: 3/5</h3>

The UI changes are self-contained and low-risk, but the package-lock.json mutation needs to be resolved before merging.

The navbar restyle is coherent and visually consistent. The only cosmetic concern is the 40% opacity border that stands out against the otherwise subtle glassmorphic treatment. More importantly, package-lock.json has been regenerated under a different npm version, silently reclassifying ~15 packages by stripping their peer metadata and introducing two new optional @emnapi entries unrelated to the UI change.

frontend/package-lock.json — the lock-file drift is unrelated to the UI change and should be reverted or addressed in a dedicated commit.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/layouts/MarketingLayout.tsx | Dark glassmorphic navbar restyle: bg-black/40 + backdrop-blur-lg, white text, white Sign-In button, max-width narrowed 1100px to 900px, mobile menu and overlay updated consistently. |
| frontend/package-lock.json | Multiple peer:true fields stripped from lock-file entries and two new optional @emnapi packages added — appears to be an unintended artifact of running npm install under a different npm version, not related to the navbar change. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/package-lock.json`, line 82-88 ([link](https://github.com/7-blocks/kepler/blob/74a8c1d1a26c07c6cda5f22cdb580db804f70131/frontend/package-lock.json#L82-L88)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unrelated lock-file mutation included in PR** — This diff strips `"peer": true` from ~15 unrelated packages (`react`, `react-dom`, `vite`, `zod`, `redux`, `cesium`, `hono`, `date-fns`, TypeScript, and others) and adds two new optional `@emnapi/core` / `@emnapi/runtime` entries. These changes are characteristic of regenerating the lock file under a different npm version and have nothing to do with the navbar restyle. Committing them alongside a UI change adds noise to the git history, makes it harder to audit dependency changes, and could cause issues if other contributors are on the npm version that expects `"peer": true` in those entries. Consider reverting `package-lock.json` to its original state (or regenerating it in a dedicated commit) before merging.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/package-lock.json
   Line: 82-88

   Comment:
   **Unrelated lock-file mutation included in PR** — This diff strips `"peer": true` from ~15 unrelated packages (`react`, `react-dom`, `vite`, `zod`, `redux`, `cesium`, `hono`, `date-fns`, TypeScript, and others) and adds two new optional `@emnapi/core` / `@emnapi/runtime` entries. These changes are characteristic of regenerating the lock file under a different npm version and have nothing to do with the navbar restyle. Committing them alongside a UI change adds noise to the git history, makes it harder to audit dependency changes, and could cause issues if other contributors are on the npm version that expects `"peer": true` in those entries. Consider reverting `package-lock.json` to its original state (or regenerating it in a dedicated commit) before merging.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
frontend/src/components/layouts/MarketingLayout.tsx:88
The desktop navbar uses `border-white/40` (40% opacity) while every other newly-styled dark element in the same component — the mobile menu button, mobile nav drawer, and the active/hover backgrounds — consistently uses `border-white/10`. The 40% border reads as quite stark against the semi-transparent `bg-black/40` background and breaks the subtle glassmorphic treatment applied everywhere else in this update.

```suggestion
        className="pointer-events-auto w-[calc(100%-32px)] max-w-[900px] mx-auto bg-black/40 backdrop-blur-lg rounded-full border border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
```

### Issue 2 of 2
frontend/package-lock.json:82-88
**Unrelated lock-file mutation included in PR** — This diff strips `"peer": true` from ~15 unrelated packages (`react`, `react-dom`, `vite`, `zod`, `redux`, `cesium`, `hono`, `date-fns`, TypeScript, and others) and adds two new optional `@emnapi/core` / `@emnapi/runtime` entries. These changes are characteristic of regenerating the lock file under a different npm version and have nothing to do with the navbar restyle. Committing them alongside a UI change adds noise to the git history, makes it harder to audit dependency changes, and could cause issues if other contributors are on the npm version that expects `"peer": true` in those entries. Consider reverting `package-lock.json` to its original state (or regenerating it in a dedicated commit) before merging.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: minor change of navbar width"](https://github.com/7-blocks/kepler/commit/74a8c1d1a26c07c6cda5f22cdb580db804f70131) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45095936)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->