### PR TITLE
feat: add authentication pages with Google OAuth sign-in

### DIFF
--- a/backend/api/v1/endpoints/auth.py
+++ b/backend/api/v1/endpoints/auth.py
@@ -1,27 +1,48 @@
+import logging
+import secrets
+
+import httpx
 from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
 from database.session import get_db
 from models.db_models import User, Role, Organization
-from schemas.api_schemas import APIResponse, Token, UserResponse, UserCreate
-from app.core.exceptions import ConflictError, UnauthorizedError
-from app.core.security import verify_password, get_password_hash, create_access_token, create_refresh_token
-import logging
+from schemas.api_schemas import (
+    APIResponse,
+    Token,
+    UserResponse,
+    UserCreate,
+    GoogleAuthRequest,
+)
+from app.core.config import settings
+from app.core.exceptions import (
+    ConflictError,
+    UnauthorizedError,
+    BadRequestError,
+)
+from app.core.security import (
+    verify_password,
+    get_password_hash,
+    create_access_token,
+    create_refresh_token,
+)
+
+logger = logging.getLogger("app.auth")
 
 router = APIRouter()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
 
-@router.post("/register", response_model=APIResponse[UserResponse])
-def register(user_in: UserCreate, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.email == user_in.email).first()
-    if user:
-        raise ConflictError(
-            "An operator is already registered with this email address.",
-            details={"field": "email", "value": user_in.email},
-        )
+GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+GOOGLE_TOKENINFO_URL = "https://oauth2.googleapis.com/tokeninfo"
 
-    hashed_pwd = get_password_hash(user_in.password)
 
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _default_org_and_role(db: Session) -> tuple[Organization, Role]:
+    """Return the default organisation/role, creating them on first use."""
     org = db.query(Organization).first()
     if not org:
         org = Organization(name="Global Space Command")
@@ -36,9 +57,39 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
         db.commit()
         db.refresh(role)
 
+    return org, role
+
+
+def _issue_tokens(user: User) -> Token:
+    """Mint an access/refresh token pair for an authenticated user."""
+    return Token(
+        access_token=create_access_token(subject=user.email),
+        refresh_token=create_refresh_token(subject=user.email),
+        token_type="bearer",
+        user=UserResponse.model_validate(user),
+    )
+
+
+# ---------------------------------------------------------------------------
+# email / password
+# ---------------------------------------------------------------------------
+
+@router.post("/register", response_model=APIResponse[UserResponse])
+def register(user_in: UserCreate, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == user_in.email).first()
+    if user:
+        raise ConflictError(
+            "An operator is already registered with this email address.",
+            details={"field": "email", "value": user_in.email},
+        )
+
+    org, role = _default_org_and_role(db)
+
     user = User(
         email=user_in.email,
-        hashed_password=hashed_pwd,
+        full_name=user_in.full_name,
+        hashed_password=get_password_hash(user_in.password),
+        auth_provider="local",
         role_id=user_in.role_id or role.id,
         organization_id=user_in.organization_id or org.id,
     )
@@ -52,17 +103,142 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
         data=UserResponse.model_validate(user),
     )
 
+
 @router.post("/token", response_model=Token)
-def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
     user = db.query(User).filter(User.email == form_data.username).first()
-    if not user or not verify_password(form_data.password, user.hashed_password):
+    if not user or not user.hashed_password or not verify_password(
+        form_data.password, user.hashed_password
+    ):
         raise UnauthorizedError("Incorrect email or password.")
 
-    access_token = create_access_token(subject=user.email)
-    refresh_token = create_refresh_token(subject=user.email)
+    return _issue_tokens(user)
 
-    return Token(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        token_type="bearer",
-    )
+
+# ---------------------------------------------------------------------------
+# Google OAuth
+# ---------------------------------------------------------------------------
+
+def _verify_google_token(payload: GoogleAuthRequest) -> dict:
+    """
+    Resolve a verified Google profile from either an access token or an id_token.
+
+    Both paths call Google directly, so a client can never forge a profile: the
+    token has to have been minted by Google. When ``GOOGLE_CLIENT_ID`` is set we
+    additionally assert the token's audience matches, so tokens issued for a
+    *different* application are rejected.
+    """
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            if payload.id_token:
+                resp = client.get(
+                    GOOGLE_TOKENINFO_URL, params={"id_token": payload.id_token}
+                )
+                resp.raise_for_status()
+                info = resp.json()
+                aud = info.get("aud")
+            elif payload.access_token:
+                # Confirm the access token belongs to us, then read the profile.
+                token_resp = client.get(
+                    GOOGLE_TOKENINFO_URL,
+                    params={"access_token": payload.access_token},
+                )
+                token_resp.raise_for_status()
+                token_info = token_resp.json()
+                aud = token_info.get("aud") or token_info.get("azp")
+
+                userinfo_resp = client.get(
+                    GOOGLE_USERINFO_URL,
+                    headers={"Authorization": f"Bearer {payload.access_token}"},
+                )
+                userinfo_resp.raise_for_status()
+                info = userinfo_resp.json()
+            else:
+                raise BadRequestError(
+                    "A Google access_token or id_token is required.",
+                    details={"field": "access_token"},
+                )
+    except httpx.HTTPError as exc:
+        logger.warning("Google token verification failed: %s", exc)
+        raise UnauthorizedError(
+            "Could not verify your Google sign-in. Please try again."
+        )
+
+    if settings.GOOGLE_CLIENT_ID and aud and aud != settings.GOOGLE_CLIENT_ID:
+        logger.warning("Google token audience mismatch: %s", aud)
+        raise UnauthorizedError("This Google sign-in was issued for another app.")
+
+    email = info.get("email")
+    if not email:
+        raise UnauthorizedError("Google did not return an email for this account.")
+
+    email_verified = info.get("email_verified")
+    if email_verified in (False, "false"):
+        raise UnauthorizedError("Your Google email address is not verified.")
+
+    return {
+        "sub": info.get("sub"),
+        "email": email,
+        "name": info.get("name"),
+        "picture": info.get("picture"),
+    }
+
+
+@router.post("/google", response_model=Token)
+def google_auth(payload: GoogleAuthRequest, db: Session = Depends(get_db)):
+    """
+    Sign in (or transparently register) a user with Google.
+
+    First-time Google users get an account created automatically; returning
+    users are matched by Google `sub` first, then by email so a pre-existing
+    local account is linked instead of duplicated.
+    """
+    profile = _verify_google_token(payload)
+
+    user = None
+    if profile["sub"]:
+        user = db.query(User).filter(User.google_sub == profile["sub"]).first()
+    if not user:
+        user = db.query(User).filter(User.email == profile["email"]).first()
+
+    if user:
+        # Link / refresh Google details on an existing account.
+        updated = False
+        if not user.google_sub and profile["sub"]:
+            user.google_sub = profile["sub"]
+            user.auth_provider = "google"
+            updated = True
+        if profile["name"] and user.full_name != profile["name"]:
+            user.full_name = user.full_name or profile["name"]
+            updated = True
+        if profile["picture"] and user.avatar_url != profile["picture"]:
+            user.avatar_url = profile["picture"]
+            updated = True
+        if updated:
+            db.commit()
+            db.refresh(user)
+    else:
+        org, role = _default_org_and_role(db)
+        user = User(
+            email=profile["email"],
+            full_name=profile["name"],
+            avatar_url=profile["picture"],
+            # OAuth accounts have no usable password; store an unguessable hash
+            # so the row satisfies NOT NULL and can never be logged into locally.
+            hashed_password=get_password_hash(secrets.token_urlsafe(32)),
+            auth_provider="google",
+            google_sub=profile["sub"],
+            role_id=role.id,
+            organization_id=org.id,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    if not user.is_active:
+        raise UnauthorizedError("This account has been deactivated.")
+
+    return _issue_tokens(user)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,6 +37,12 @@ class Settings(BaseSettings):
     # OpenAI — optional; AI agent endpoints will be unavailable without a real key.
     OPENAI_API_KEY: Optional[str] = None
 
+    # Google OAuth — required for "Continue with Google". Create an OAuth 2.0
+    # Client ID (Web application) in Google Cloud Console and set it here and in
+    # the frontend (VITE_GOOGLE_CLIENT_ID). When set, incoming Google tokens are
+    # verified to have been issued for this client id.
+    GOOGLE_CLIENT_ID: Optional[str] = None
+
     # NASA DONKI space weather API key (public demo key provided as default)
     NASA_DONKI_API_KEY: str = "DEMO_KEY"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,35 @@ async def websocket_endpoint(websocket: WebSocket):
         manager.disconnect(websocket)
 
 
+def _ensure_user_auth_columns(engine):
+    """Add auth-related `users` columns if an older schema is missing them."""
+    from sqlalchemy import inspect, text
+
+    wanted = {
+        "full_name": "VARCHAR(255)",
+        "auth_provider": "VARCHAR(20) NOT NULL DEFAULT 'local'",
+        "google_sub": "VARCHAR(255)",
+        "avatar_url": "VARCHAR(512)",
+    }
+    try:
+        inspector = inspect(engine)
+        existing = {c["name"] for c in inspector.get_columns("users")}
+    except Exception:
+        return  # users table not created yet / inspection unsupported
+
+    missing = {name: ddl for name, ddl in wanted.items() if name not in existing}
+    if not missing:
+        return
+
+    with engine.begin() as conn:
+        for name, ddl in missing.items():
+            try:
+                conn.execute(text(f"ALTER TABLE users ADD COLUMN {name} {ddl}"))
+                logger.info("Added missing users.%s column.", name)
+            except Exception as exc:
+                logger.warning("Could not add users.%s column: %s", name, exc)
+
+
 @app.on_event("startup")
 async def on_startup():
     logger.info("Initializing PostgreSQL database schema...")
@@ -95,6 +124,11 @@ async def on_startup():
         import models.db_models  # noqa: F401
         Base.metadata.create_all(bind=engine)
         logger.info("✅ PostgreSQL tables created / verified.")
+
+        # Lightweight, idempotent backfill for columns added after a database was
+        # first created (create_all never ALTERs existing tables). Keeps older
+        # dev/prod databases working without a full migration tool.
+        _ensure_user_auth_columns(engine)
 
         db = SessionLocal()
         try:

--- a/backend/models/db_models.py
+++ b/backend/models/db_models.py
@@ -58,9 +58,15 @@ class User(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    full_name: Mapped[Optional[str]] = mapped_column(String(255))
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_superuser: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    # "local" for email/password, "google" for Google OAuth accounts.
+    auth_provider: Mapped[str] = mapped_column(String(20), default="local", nullable=False)
+    # Google's stable subject identifier (`sub`); unique per Google account.
+    google_sub: Mapped[Optional[str]] = mapped_column(String(255), unique=True, index=True)
+    avatar_url: Mapped[Optional[str]] = mapped_column(String(512))
     role_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("roles.id", ondelete="SET NULL"))
     organization_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("organizations.id", ondelete="SET NULL"))
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/schemas/api_schemas.py
+++ b/backend/schemas/api_schemas.py
@@ -53,12 +53,28 @@ class UserLogin(BaseModel):
 class UserCreate(BaseModel):
     email: EmailStr
     password: str
