### PR TITLE
fix: resolve Vercel deployment failure and production build issues

### DIFF
--- a/frontend/src/components/MaterialIcon.tsx
+++ b/frontend/src/components/MaterialIcon.tsx
@@ -4,13 +4,14 @@ interface MaterialIconProps {
   name: string;
   className?: string;
   filled?: boolean;
+  style?: React.CSSProperties;
 }
 
-export const MaterialIcon: React.FC<MaterialIconProps> = ({ name, className = '', filled = false }) => {
+export const MaterialIcon: React.FC<MaterialIconProps> = ({ name, className = '', filled = false, style }) => {
   return (
     <span
       className={`material-symbols-outlined select-none align-middle ${className}`}
-      style={filled ? { fontVariationSettings: "'FILL' 1" } : undefined}
+      style={filled ? { fontVariationSettings: "'FILL' 1", ...style } : style}
     >
       {name}
     </span>

--- a/frontend/src/components/ui/magic-card.tsx
+++ b/frontend/src/components/ui/magic-card.tsx
@@ -47,7 +47,21 @@ interface MagicCardOrbProps extends MagicCardBaseProps {
   gradientOpacity?: never
 }
 
-type MagicCardProps = MagicCardGradientProps | MagicCardOrbProps
+interface MagicCardMixedProps extends MagicCardBaseProps {
+  mode: "orb" | "gradient"
+
+  gradientColor?: string
+  gradientOpacity?: number
+
+  glowFrom?: string
+  glowTo?: string
+  glowAngle?: number
+  glowSize?: number
+  glowBlur?: number
+  glowOpacity?: number
+}
+
+type MagicCardProps = MagicCardGradientProps | MagicCardOrbProps | MagicCardMixedProps
 type ResetReason = "enter" | "leave" | "global" | "init"
 
 function isOrbMode(props: MagicCardProps): props is MagicCardOrbProps {

--- a/frontend/src/pages/DevelopersPage.tsx
+++ b/frontend/src/pages/DevelopersPage.tsx
@@ -8,7 +8,7 @@ import { MaterialIcon } from "@/components/MaterialIcon";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 24 },
-  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.16, 1, 0.3, 1] } },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] } },
 };
 
 const stagger = {
@@ -123,7 +123,7 @@ function DevelopersHero() {
       <motion.div
         initial={reduce ? undefined : { opacity: 0, y: 30 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+        transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] }}
         className="relative z-10 max-w-4xl mx-auto text-center"
       >
         <div className="inline-flex items-center gap-2 rounded-full border border-[#7c3aed]/20 bg-[#7c3aed]/10 px-5 py-2 text-xs uppercase tracking-[0.22em] text-[#a855f7] mb-8">

--- a/frontend/src/pages/ProductPage.tsx
+++ b/frontend/src/pages/ProductPage.tsx
@@ -8,7 +8,7 @@ import { MaterialIcon } from "@/components/MaterialIcon";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 24 },
-  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.16, 1, 0.3, 1] } },
+  show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] } },
 };
 
 const stagger = {
@@ -134,7 +134,7 @@ function ProductHero() {
       <motion.div
         initial={reduce ? undefined : { opacity: 0, y: 30 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+        transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] }}
         className="relative z-10 max-w-4xl mx-auto text-center"
       >
         <div className="inline-flex items-center gap-2 rounded-full border border-[#00e5ff]/20 bg-[#00e5ff]/10 px-5 py-2 text-xs uppercase tracking-[0.22em] text-[#00e5ff] mb-8">


### PR DESCRIPTION
## 📌 Related Issue

Fixes the Vercel deployment failure that occurred after the previous PR was merged.

---

## 📖 Summary

This PR resolves the production deployment failure on Vercel by identifying and fixing the underlying build issues while preserving all existing functionality and UI.

---

## 🔧 What Was Fixed

- Fixed the root cause of the Vercel deployment failure.
- Resolved production build issues.
- Corrected deployment-specific errors.
- Fixed import/export or path issues (if applicable).
- Ensured Linux/Vercel compatibility.
- Removed build-breaking issues.
- Verified project configuration for production deployment.

---

## ✅ Verification

### Build & Quality

- ✅ `npm install` completed successfully
- ✅ `npm run lint` passes
- ✅ `npm run build` passes
- ✅ TypeScript checks pass (if applicable)
- ✅ No production build errors
- ✅ No deployment-blocking issues

### Deployment

- ✅ Successfully pushed the fix to the same branch
- ✅ Triggered a new Vercel deployment
- ✅ Deployment completes successfully
- ✅ Project is production-ready

---

## 📋 Checklist

- [x] Root cause identified
- [x] Deployment issue fixed
- [x] No UI or functionality changes
- [x] No merge conflicts
- [x] Production build passes
- [x] Lint passes
- [x] TypeScript checks pass (if applicable)
- [x] Successfully deployed on Vercel

## **CodeAnt-AI Description**
**Fix build issues that blocked deployment and preserve existing page behavior**

### What Changed
- Fixed type errors that were preventing the site from building and deploying
- Allowed the icon component to accept custom styles without losing its filled icon appearance
- Expanded the card component so pages can use gradient, orb, or combined visual settings without errors

### Impact
`✅ Fewer deployment failures`
`✅ Shorter release delays`
`✅ Clearer page rendering for styled icons`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom styling on material icons, including filled-icon configurations.
  * Expanded Magic Card visual configuration options, allowing gradient and orb effects to be combined.
* **Style**
  * Improved animation transition handling across developer and product pages for smoother, more consistent effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four TypeScript build errors that were blocking Vercel deployment, with minimal logic changes.

- **Ease arrays** in `DevelopersPage.tsx` and `ProductPage.tsx` are cast to `[number, number, number, number]` tuples so framer-motion's `Variants` type accepts them.
- **`MaterialIcon`** gains an optional `style` prop with correct merge logic (filled settings first, caller styles spread last).
- **`MagicCardMixedProps`** is added to `magic-card.tsx` as a third union variant so a conditional `mode={condition ? \"orb\" : \"gradient\"}` expression compiles; however, this broadens the type and removes the `never` guard that prevented mixing orb-only and gradient-only props simultaneously.

<h3>Confidence Score: 4/5</h3>

The build-blocking errors are resolved and no runtime behaviour changes; the two concerns are type-system only and do not affect rendered output.

The MagicCardMixedProps approach works at runtime but quietly widens the accepted prop surface — future callers can now mix orb-only and gradient-only props on a single instance without a compiler warning, which was explicitly prevented before. The fontVariationSettings spread order in MaterialIcon also lets callers silently override filled behaviour. Neither issue breaks anything today, but both represent small regressions in the type contracts the codebase had established.

frontend/src/components/ui/magic-card.tsx deserves a second look on the MagicCardMixedProps design; frontend/src/components/MaterialIcon.tsx has a minor style-merge ordering point worth confirming is intentional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/ui/magic-card.tsx | Adds MagicCardMixedProps to satisfy the TypeScript discriminated union; the new variant removes the never guards, weakening type safety and making the isOrbMode type guard unsound for mixed instances. |
| frontend/src/components/MaterialIcon.tsx | Adds optional style prop; merge order allows callers to override fontVariationSettings even when filled=true, which may or may not be intentional. |
| frontend/src/pages/DevelopersPage.tsx | Casts two easing arrays to the required [number, number, number, number] tuple type; correct and safe fix. |
| frontend/src/pages/ProductPage.tsx | Same easing-array tuple casts as DevelopersPage; the conditional mode on the pricing card that motivated MagicCardMixedProps is at line 404. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MagicCard props passed by caller"] --> B{TypeScript union resolution}
    B -->|"mode === 'gradient' literal"| C["MagicCardGradientProps"]
    B -->|"mode === 'orb' literal"| D["MagicCardOrbProps"]
    B -->|"mode = cond ? 'orb' : 'gradient' union type"| E["MagicCardMixedProps NEW - no never guards"]
    C --> F["Render gradient overlay"]
    D --> G["Render orb glow"]
    E --> H{Runtime: props.mode}
    H -->|"=== 'orb'"| G
    H -->|"=== 'gradient'"| F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["MagicCard props passed by caller"] --> B{TypeScript union resolution}
    B -->|"mode === 'gradient' literal"| C["MagicCardGradientProps"]
    B -->|"mode === 'orb' literal"| D["MagicCardOrbProps"]
    B -->|"mode = cond ? 'orb' : 'gradient' union type"| E["MagicCardMixedProps NEW - no never guards"]
    C --> F["Render gradient overlay"]
    D --> G["Render orb glow"]
    E --> H{Runtime: props.mode}
    H -->|"=== 'orb'"| G
    H -->|"=== 'gradient'"| F
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
frontend/src/components/ui/magic-card.tsx:50-64
**MagicCardMixedProps removes discriminated-union guards**

The original `MagicCardGradientProps` / `MagicCardOrbProps` pair used `never` to ensure orb-only props (`glowFrom`, `glowTo`, …) couldn't appear alongside gradient-only props (`gradientColor`, `gradientOpacity`) and vice versa. `MagicCardMixedProps` makes all of those optional with no `never` restrictions, so TypeScript will silently accept an object that mixes both sets of props — something the design explicitly prevented. Additionally, `isOrbMode` is typed as `props is MagicCardOrbProps`, but a `MagicCardMixedProps` instance that passes the runtime check is not actually narrowed to `MagicCardOrbProps` (which has `gradientColor?: never`), making the guard technically unsound for that variant.

A narrower fix that preserves type safety would be to keep the discriminated union and cast only at the call site, or introduce a wrapper component that accepts both and delegates. As written, any future consumer can now mix orb and gradient props on `MagicCardMixedProps` instances without a compile-time warning.

### Issue 2 of 2
frontend/src/components/MaterialIcon.tsx:14
When `filled=true`, the spread order lets a caller's `style` object override `fontVariationSettings`, so passing `style={{ fontVariationSettings: "'FILL' 0" }}` silently disables the fill despite `filled={true}`. Reversing the spread keeps the filled setting authoritative while still forwarding other style properties.

```suggestion
      style={filled ? { ...style, fontVariationSettings: "'FILL' 1" } : style}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve TypeScript build errors blo..."](https://github.com/7-blocks/kepler/commit/e7d690875d7dadbeb5b4b416bcfb230ea48f819a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45693470)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->