### PR TITLE
feat: add Earth day/night terminator visualization

### DIFF
--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -190,12 +190,16 @@ export const EarthTwin: React.FC = () => {
         const pixelSize = isCollisionRisk ? 8 : getPointSize(obj.classification);
         const outlineWidth = isCollisionRisk ? 3 : getOutlineWidth(obj.classification);
 
+        const cartPos = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000);
+        const nowJulian = Cesium.JulianDate.now();
+        const sunlit = isSatelliteSunlit(cartPos, nowJulian, viewer.scene.globe);
+
         const entity = viewer.entities.add({
-          position: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000),
+          position: cartPos,
           point: {
             pixelSize,
-            color: colorConfig.cesium.withAlpha(0.85),
-            outlineColor: colorConfig.cesium.withAlpha(0.4),
+            color: sunlit ? colorConfig.cesium.withAlpha(0.85) : colorConfig.cesium.withAlpha(0.3),
+            outlineColor: sunlit ? colorConfig.cesium.withAlpha(0.4) : colorConfig.cesium.withAlpha(0.1),
             outlineWidth,
             disableDepthTestDistance: Number.POSITIVE_INFINITY,
             scaleByDistance: new Cesium.NearFarScalar(1e6, 1.5, 5e7, 0.4),
@@ -287,7 +291,7 @@ export const EarthTwin: React.FC = () => {
       setUseFallback(false);
 
       
-      viewer.scene.globe.enableLighting = false;
+      viewer.scene.globe.enableLighting = true; // Enable real-time day/night lighting
       viewer.scene.backgroundColor = Cesium.Color.fromCssColorString('#050710');
       viewer.scene.fog.enabled = false;
       if (viewer.scene.skyAtmosphere) {

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { MaterialIcon } from './MaterialIcon';
 import * as Cesium from 'cesium';
+import { isSatelliteSunlit } from '../utils/illumination';
 
 interface CatalogObject {
   id: number;
@@ -171,7 +172,7 @@ export const EarthTwin: React.FC = () => {
 
       
       viewer.entities.removeAll();
-
+const nowJulian = Cesium.JulianDate.now();
       objects.forEach(obj => {
         const pos = keplerToLatLonAlt(obj);
         if (!pos) return;
@@ -191,8 +192,7 @@ export const EarthTwin: React.FC = () => {
         const outlineWidth = isCollisionRisk ? 3 : getOutlineWidth(obj.classification);
 
         const cartPos = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000);
-        const nowJulian = Cesium.JulianDate.now();
-        const sunlit = isSatelliteSunlit(cartPos, nowJulian, viewer.scene.globe);
+                const sunlit = isSatelliteSunlit(cartPos, nowJulian, viewer.scene.globe);
 
         const entity = viewer.entities.add({
           position: cartPos,

--- a/frontend/src/utils/illumination.ts
+++ b/frontend/src/utils/illumination.ts
@@ -19,7 +19,8 @@ export function isSatelliteSunlit(
 
   // Convert Sun position to Earth‑Fixed frame.
   const temeToFixed = Cesium.Transforms.computeTemeToPseudoFixedMatrix(julianDate);
-  const sunPosFixed = Cesium.Matrix4.multiplyByPoint(temeToFixed, sunPosInertial, new Cesium.Cartesian3());
+  if (!temeToFixed) return false;
+  const sunPosFixed = Cesium.Matrix3.multiplyByVector(temeToFixed, sunPosInertial, new Cesium.Cartesian3());
 
   // Vector from satellite to Sun.
   const satToSun = Cesium.Cartesian3.subtract(sunPosFixed, position, new Cesium.Cartesian3());
@@ -29,7 +30,7 @@ export function isSatelliteSunlit(
   const ray = new Cesium.Ray(position, direction);
 
   // Test intersection with Earth's ellipsoid (WGS84).
-  const intersection = Cesium.IntersectionTests.rayEllipsoid(ray, Cesium.Ellipsoid.WGS84);
+  const intersection = Cesium.IntersectionTests.rayEllipsoid(ray, globe.ellipsoid);
 
   // If there is no intersection, the satellite is sunlit.
   if (!intersection) return true;

--- a/frontend/src/utils/illumination.ts
+++ b/frontend/src/utils/illumination.ts
@@ -1,0 +1,45 @@
+import * as Cesium from 'cesium';
+
+/**
+ * Determines whether a satellite at the given position is illuminated by the Sun.
+ * Returns true if the line of sight from the satellite to the Sun does not intersect the Earth.
+ *
+ * @param position - Satellite position in Earth-centered fixed (ECEF) coordinates.
+ * @param julianDate - Current Cesium JulianDate (typically Cesium.JulianDate.now()).
+ * @param globe - The Cesium Globe instance (used for ellipsoid reference).
+ */
+export function isSatelliteSunlit(
+  position: Cesium.Cartesian3,
+  julianDate: Cesium.JulianDate,
+  globe: Cesium.Globe
+): boolean {
+  // Compute Sun position in the Earth‑Centered Inertial (ECI) frame.
+  const sunPosInertial = new Cesium.Cartesian3();
+  Cesium.Simon1994PlanetaryPositions.computeSunPositionInEarthInertialFrame(julianDate, sunPosInertial);
+
+  // Convert Sun position to Earth‑Fixed frame.
+  const temeToFixed = Cesium.Transforms.computeTemeToPseudoFixedMatrix(julianDate);
+  const sunPosFixed = Cesium.Matrix4.multiplyByPoint(temeToFixed, sunPosInertial, new Cesium.Cartesian3());
+
+  // Vector from satellite to Sun.
+  const satToSun = Cesium.Cartesian3.subtract(sunPosFixed, position, new Cesium.Cartesian3());
+  const direction = Cesium.Cartesian3.normalize(satToSun, new Cesium.Cartesian3());
+
+  // Ray from satellite toward the Sun.
+  const ray = new Cesium.Ray(position, direction);
+
+  // Test intersection with Earth's ellipsoid (WGS84).
+  const intersection = Cesium.IntersectionTests.rayEllipsoid(ray, Cesium.Ellipsoid.WGS84);
+
+  // If there is no intersection, the satellite is sunlit.
+  if (!intersection) return true;
+
+  // Distance from satellite to Sun.
+  const distanceToSun = Cesium.Cartesian3.distance(position, sunPosFixed);
+
+  // Intersection distance along the ray (already normalized).
+  const distanceToEarth = intersection.start;
+
+  // Satellite is sunlit if the Earth lies beyond the Sun.
+  return distanceToEarth > distanceToSun;
+}


### PR DESCRIPTION
## **User description**
## Description

- 

This PR adds a real-time Earth day/night terminator visualization to the Cesium globe.

### Changes
- Enabled Cesium globe lighting for realistic day/night shading.
- Added a reusable `illumination.ts` utility to determine whether a satellite is sunlit or inside Earth's shadow.
- Updated satellite rendering to visually dim satellites while they are in Earth's shadow.
- Optimized illumination calculations by:
  - Computing the satellite Cartesian3 position once per satellite.
  - Computing the current JulianDate once per update.
  - Reusing the illumination result for both color and outline rendering.

## Related Issue

Fixes #92

## Checklist

- [x] I have read the contributing guidelines

- [x] My code follows the project guidelines
- [ ] I have completed testing of my changes
- [ ] Documentation has been updated (if applicable)

> If you were **not able to complete testing** because the project currently has unrelated TypeScript/build errors, leave the testing box unchecked.

## Screenshots / Screen Recordings

<img width="1470" height="956" alt="Screenshot 2026-07-21 at 2 22 08 AM" src="https://github.com/user-attachments/assets/ac2e0f20-5044-428e-9bbc-12dd93cecb21" />

<img width="1470" height="956" alt="Screenshot 2026-07-21 at 2 24 41 AM" src="https://github.com/user-attachments/assets/cd46ab2d-c956-4f8c-961f-cc114a431d36" />

<img width="1470" height="956" alt="Screenshot 2026-07-21 at 2 25 50 AM" src="https://github.com/user-attachments/assets/ed458cca-8f1e-4c8d-815b-040ad49dfab5" />


## Breaking Changes

No breaking changes.

---

## ECSoC26 Submission

- [ ] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [x] `ECSoC26-L3` – Advanced


___

## **CodeAnt-AI Description**
Make satellites dim when they pass into Earth’s shadow and show a lit day/night globe

### What Changed
- The globe now uses real day/night lighting, so the Earth shows a visible terminator line.
- Satellites are dimmed when they are not sunlit, making shadowed objects easier to distinguish from lit ones.
- Sunlit and shadowed satellites keep their size and highlighting, but their brightness changes based on whether they are in Earth’s shadow.

### Impact
`✅ Clearer Earth day/night view`
`✅ Easier to spot shadowed satellites`
`✅ More realistic globe lighting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Satellite markers now update in real time to reflect illumination status, with brighter styling when sunlit and dimmer styling when Earth-shadowed.
  * Globe lighting has been enabled to improve overall visual realism and how lighting affects the scene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds real-time Earth day/night terminator visualization by enabling Cesium globe lighting and introducing `illumination.ts`, which computes per-satellite shadow status via a sun-position / ellipsoid ray-intersection test.

- Previously flagged issues (missing import, `Matrix4` vs `Matrix3` API, unused `globe` parameter, `JulianDate.now()` inside the loop) are all resolved in this revision.
- The core shadow-detection logic is correct: a ray from the satellite toward the sun is tested against WGS84; if Earth intersects that ray closer than the sun the satellite is dimmed.
- One remaining efficiency gap: `computeSunPositionInEarthInertialFrame` and `computeTemeToPseudoFixedMatrix` are called once per satellite per frame rather than once per frame, repeating identical work for every object in the scene.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the illumination logic is geometrically correct and all blocking issues from earlier reviews have been addressed.

The shadow-detection algorithm is sound: the Matrix3 API is used correctly, the globe ellipsoid is referenced through the parameter rather than hardcoded, the import is present, and JulianDate allocation is hoisted outside the per-satellite loop. Remaining feedback is about a redundant per-satellite sun-position recomputation and a formatting inconsistency, neither of which affects correctness.

No files require special attention beyond the optional refactor in illumination.ts to hoist sun-position computation out of per-satellite calls.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/utils/illumination.ts | New utility computing satellite illumination via sun-position / ellipsoid ray test; previously flagged Matrix3/globe issues are fixed, but sun position and TEME matrix are recomputed on every per-satellite call. |
| frontend/src/components/EarthTwin.tsx | Import and JulianDate hoisting are correct; minor indentation inconsistency introduced around the nowJulian and sunlit lines. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant ET as EarthTwin.tsx
    participant IL as illumination.ts
    participant CES as Cesium APIs

    ET->>ET: JulianDate.now() [once per frame]
    loop for each satellite
        ET->>ET: "keplerToLatLonAlt(obj) → {lat,lon,alt}"
        ET->>ET: Cartesian3.fromDegrees(lon,lat,alt)
        ET->>IL: isSatelliteSunlit(cartPos, nowJulian, globe)
        IL->>CES: Simon1994.computeSunPositionInEarthInertialFrame(julianDate)
        IL->>CES: Transforms.computeTemeToPseudoFixedMatrix(julianDate)
        IL->>CES: Matrix3.multiplyByVector(teme, sunInertial) → sunPosFixed
        IL->>CES: IntersectionTests.rayEllipsoid(ray, ellipsoid)
        IL-->>ET: boolean (sunlit)
        ET->>CES: "viewer.entities.add({ color based on sunlit })"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant ET as EarthTwin.tsx
    participant IL as illumination.ts
    participant CES as Cesium APIs

    ET->>ET: JulianDate.now() [once per frame]
    loop for each satellite
        ET->>ET: "keplerToLatLonAlt(obj) → {lat,lon,alt}"
        ET->>ET: Cartesian3.fromDegrees(lon,lat,alt)
        ET->>IL: isSatelliteSunlit(cartPos, nowJulian, globe)
        IL->>CES: Simon1994.computeSunPositionInEarthInertialFrame(julianDate)
        IL->>CES: Transforms.computeTemeToPseudoFixedMatrix(julianDate)
        IL->>CES: Matrix3.multiplyByVector(teme, sunInertial) → sunPosFixed
        IL->>CES: IntersectionTests.rayEllipsoid(ray, ellipsoid)
        IL-->>ET: boolean (sunlit)
        ET->>CES: "viewer.entities.add({ color based on sunlit })"
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/EarthTwin.tsx`, line 175-194 ([link](https://github.com/7-blocks/kepler/blob/88791790495355ca4a718d70aa244afce31109d5/frontend/src/components/EarthTwin.tsx#L175-L194)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The PR description claims "Computing the current JulianDate once per update," but `Cesium.JulianDate.now()` is called inside `objects.forEach`, allocating a new object per satellite. With 500 objects this is 500 allocations. Moving it above the loop matches the stated intent and eliminates the redundancy.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/components/EarthTwin.tsx
   Line: 175-194

   Comment:
   The PR description claims "Computing the current JulianDate once per update," but `Cesium.JulianDate.now()` is called inside `objects.forEach`, allocating a new object per satellite. With 500 objects this is 500 allocations. Moving it above the loop matches the stated intent and eliminates the redundancy.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback"](https://github.com/7-blocks/kepler/commit/961dfe9fa849c915a59918e3488ff3c5ae19c73f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45702285)</sub>

<!-- /greptile_comment -->