+    full_name: Optional[str] = Field(None, max_length=255)
     role_id: Optional[int] = None
     organization_id: Optional[int] = None
+
+class GoogleAuthRequest(BaseModel):
+    """
+    Payload sent by the frontend after Google Identity Services returns.
+
+    Send *either* an OAuth 2.0 `access_token` (token-client flow) or an
+    `id_token` (One Tap / credential flow). The backend verifies whichever
+    is provided against Google before trusting any profile data.
+    """
+
+    access_token: Optional[str] = None
+    id_token: Optional[str] = None
 
 class UserResponse(BaseModel):
     id: int
     email: EmailStr
+    full_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    auth_provider: str = "local"
     is_active: bool
     role_id: Optional[int]
     organization_id: Optional[int]
@@ -70,6 +86,7 @@ class Token(BaseModel):
     access_token: str
     refresh_token: str
     token_type: str
+    user: Optional["UserResponse"] = None
 
 class TokenData(BaseModel):
     email: Optional[str] = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,10 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { MainLayout } from '@/components/layouts/MainLayout';
 import { MarketingLayout } from '@/components/layouts/MarketingLayout';
+import { AuthLayout } from '@/components/layouts/AuthLayout';
 import { LandingPage } from '@/pages/LandingPage';
 import { AboutPage } from '@/pages/AboutPage';
-import { ProductPage, SolutionsPage, DevelopersPage, DocsPage, SignInPage } from '@/pages/PlaceholderPage';
+import { ProductPage, SolutionsPage, DevelopersPage, DocsPage } from '@/pages/PlaceholderPage';
 import { Dashboard } from '@/pages/Dashboard';
 import { SpaceTraffic } from '@/pages/SpaceTraffic';
 import { Satellites } from '@/pages/Satellites';
@@ -17,6 +18,8 @@ import { toastOptions } from './constants/toast';
 import { NotFound } from '@/pages/NotFound';
 import { Technologies } from './pages/Technologies';
 import ButtonBackToTop from './components/ui/ButtonBackToTop';
