### PR TITLE
chore: update actions/github-script to v8

### DIFF
--- a/.github/workflows/ecsoc26-auto-label.yml
+++ b/.github/workflows/ecsoc26-auto-label.yml
@@ -60,7 +60,7 @@ jobs:
       # actions/github-script, which already provides the `github`, `context`,
       # and `core` objects – no extra setup needed.
       - name: Apply ECSoC26 Labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Description

This PR updates the ECSoC26 auto-labeler workflow to use `actions/github-script@v8` instead of `v7`.

### Changes
- Updated `actions/github-script` from `v7` to `v8`.
- Aligns the workflow with the latest GitHub Actions runtime.
- Helps address the Node.js runtime deprecation mentioned in the issue.

## Related Issue

Fixes #64

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [ ] I have completed testing of my changes
- [ ] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings

N/A

## Breaking Changes

No breaking changes.

---

## ECSoC26 Submission

- [x] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated ECSoC26 labeling workflow to use the latest supported GitHub Actions scripting version.
  - Labeling behavior and configuration remain unchanged.
  - No user-facing product changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `actions/github-script` from `v7` to `v8` in the ECSoC26 auto-labeler workflow. The `v8` release moves the action from the deprecated Node.js 16 runtime to Node.js 20, addressing the deprecation warning referenced in issue #64.

- The single changed line is in `.github/workflows/ecsoc26-auto-label.yml`; all other workflow structure (permissions, trigger events, checkout strategy, script inputs) is unchanged.
- The `github`, `context`, and `core` objects passed to the local labeler script have the same signatures in v8, so no changes to `.github/scripts/ecsoc26-labeler.js` are required.

<h3>Confidence Score: 5/5</h3>

This is a minimal, focused version bump with no structural workflow changes; safe to merge as-is.

The only change is one line replacing actions/github-script@v7 with @v8. The action's public API (the github, context, and core objects, the github-token input, and the require() pattern for loading local scripts) is fully compatible between v7 and v8. The rest of the workflow — pull_request_target trigger, least-privilege permissions, base-branch checkout — is untouched and continues to follow good security practices.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ecsoc26-auto-label.yml | Single-line version bump of actions/github-script from v7 to v8, upgrading the underlying Node.js runtime from 16 to 20; no API changes affect this usage pattern. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Events
    participant WF as ecsoc26-auto-label workflow
    participant CO as actions/checkout@v4
    participant GS as actions/github-script@v8 (Node 20)
    participant LS as ecsoc26-labeler.js
    participant API as GitHub Labels API

    GH->>WF: pull_request_target (opened/edited/synchronize/…)
    WF->>CO: checkout base branch (default_branch)
    CO-->>WF: trusted repo code available
    WF->>GS: run with github-token + inline script
    GS->>LS: require('.github/scripts/ecsoc26-labeler.js')
    LS->>API: addLabels (ECSoC26, ECSoC26-L1/L2/L3)
    API-->>LS: 200 OK
    LS-->>GS: done
    GS-->>WF: step complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Events
    participant WF as ecsoc26-auto-label workflow
    participant CO as actions/checkout@v4
    participant GS as actions/github-script@v8 (Node 20)
    participant LS as ecsoc26-labeler.js
    participant API as GitHub Labels API

    GH->>WF: pull_request_target (opened/edited/synchronize/…)
    WF->>CO: checkout base branch (default_branch)
    CO-->>WF: trusted repo code available
    WF->>GS: run with github-token + inline script
    GS->>LS: require('.github/scripts/ecsoc26-labeler.js')
    LS->>API: addLabels (ECSoC26, ECSoC26-L1/L2/L3)
    API-->>LS: 200 OK
    LS-->>GS: done
    GS-->>WF: step complete
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore: update actions/github-script to v..."](https://github.com/7-blocks/kepler/commit/3704db05c5f987509555320649dd8a7a336735a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45437651)</sub>

<!-- /greptile_comment -->