+import SignIn from './pages/SignIn';
+import SignUp from './pages/SignUp';
 
 function App() {
   return (
@@ -35,7 +38,10 @@ function App() {
           <Route path="/solutions" element={<SolutionsPage />} />
           <Route path="/developers" element={<DevelopersPage />} />
           <Route path="/docs" element={<DocsPage />} />
-          <Route path="/signin" element={<SignInPage />} />
+        </Route>
+        <Route element={<AuthLayout />}>
+          <Route path="/signin" element={<SignIn />} />
+          <Route path="/signup" element={<SignUp />} />
         </Route>
         <Route path="/dashboard" element={<MainLayout />}>
           <Route index element={<Dashboard />} />

--- a/frontend/src/components/auth/AuthShell.tsx
+++ b/frontend/src/components/auth/AuthShell.tsx
@@ -3,41 +3,13 @@ import { Link } from 'react-router-dom';
 import { motion, useReducedMotion } from 'framer-motion';
 import { Particles } from '@/components/ui/particles';
 import { MagicCard } from '@/components/ui/magic-card';
+import { OrbitSatellites } from '../ui/OrbitSatellites';
 
 interface AuthShellProps {
   title: string;
   subtitle: string;
   children: React.ReactNode;
   footer: React.ReactNode;
-}
-
-/** Faint concentric orbital rings that give the backdrop depth. */
-function OrbitalRings() {
-  return (
-    <svg
-      aria-hidden="true"
-      className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[160vmin] w-[160vmin] -translate-x-1/2 -translate-y-1/2 opacity-[0.28]"
-      viewBox="0 0 800 800"
-      fill="none"
-    >
-      <defs>
-        <radialGradient id="auth-ring-fade" cx="50%" cy="50%" r="50%">
-          <stop offset="55%" stopColor="#5EE7FF" stopOpacity="0" />
-          <stop offset="100%" stopColor="#5EE7FF" stopOpacity="0.5" />
-        </radialGradient>
-      </defs>
-      {[120, 200, 290, 380].map((r) => (
-        <circle
-          key={r}
-          cx="400"
-          cy="400"
-          r={r}
-          stroke="url(#auth-ring-fade)"
-          strokeWidth="1"
-        />
-      ))}
-    </svg>
-  );
 }
 
 /**
@@ -62,15 +34,15 @@ export function AuthShell({ title, subtitle, children, footer }: AuthShellProps)
       />
 
       {/* Star field (Magic UI) */}
-      {/* <Particles
-        className="absolute inset-0 -z-20"
+      <Particles
+        className="absolute inset-0"
         quantity={90}
         ease={70}
         color="#8FB4FF"
         refresh={false}
-      /> */}
+      />
 
-      {/* <OrbitalRings /> */}
+      <OrbitSatellites />
 
       <motion.div
         initial={reduce ? false : { opacity: 0, y: 24 }}
@@ -84,7 +56,7 @@ export function AuthShell({ title, subtitle, children, footer }: AuthShellProps)
           gradientColor="rgba(94, 231, 255, 0.14)"
           gradientOpacity={0.55}
           gradientSize={280}
-          fillClassName="bg-[rgba(10,15,26,0.72)] backdrop-blur-xl"
+          fillClassName="bg-[rgba(255,255,255,0.04)] backdrop-blur-xl"
           className="rounded-[24px] border-white/8 p-7 shadow-[0_24px_80px_-20px_rgba(0,0,0,0.7)] sm:p-9 [--color-background:#0A0F1A] [--color-border:rgba(255,255,255,0.08)]"
         >
           <div className="mb-7 flex flex-col items-center text-center">

--- a/frontend/src/components/auth/AuthShell.tsx
+++ b/frontend/src/components/auth/AuthShell.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { Particles } from '@/components/ui/particles';
+import { MagicCard } from '@/components/ui/magic-card';
+
+interface AuthShellProps {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+  footer: React.ReactNode;
+}
+
+/** Faint concentric orbital rings that give the backdrop depth. */
+function OrbitalRings() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[160vmin] w-[160vmin] -translate-x-1/2 -translate-y-1/2 opacity-[0.28]"
+      viewBox="0 0 800 800"
+      fill="none"
+    >
+      <defs>
+        <radialGradient id="auth-ring-fade" cx="50%" cy="50%" r="50%">
+          <stop offset="55%" stopColor="#5EE7FF" stopOpacity="0" />
+          <stop offset="100%" stopColor="#5EE7FF" stopOpacity="0.5" />
+        </radialGradient>
+      </defs>
+      {[120, 200, 290, 380].map((r) => (
+        <circle
+          key={r}
+          cx="400"
+          cy="400"
+          r={r}
+          stroke="url(#auth-ring-fade)"
+          strokeWidth="1"
+        />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * Shared visual scaffold for the auth pages: a dark, space-inspired backdrop
+ * (star field + orbital rings + radial glows) wrapping a Magic UI glass card.
+ */
+export function AuthShell({ title, subtitle, children, footer }: AuthShellProps) {
+  const reduce = useReducedMotion();
+
+  return (
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#050811] px-4 py-10 text-[#F8FAFC] sm:px-6 selection:bg-[#5EE7FF]/30">
+      {/* Base gradient wash */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 -z-30"
+        style={{
+          background:
+            'radial-gradient(ellipse 90% 60% at 50% -10%, rgba(79,125,255,0.16), transparent 60%),' +
+            'radial-gradient(ellipse 70% 50% at 85% 110%, rgba(139,92,246,0.14), transparent 55%),' +
+            'linear-gradient(180deg, #050811 0%, #0A0F1A 100%)',
+        }}
+      />
+
+      {/* Star field (Magic UI) */}
+      {/* <Particles
+        className="absolute inset-0 -z-20"
+        quantity={90}
+        ease={70}
+        color="#8FB4FF"
+        refresh={false}
+      /> */}
+
+      {/* <OrbitalRings /> */}
+
+      <motion.div
+        initial={reduce ? false : { opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.55, ease: [0.16, 1, 0.3, 1] }}
+        className="relative z-10 w-full max-w-[440px]"
+      >
+        <MagicCard
+          gradientFrom="#5EE7FF"
+          gradientTo="#4F7DFF"
+          gradientColor="rgba(94, 231, 255, 0.14)"
+          gradientOpacity={0.55}
+          gradientSize={280}
+          fillClassName="bg-[rgba(10,15,26,0.72)] backdrop-blur-xl"
+          className="rounded-[24px] border-white/8 p-7 shadow-[0_24px_80px_-20px_rgba(0,0,0,0.7)] sm:p-9 [--color-background:#0A0F1A] [--color-border:rgba(255,255,255,0.08)]"
+        >
+          <div className="mb-7 flex flex-col items-center text-center">
+            <Link
+              to="/"
+              aria-label="Kepler home"
+              className="mb-6 inline-flex items-center gap-2.5 no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5EE7FF]/50 rounded-xl"
+            >
+              <span className="relative flex h-10 w-10 items-center justify-center rounded-xl bg-linear-to-br from-[#5EE7FF]/20 to-[#4F7DFF]/20 ring-1 ring-white/10">
+                <img
+                  src="/Logo.svg"
+                  alt=""
+                  width={22}
+                  height={22}
+                  className="h-[22px] w-[22px] object-contain"
+                />
+              </span>
+              <span className="font-necosmic text-[18px] tracking-wide text-[#F8FAFC]">
+                Kepler
+              </span>
+            </Link>
+
+            <h1 className="font-display-lg text-[28px] font-bold leading-tight tracking-tight text-[#F8FAFC] sm:text-[30px]">
+              {title}
+            </h1>
+            <p className="mt-2 max-w-[320px] font-body-ui text-[14.5px] leading-relaxed text-[#94A3B8]">
+              {subtitle}
+            </p>
+          </div>
+
+          {children}
+        </MagicCard>
+
+        <div className="mt-6 text-center font-body-ui text-[14px] text-[#94A3B8]">
+          {footer}
+        </div>
+      </motion.div>
+    </main>
+  );
+}

--- a/frontend/src/components/auth/Divider.tsx
+++ b/frontend/src/components/auth/Divider.tsx
@@ -1,0 +1,16 @@
+interface DividerProps {
+  label?: string;
+}
+
+/** A hairline separator with an optional centered label. */
+export function Divider({ label = 'or continue with' }: DividerProps) {
+  return (
+    <div className="flex items-center gap-4" role="separator" aria-label={label}>
+      <span className="h-px flex-1 bg-linear-to-r from-transparent to-white/12" />
+      <span className="font-body-ui text-[12px] uppercase tracking-[0.14em] text-[#64748B]">
+        {label}
+      </span>
+      <span className="h-px flex-1 bg-linear-to-l from-transparent to-white/12" />
+    </div>
+  );
+}

--- a/frontend/src/components/auth/GoogleButton.tsx
+++ b/frontend/src/components/auth/GoogleButton.tsx
@@ -1,0 +1,56 @@
+import { Loader2 } from 'lucide-react';
+
+interface GoogleButtonProps {
+  onClick: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  label?: string;
+}
+
+function GoogleLogo() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+      <path
+        fill="#4285F4"
+        d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.167 6.656 3.58 9 3.58z"
+      />
+    </svg>
+  );
+}
+
+/** "Continue with Google" — glassmorphism button with loading state. */
+export function GoogleButton({
+  onClick,
+  loading = false,
+  disabled = false,
+  label = 'Continue with Google',
+}: GoogleButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || loading}
+      aria-busy={loading}
+      className="group relative flex w-full items-center justify-center gap-3 rounded-xl border border-white/10 bg-white/4 px-5 py-3 font-body-ui text-[14.5px] font-medium text-[#F1F5F9] backdrop-blur-sm transition-all duration-200 hover:bg-white/8 hover:border-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5EE7FF]/50 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {loading ? (
+        <Loader2 size={18} className="animate-spin text-[#94A3B8]" aria-hidden="true" />
+      ) : (
+        <GoogleLogo />
+      )}
+      <span>{loading ? 'Connecting…' : label}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/auth/SubmitButton.tsx
+++ b/frontend/src/components/auth/SubmitButton.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import { ShimmerButton } from '@/components/ui/shimmer-button';
+import { cn } from '@/lib/utils';
+
+interface SubmitButtonProps extends React.ComponentPropsWithoutRef<'button'> {
+  loading?: boolean;
+  loadingText?: string;
+}
+
+const ACCENT_GRADIENT =
+  'linear-gradient(100deg, #5EE7FF 0%, #4F7DFF 55%, #6D5AF7 100%)';
+
+/** Primary auth CTA: cyan→blue gradient shimmer button with a loading state. */
+export function SubmitButton({
+  loading = false,
+  loadingText = 'Please wait…',
+  disabled,
+  children,
+  className,
+  ...props
+}: SubmitButtonProps) {
+  return (
+    <ShimmerButton
+      background={ACCENT_GRADIENT}
+      shimmerColor="#ffffff"
+      shimmerDuration="2.5s"
+      borderRadius="12px"
+      disabled={disabled || loading}
+      aria-busy={loading}
+      className={cn(
+        'w-full py-3 font-body-ui text-[15px] font-semibold text-[#04121F] border-transparent',
+        'shadow-[0_8px_30px_rgba(79,125,255,0.35)] hover:shadow-[0_10px_40px_rgba(94,231,255,0.45)]',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5EE7FF]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]',
+        'disabled:cursor-not-allowed disabled:opacity-70 disabled:shadow-none',
+        className
+      )}
+      {...props}
+    >
+      <span className="flex items-center justify-center gap-2">
+        {loading && <Loader2 size={18} className="animate-spin" aria-hidden="true" />}
+        {loading ? loadingText : children}
+      </span>
+    </ShimmerButton>
+  );
+}

--- a/frontend/src/components/auth/SubmitButton.tsx
+++ b/frontend/src/components/auth/SubmitButton.tsx
@@ -30,7 +30,7 @@ export function SubmitButton({
       aria-busy={loading}
       className={cn(
         'w-full py-3 font-body-ui text-[15px] font-semibold text-[#04121F] border-transparent',
-        'shadow-[0_8px_30px_rgba(79,125,255,0.35)] hover:shadow-[0_10px_40px_rgba(94,231,255,0.45)]',
+        'shadow-[0_4px_16px_rgba(79,125,255,0.18)] hover:shadow-[0_6px_20px_rgba(94,231,255,0.22)]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5EE7FF]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0F1A]',
         'disabled:cursor-not-allowed disabled:opacity-70 disabled:shadow-none',
         className

--- a/frontend/src/components/auth/fields.tsx
+++ b/frontend/src/components/auth/fields.tsx
@@ -1,0 +1,131 @@
+import React, { forwardRef, useId, useState } from 'react';
+import { Eye, EyeOff, type LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface BaseFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+  icon?: LucideIcon;
+}
+
+const inputBase =
+  'w-full rounded-xl bg-white/[0.03] border text-[15px] text-[#F8FAFC] placeholder:text-[#64748B] ' +
+  'py-3 pr-4 transition-all duration-200 outline-none ' +
+  'focus:bg-white/[0.05] focus:ring-2 focus:ring-[#5EE7FF]/40 focus:border-[#5EE7FF]/60 ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed autofill:shadow-[inset_0_0_0px_1000px_rgba(10,15,26,1)]';
+
+/** Standard labelled text input with an optional leading icon and error state. */
+export const TextField = forwardRef<HTMLInputElement, BaseFieldProps>(
+  ({ label, error, icon: Icon, id, className, ...props }, ref) => {
+    const autoId = useId();
+    const fieldId = id ?? autoId;
+    const errorId = `${fieldId}-error`;
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={fieldId}
+          className="font-body-ui text-[13px] font-medium text-[#CBD5E1]"
+        >
+          {label}
+        </label>
+        <div className="group relative">
+          {Icon && (
+            <Icon
+              size={17}
+              aria-hidden="true"
+              className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-[#64748B] transition-colors group-focus-within:text-[#5EE7FF]"
+            />
+          )}
+          <input
+            ref={ref}
+            id={fieldId}
+            className={cn(
+              inputBase,
+              Icon ? 'pl-11' : 'pl-4',
+              error
+                ? 'border-[#F87171]/70 focus:ring-[#F87171]/30 focus:border-[#F87171]/70'
+                : 'border-white/10',
+              className
+            )}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
+            {...props}
+          />
+        </div>
+        {error && (
+          <p id={errorId} role="alert" className="font-body-ui text-[12.5px] text-[#F87171]">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+TextField.displayName = 'TextField';
+
+/** Password input with an accessible show/hide toggle. */
+export const PasswordField = forwardRef<HTMLInputElement, BaseFieldProps>(
+  ({ label, error, icon: Icon, id, className, ...props }, ref) => {
+    const autoId = useId();
+    const fieldId = id ?? autoId;
+    const errorId = `${fieldId}-error`;
+    const [visible, setVisible] = useState(false);
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={fieldId}
+          className="font-body-ui text-[13px] font-medium text-[#CBD5E1]"
+        >
+          {label}
+        </label>
+        <div className="group relative">
+          {Icon && (
+            <Icon
+              size={17}
+              aria-hidden="true"
+              className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-[#64748B] transition-colors group-focus-within:text-[#5EE7FF]"
+            />
+          )}
+          <input
+            ref={ref}
+            id={fieldId}
+            type={visible ? 'text' : 'password'}
+            className={cn(
+              inputBase,
+              Icon ? 'pl-11' : 'pl-4',
+              'pr-11',
+              error
+                ? 'border-[#F87171]/70 focus:ring-[#F87171]/30 focus:border-[#F87171]/70'
+                : 'border-white/10',
+              className
+            )}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
+            {...props}
+          />
+          <button
+            type="button"
+            onClick={() => setVisible((v) => !v)}
+            aria-label={visible ? 'Hide password' : 'Show password'}
+            aria-pressed={visible}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-lg text-[#64748B] hover:text-[#CBD5E1] hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5EE7FF]/50 transition-colors"
+          >
+            {visible ? (
+              <EyeOff size={17} aria-hidden="true" />
+            ) : (
+              <Eye size={17} aria-hidden="true" />
+            )}
+          </button>
+        </div>
+        {error && (
+          <p id={errorId} role="alert" className="font-body-ui text-[12.5px] text-[#F87171]">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+PasswordField.displayName = 'PasswordField';

--- a/frontend/src/components/layouts/AuthLayout.tsx
+++ b/frontend/src/components/layouts/AuthLayout.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
+
+/** Full-screen layout for the authentication pages — no navbar or footer. */
+export const AuthLayout: React.FC = () => {
+
+  useEffect(() => {
+    // Auth pages can be taller than the viewport on small screens, so allow
+    // vertical scrolling while they're mounted (the app locks it globally).
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'auto';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  return <Outlet />;
+};
+
+export default AuthLayout;

--- a/frontend/src/components/ui/magic-card.tsx
+++ b/frontend/src/components/ui/magic-card.tsx
@@ -12,6 +12,8 @@ import { cn } from "@/lib/utils"
 interface MagicCardBaseProps {
   children?: React.ReactNode
   className?: string
+  /** Overrides the solid fill layer (e.g. glassmorphism on auth cards). */
+  fillClassName?: string
   gradientSize?: number
   gradientFrom?: string
   gradientTo?: string
@@ -56,6 +58,7 @@ export function MagicCard(props: MagicCardProps) {
   const {
     children,
     className,
+    fillClassName,
     gradientSize = 200,
     gradientColor = "#262626",
     gradientOpacity = 0.8,
@@ -174,7 +177,12 @@ export function MagicCard(props: MagicCardProps) {
         `,
       }}
     >
-      <div className="bg-background absolute inset-px z-20 rounded-[inherit]" />
+      <div
+        className={cn(
+          "bg-background absolute inset-px z-20 rounded-[inherit]",
+          fillClassName
+        )}
+      />
 
       {mode === "gradient" && (
         <motion.div

--- a/frontend/src/hooks/useGoogleAuth.ts
+++ b/frontend/src/hooks/useGoogleAuth.ts
@@ -1,0 +1,145 @@
+/**
+ * useGoogleAuth — Google Identity Services (GIS) integration.
+ *
+ * Loads the official GIS script once, then exposes a promise-based `signIn`
+ * that runs the OAuth 2.0 token flow and resolves with an access token. The
+ * token is sent to our backend (`/auth/google`), which verifies it with Google
+ * before creating or signing in the user. Using our own trigger (instead of
+ * Google's pre-styled button) lets the "Continue with Google" control match the
+ * app's design while remaining fully functional and production-ready.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const GSI_SRC = 'https://accounts.google.com/gsi/client';
+const GSI_SCRIPT_ID = 'google-identity-services';
+
+const CLIENT_ID: string | undefined = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+interface TokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface TokenClient {
+  callback: (resp: TokenResponse) => void;
+  error_callback?: (err: { type?: string; message?: string }) => void;
+  requestAccessToken: (overrides?: { prompt?: string }) => void;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        oauth2: {
+          initTokenClient: (config: {
+            client_id: string;
+            scope: string;
+            callback: (resp: TokenResponse) => void;
+            error_callback?: (err: { type?: string; message?: string }) => void;
+          }) => TokenClient;
+        };
+      };
+    };
+  }
+}
+
+export class GoogleAuthError extends Error {}
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadGsiScript(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.reject(new Error('no window'));
+  if (window.google?.accounts?.oauth2) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.getElementById(GSI_SCRIPT_ID) as HTMLScriptElement | null;
+    if (existing) {
+      existing.addEventListener('load', () => resolve());
+      existing.addEventListener('error', () => reject(new Error('Failed to load Google script')));
+      return;
+    }
+    const script = document.createElement('script');
+    script.id = GSI_SCRIPT_ID;
+    script.src = GSI_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      scriptPromise = null;
+      reject(new Error('Failed to load Google script'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return scriptPromise;
+}
+
+export function useGoogleAuth() {
+  const isConfigured = Boolean(CLIENT_ID);
+  const [isReady, setIsReady] = useState(false);
+  const tokenClientRef = useRef<TokenClient | null>(null);
+
+  useEffect(() => {
+    if (!isConfigured) return;
+    let cancelled = false;
+    loadGsiScript()
+      .then(() => {
+        if (!cancelled) setIsReady(true);
+      })
+      .catch(() => {
+        if (!cancelled) setIsReady(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isConfigured]);
+
+  const signIn = useCallback((): Promise<string> => {
+    return new Promise<string>((resolve, reject) => {
+      if (!isConfigured || !CLIENT_ID) {
+        reject(new GoogleAuthError('Google sign-in is not configured.'));
+        return;
+      }
+      const oauth2 = window.google?.accounts?.oauth2;
+      if (!oauth2) {
+        reject(new GoogleAuthError('Google sign-in is still loading. Please try again.'));
+        return;
+      }
+
+      if (!tokenClientRef.current) {
+        tokenClientRef.current = oauth2.initTokenClient({
+          client_id: CLIENT_ID,
+          scope: 'openid email profile',
+          callback: () => {},
+        });
+      }
+
+      const client = tokenClientRef.current;
+      client.callback = (resp: TokenResponse) => {
+        if (resp.error) {
+          reject(new GoogleAuthError(resp.error_description || 'Google sign-in failed.'));
+          return;
+        }
+        if (!resp.access_token) {
+          reject(new GoogleAuthError('Google did not return an access token.'));
+          return;
+        }
+        resolve(resp.access_token);
+      };
+      client.error_callback = (err) => {
+        // Popup closed / blocked / user cancelled.
+        reject(new GoogleAuthError(err?.message || 'Google sign-in was cancelled.'));
+      };
+
+      try {
+        client.requestAccessToken();
+      } catch {
+        reject(new GoogleAuthError('Could not open the Google sign-in window.'));
+      }
+    });
+  }, [isConfigured]);
+
+  return { signIn, isReady, isConfigured };
+}

--- a/frontend/src/hooks/useGoogleSignIn.ts
+++ b/frontend/src/hooks/useGoogleSignIn.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useGoogleAuth, GoogleAuthError } from '@/hooks/useGoogleAuth';
+import { useAuthStore } from '@/store/authStore';
+import { googleAuth } from '@/services/auth';
+import { ApiError } from '@/services/api';
+
+/**
+ * Runs the full "Continue with Google" flow: obtain a Google token, exchange it
+ * with the backend, persist the session, and redirect. Shared by Sign In and
+ * Sign Up since Google auth is identical for both (first-time users are created
+ * automatically, returning users are signed in).
+ */
+export function useGoogleSignIn(redirectTo = '/dashboard') {
+  const navigate = useNavigate();
+  const setSession = useAuthStore((s) => s.setSession);
+  const { signIn, isConfigured, isReady } = useGoogleAuth();
+  const [loading, setLoading] = useState(false);
+
+  const handleGoogle = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const accessToken = await signIn();
+      const session = await googleAuth({ accessToken });
+      setSession(session);
+      toast.success(
+        `Welcome, ${session.user?.full_name || session.user?.email || 'operator'}!`
+      );
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      if (err instanceof GoogleAuthError) {
+        // User cancelled or the popup was blocked — keep it low-key.
+        if (!/cancel/i.test(err.message)) toast.error(err.message);
+      } else if (err instanceof ApiError) {
+        toast.error(err.message);
+      } else {
+        toast.error('Google sign-in failed. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, signIn, setSession, navigate, redirectTo]);
+
+  return { handleGoogle, loading, isConfigured, isReady };
+}

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+const email = z.email('Enter a valid email address');
+
+/** Sign-in only requires a well-formed email and a non-empty password. */
+export const signInSchema = z.object({
+  email,
+  password: z.string().min(1, 'Password is required'),
+});
+
+/** Sign-up enforces the full password policy and confirmation match. */
+export const signUpSchema = z
+  .object({
+    fullName: z
+      .string()
+      .min(1, 'Full name is required')
+      .min(2, 'Full name is too short')
+      .max(80, 'Full name is too long'),
+    email,
+    password: z
+      .string()
+      .min(8, 'Use at least 8 characters')
+      .regex(/[A-Z]/, 'Add at least one uppercase letter')
+      .regex(/[a-z]/, 'Add at least one lowercase letter')
+      .regex(/[0-9]/, 'Add at least one number')
+      .regex(/[^a-zA-Z0-9]/, 'Add at least one special character'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+export type SignInValues = z.infer<typeof signInSchema>;
+export type SignUpValues = z.infer<typeof signUpSchema>;

--- a/frontend/src/pages/PlaceholderPage.tsx
+++ b/frontend/src/pages/PlaceholderPage.tsx
@@ -57,4 +57,4 @@ export const ProductPage = () => <PlaceholderPage title="Product" description="E
 export const SolutionsPage = () => <PlaceholderPage title="Solutions" description="Tailored solutions for satellite operators and space traffic management." />;
 export const DevelopersPage = () => <PlaceholderPage title="Developers" description="API documentation, SDKs, and resources for developers building with Kepler." />;
 export const DocsPage = () => <PlaceholderPage title="Documentation" description="Comprehensive guides and references for the Kepler platform." />;
-export const SignInPage = () => <PlaceholderPage title="Sign In" description="Sign in to your Kepler account to access the dashboard." />;
+// export const SignInPage = () => <PlaceholderPage title="Sign In" description="Sign in to your Kepler account to access the dashboard." />;

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,0 +1,142 @@
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Mail, Lock } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { AuthShell } from '@/components/auth/AuthShell';
+import { TextField, PasswordField } from '@/components/auth/fields';
+import { SubmitButton } from '@/components/auth/SubmitButton';
+import { GoogleButton } from '@/components/auth/GoogleButton';
+import { Divider } from '@/components/auth/Divider';
+import { signInSchema, type SignInValues } from '@/lib/validation';
+import { login } from '@/services/auth';
+import { ApiError } from '@/services/api';
+import { useAuthStore } from '@/store/authStore';
+import { useGoogleSignIn } from '@/hooks/useGoogleSignIn';
+
+const REDIRECT_TO = '/dashboard';
+
+const SignIn = () => {
+  const navigate = useNavigate();
+  const setSession = useAuthStore((s) => s.setSession);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const {
+    handleGoogle,
+    loading: googleLoading,
+    isConfigured: googleConfigured,
+    isReady: googleReady,
+  } = useGoogleSignIn(REDIRECT_TO);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<SignInValues>({
+    resolver: zodResolver(signInSchema),
+    mode: 'onTouched',
+    defaultValues: { email: '', password: '' },
+  });
+
+  useEffect(() => {
+    if (isAuthenticated) navigate(REDIRECT_TO, { replace: true });
+  }, [isAuthenticated, navigate]);
+
+  const onSubmit = async (values: SignInValues) => {
+    try {
+      const session = await login(values);
+      setSession(session);
+      toast.success('Signed in successfully.');
+      navigate(REDIRECT_TO, { replace: true });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.code === 'UNAUTHORIZED') {
+          setError('password', { message: 'Incorrect email or password' });
+        }
+        toast.error(err.message);
+      } else {
+        toast.error('Something went wrong. Please try again.');
+      }
+    }
+  };
+
+  const busy = isSubmitting || googleLoading;
+
+  return (
+    <AuthShell
+      title="Welcome back"
+      subtitle="Sign in to your Kepler account to access mission control."
+      footer={
+        <>
+          Don&apos;t have an account?{' '}
+          <Link
+            to="/signup"
+            className="font-medium text-[#5EE7FF] no-underline hover:text-[#8FD9FF] transition-colors"
+          >
+            Sign up
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="flex flex-col gap-4">
+        <TextField
+          label="Email"
+          type="email"
+          autoComplete="email"
+          placeholder="you@example.com"
+          icon={Mail}
+          error={errors.email?.message}
+          disabled={busy}
+          {...register('email')}
+        />
+
+        <div className="flex flex-col gap-1.5">
+          <PasswordField
+            label="Password"
+            autoComplete="current-password"
+            placeholder="Enter your password"
+            icon={Lock}
+            error={errors.password?.message}
+            disabled={busy}
+            {...register('password')}
+          />
+          <div className="flex justify-end">
+            <a
+              href="#forgot-password"
+              onClick={(e) => {
+                e.preventDefault();
+                toast.info('Password reset is coming soon.');
+              }}
+              className="font-body-ui text-[12.5px] text-[#94A3B8] hover:text-[#5EE7FF] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#5EE7FF]/50 rounded"
+            >
+              Forgot password?
+            </a>
+          </div>
+        </div>
+
+        <SubmitButton type="submit" loading={isSubmitting} loadingText="Signing in…" disabled={busy}>
+          Sign In
+        </SubmitButton>
+      </form>
+
+      <div className="my-6">
+        <Divider />
+      </div>
+
+      <GoogleButton
+        onClick={handleGoogle}
+        loading={googleLoading}
+        disabled={busy || !googleConfigured || !googleReady}
+      />
+      {!googleConfigured && (
+        <p className="mt-2 text-center font-body-ui text-[12px] text-[#64748B]">
+          Google sign-in is not configured. Set VITE_GOOGLE_CLIENT_ID to enable it.
+        </p>
+      )}
+    </AuthShell>
+  );
+};
+
+export default SignIn;

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,0 +1,152 @@
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { User, Mail, Lock } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { AuthShell } from '@/components/auth/AuthShell';
+import { TextField, PasswordField } from '@/components/auth/fields';
+import { SubmitButton } from '@/components/auth/SubmitButton';
+import { GoogleButton } from '@/components/auth/GoogleButton';
+import { Divider } from '@/components/auth/Divider';
+import { signUpSchema, type SignUpValues } from '@/lib/validation';
+import { register as registerUser } from '@/services/auth';
+import { ApiError } from '@/services/api';
+import { useAuthStore } from '@/store/authStore';
+import { useGoogleSignIn } from '@/hooks/useGoogleSignIn';
+
+const REDIRECT_TO = '/dashboard';
+
+const SignUp = () => {
+  const navigate = useNavigate();
+  const {setSession, isAuthenticated} = useAuthStore()
+  const {
+    handleGoogle,
+    loading: googleLoading,
+    isConfigured: googleConfigured,
+    isReady: googleReady,
+  } = useGoogleSignIn(REDIRECT_TO);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<SignUpValues>({
+    resolver: zodResolver(signUpSchema),
+    mode: 'onTouched',
+    defaultValues: { fullName: '', email: '', password: '', confirmPassword: '' },
+  });
+
+  useEffect(() => {
+    if (isAuthenticated) navigate(REDIRECT_TO, { replace: true });
+  }, [isAuthenticated, navigate]);
+
+  const onSubmit = async (values: SignUpValues) => {
+    try {
+      const session = await registerUser({
+        fullName: values.fullName,
+        email: values.email,
+        password: values.password,
+      });
+      setSession(session);
+      toast.success('Account created. Welcome aboard!');
+      navigate(REDIRECT_TO, { replace: true });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.code === 'CONFLICT') {
+          setError('email', { message: 'This email is already registered' });
+        }
+        toast.error(err.message);
+      } else {
+        toast.error('Something went wrong. Please try again.');
+      }
+    }
+  };
+
+  const busy = isSubmitting || googleLoading;
+
+  return (
+    <AuthShell
+      title="Create your account"
+      subtitle="Join Kepler and start monitoring the orbital environment."
+      footer={
+        <>
+          Already have an account?{' '}
+          <Link
+            to="/signin"
+            className="font-medium text-[#5EE7FF] no-underline hover:text-[#8FD9FF] transition-colors"
+          >
+            Sign in
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="flex flex-col gap-4">
+        <TextField
+          label="Full name"
+          type="text"
+          autoComplete="name"
+          placeholder="Jane Doe"
+          icon={User}
+          error={errors.fullName?.message}
+          disabled={busy}
+          {...register('fullName')}
+        />
+
+        <TextField
+          label="Email"
+          type="email"
+          autoComplete="email"
+          placeholder="you@example.com"
+          icon={Mail}
+          error={errors.email?.message}
+          disabled={busy}
+          {...register('email')}
+        />
+
+        <PasswordField
+          label="Password"
+          autoComplete="new-password"
+          placeholder="Create a strong password"
+          icon={Lock}
+          error={errors.password?.message}
+          disabled={busy}
+          {...register('password')}
+        />
+
+        <PasswordField
+          label="Confirm password"
+          autoComplete="new-password"
+          placeholder="Re-enter your password"
+          icon={Lock}
+          error={errors.confirmPassword?.message}
+          disabled={busy}
+          {...register('confirmPassword')}
+        />
+
+        <SubmitButton type="submit" loading={isSubmitting} loadingText="Creating account…" disabled={busy}>
+          Sign Up
+        </SubmitButton>
+      </form>
+
+      <div className="my-6">
+        <Divider />
+      </div>
+
+      <GoogleButton
+        onClick={handleGoogle}
+        loading={googleLoading}
+        disabled={busy || !googleConfigured || !googleReady}
+      />
+      {!googleConfigured && (
+        <p className="mt-2 text-center font-body-ui text-[12px] text-[#64748B]">
+          Google sign-in is not configured. Set VITE_GOOGLE_CLIENT_ID to enable it.
+        </p>
+      )}
+    </AuthShell>
+  );
+};
+
+export default SignUp;

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,118 @@
+/**
+ * Authentication API — Kepler AI
+ *
+ * Thin wrapper around the FastAPI `/auth` endpoints. Every call resolves to a
+ * normalised result or throws an `ApiError` carrying the backend's
+ * human-readable message (safe to drop straight into a toast).
+ */
+import { ApiError, type ErrorResponse } from './api';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? '/api/v1';
+
+export interface UserProfile {
+  id: number;
+  email: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  auth_provider: string;
+  is_active: boolean;
+  role_id: number | null;
+  organization_id: number | null;
+  created_at: string;
+}
+
+export interface AuthSession {
+  accessToken: string;
+  refreshToken: string;
+  user: UserProfile | null;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  user: UserProfile | null;
+}
+
+async function throwApiError(res: Response, fallbackPath: string): Promise<never> {
+  const body = await res.json().catch(() => null);
+  if (body && typeof body === 'object' && 'error' in body) {
+    throw new ApiError(res.status, body as ErrorResponse);
+  }
+  throw new ApiError(res.status, {
+    message: `Request to ${fallbackPath} failed (HTTP ${res.status} ${res.statusText}).`,
+  });
+}
+
+function toSession(token: TokenResponse): AuthSession {
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    user: token.user,
+  };
+}
+
+export interface LoginInput {
+  email: string;
+  password: string;
+}
+
+export interface RegisterInput {
+  fullName: string;
+  email: string;
+  password: string;
+}
+
+export interface GoogleAuthInput {
+  accessToken?: string;
+  idToken?: string;
+}
+
+/** Exchange email + password for a token pair. */
+export async function login({ email, password }: LoginInput): Promise<AuthSession> {
+  // The `/token` endpoint uses OAuth2's password flow, which expects a
+  // urlencoded form body with `username`/`password` fields.
+  const form = new URLSearchParams();
+  form.set('username', email);
+  form.set('password', password);
+
+  const res = await fetch(`${API_BASE}/auth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  });
+  if (!res.ok) await throwApiError(res, '/auth/token');
+  return toSession(await res.json());
+}
+
+/** Create an account, then immediately sign the new operator in. */
+export async function register(input: RegisterInput): Promise<AuthSession> {
+  const res = await fetch(`${API_BASE}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: input.email,
+      password: input.password,
+      full_name: input.fullName,
+    }),
+  });
+  if (!res.ok) await throwApiError(res, '/auth/register');
+  return login({ email: input.email, password: input.password });
+}
+
+/**
+ * Sign in or transparently register with Google. Send whichever token Google
+ * Identity Services produced; the backend verifies it before trusting anything.
+ */
+export async function googleAuth(input: GoogleAuthInput): Promise<AuthSession> {
+  const res = await fetch(`${API_BASE}/auth/google`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      access_token: input.accessToken,
+      id_token: input.idToken,
+    }),
+  });
+  if (!res.ok) await throwApiError(res, '/auth/google');
+  return toSession(await res.json());
+}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { AuthSession, UserProfile } from '@/services/auth';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  user: UserProfile | null;
+  isAuthenticated: boolean;
+  setSession: (session: AuthSession) => void;
+  clearSession: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      refreshToken: null,
+      user: null,
+      isAuthenticated: false,
+      setSession: (session) =>
+        set({
+          accessToken: session.accessToken,
+          refreshToken: session.refreshToken,
+          user: session.user,
+          isAuthenticated: Boolean(session.accessToken),
+        }),
+      clearSession: () =>
+        set({
+          accessToken: null,
+          refreshToken: null,
+          user: null,
+          isAuthenticated: false,
+        }),
+    }),
+    {
+      name: 'kepler-auth',
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## **User description**
## Description
Adds full sign-in and sign-up pages for Kepler, including Google OAuth support.

- New `SignIn` and `SignUp` pages built with a shared `AuthShell` layout (space-themed background with animated particles and orbital rings, consistent with Kepler's visual identity)
- Form validation via Zod schemas (`signInSchema`, `signUpSchema`) with react-hook-form + zodResolver, including password strength rules (uppercase, lowercase, number, special character) and confirm-password matching
- Google OAuth sign-in flow via `useGoogleAuth` / `useGoogleSignIn` hooks, with a "Continue with Google" button that gracefully disables and shows a config warning if `VITE_GOOGLE_CLIENT_ID` isn't set
- New `authStore` (session state) and `auth` service (API calls for login/signup)
- Reusable auth UI components: `TextField`, `PasswordField` (with show/hide toggle), `SubmitButton` (shimmer effect), `GoogleButton`, `Divider`
- New `AuthLayout` for auth routes (no navbar/footer, scroll enabled)
- Backend: updated `auth.py`, `config.py`, `main.py`, and `db_models.py` to support the new auth flow

## Related Issue
Fixes #68 

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [ ] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings
<img width="959" height="473" alt="Screenshot 2026-07-20 021053" src="https://github.com/user-attachments/assets/f08eb307-894f-4b71-9e4c-eb1fcdf4e596" />
<img width="1918" height="949" alt="image" src="https://github.com/user-attachments/assets/223e1edd-8b71-45c2-82e9-9b4c46ec1a25" />



## Breaking Changes
None. Adds new routes and components; existing functionality is unaffected.

---
## ECSoC26 Submission
- [ ] `ECSoC26-L1` – Beginner
- [x] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

___

## **CodeAnt-AI Description**
**Add Google and password sign-in pages**

### What Changed
- Added dedicated sign-in and sign-up pages with a shared auth screen, separate routes, and links between them
- Users can now register with name, email, and password, sign in with email and password, or continue with Google
- Forms now show field-specific validation errors, password rules, password confirmation checks, and a working show/hide password control
- Google sign-in is disabled with a clear message when setup is missing, and successful sign-in now creates or reuses the account before sending the user to the dashboard
- Existing accounts are also updated to support Google profile details such as display name and avatar
- Older databases are handled automatically on startup so the new auth fields can be used without a manual migration

### Impact
`✅ Faster account creation`
`✅ Fewer failed sign-in attempts`
`✅ Clearer Google sign-in setup warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email/password sign-in and account registration flows.
  * Added Google sign-in with automatic account linking or registration.
  * Added dedicated, accessible sign-in and sign-up pages with validation, password visibility controls, loading states, and error feedback.
  * Added persistent authentication sessions and profile details.
  * Added support for user names, avatars, and authentication provider information.
* **Bug Fixes**
  * Improved compatibility with existing databases by automatically adding required authentication fields at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds full sign-in and sign-up pages with Google OAuth support, including a shared `AuthShell` layout, Zod-validated forms, a Zustand auth store, and a new backend `/auth/google` endpoint that verifies tokens directly with Google before creating or linking user accounts.

- New `SignIn` and `SignUp` pages with react-hook-form + Zod validation and a space-themed `AuthShell` component; Google sign-in is gated behind `VITE_GOOGLE_CLIENT_ID` with a visible \"not configured\" warning.
- Backend adds a `/auth/google` endpoint that validates Google tokens via the tokeninfo/userinfo APIs, handles the first-time-user creation flow, and links existing accounts by `google_sub` then email.
- A startup `_ensure_user_auth_columns` helper applies the new columns to existing databases; the `authStore` persists both tokens to `localStorage` via Zustand's `persist` middleware.

<h3>Confidence Score: 3/5</h3>

Needs fixes in the Google token verification logic and the auth store before merging to production.

The Google token verification function has two holes that could allow unintended accounts in when GOOGLE_CLIENT_ID is configured: the audience check is silently skipped when aud is absent, and the email_verified guard passes when the field is missing. The concurrent new-user creation path has no protection against a race that produces an unhandled 500, and both JWT tokens land in localStorage. Frontend pages, validation, hooks, and backend model changes are well-structured.

backend/api/v1/endpoints/auth.py (token verification logic) and frontend/src/store/authStore.ts (token persistence strategy) need the most attention before this goes to production.

<details open><summary><h3>Security Review</h3></summary>

- **Token audience bypass** (`backend/api/v1/endpoints/auth.py`): When `GOOGLE_CLIENT_ID` is configured, a Google token whose `aud`/`azp` field is absent passes the audience check — the guard short-circuits on a falsy `aud`.
- **Unverified email accepted** (`backend/api/v1/endpoints/auth.py`): `if email_verified in (False, \"false\")` only blocks an explicit false; a missing or `None` field passes silently.
- **JWT tokens in localStorage** (`frontend/src/store/authStore.ts`): Both tokens are persisted to `localStorage`, readable by any JS on the page if an XSS vulnerability exists.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| backend/api/v1/endpoints/auth.py | New Google OAuth endpoint with security gaps: audience check bypassed when `aud` is absent, `email_verified` guard passes on missing field, and non-atomic user creation causes unhandled 500 on race. |
| frontend/src/store/authStore.ts | Persists both access and refresh tokens to localStorage via Zustand's default storage, exposing long-lived credentials to XSS. |
| frontend/src/services/auth.ts | Clean API wrapper; registration makes two round-trips and sends the plaintext password twice. |
| backend/app/main.py | Adds a startup migration helper that ALTER TABLEs missing columns with hardcoded values. |
| backend/models/db_models.py | Adds `full_name`, `auth_provider`, `google_sub` (unique+indexed), and `avatar_url` columns to the User model cleanly. |
| frontend/src/hooks/useGoogleAuth.ts | Loads GIS script lazily with correct deduplication and cancellation flag. |
| frontend/src/pages/SignIn.tsx | Well-structured sign-in page with react-hook-form + Zod validation, error mapping, and redirect-if-authenticated guard. |
| frontend/src/pages/SignUp.tsx | Sign-up page mirrors SignIn structure; form validation, conflict error mapping, and Google OAuth path all look correct. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
backend/api/v1/endpoints/auth.py:178-180
**Unverified Google emails pass when the field is absent**

The check `if email_verified in (False, "false")` only blocks an explicitly false value. If Google's response omits the field entirely (or returns it as `None`), the condition evaluates to `False` and the unverified account is accepted. The guard should also reject missing/truthy-false values: `if not email_verified or email_verified in (False, "false"):`.

### Issue 2 of 6
backend/api/v1/endpoints/auth.py:170-172
**Audience check silently skipped when `aud` is absent**

The guard `if settings.GOOGLE_CLIENT_ID and aud and aud != settings.GOOGLE_CLIENT_ID:` only fires when `aud` is truthy. If Google's tokeninfo response omits the `aud`/`azp` field, `aud` is `None` and the entire audience check is bypassed — accepting any Google-signed token regardless of which app it was issued for. When `GOOGLE_CLIENT_ID` is configured, a missing audience should be treated the same as a mismatch.

```suggestion
    if settings.GOOGLE_CLIENT_ID and (not aud or aud != settings.GOOGLE_CLIENT_ID):
        logger.warning("Google token audience mismatch: %s", aud)
        raise UnauthorizedError("This Google sign-in was issued for another app.")
```

### Issue 3 of 6
backend/api/v1/endpoints/auth.py:201-239
**Race condition: concurrent first-time Google sign-ins cause unhandled 500**

The check-then-insert sequence (query for user → not found → INSERT) is non-atomic. Two concurrent requests for the same new Google account both pass the `if not user:` branch, then both attempt `db.add(user); db.commit()`. The second commit hits the unique constraint on `email` (or `google_sub`) and raises an `IntegrityError` that is not caught, returning a 500 to the user. Wrapping the insert in a try/except for `IntegrityError` and re-querying for the existing user in that branch would close the gap.

### Issue 4 of 6
frontend/src/store/authStore.ts:14-46
**Access and refresh tokens persisted in localStorage**

Zustand's `persist` middleware, when no `storage` option is provided, defaults to `localStorage`. Both `accessToken` and `refreshToken` are included in `partialize`, so any JavaScript running on the page (e.g. from an XSS vulnerability) can read both tokens via `localStorage.getItem('kepler-auth')`. Storing a long-lived refresh token here is especially risky. Consider using `sessionStorage` for the access token and storing the refresh token in an `HttpOnly` cookie set by the backend, or at minimum exclude `refreshToken` from the persisted slice.

### Issue 5 of 6
frontend/src/services/auth.ts:88-101
**Double round-trip and password re-sent on registration**

After a successful `/auth/register` call the backend response is discarded and `login()` is called immediately with the same plaintext password, making two separate network requests. If the second call fails (e.g. transient network error), the user has an account but sees an error and doesn't know they're already registered. The backend `/register` endpoint could return a `Token` directly (like `/google` does), which would also eliminate the extra credential transmission.

### Issue 6 of 6
frontend/src/pages/PlaceholderPage.tsx:60
**Commented-out export should be deleted**

The `SignInPage` placeholder is now superseded by the real `SignIn` page. Leaving it as a comment adds noise — it should be removed entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor AuthShell and SubmitButton comp..."](https://github.com/7-blocks/kepler/commit/fee598cbc8e9b7fb4773cce3b955258485c683dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45533632)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->