### PR TITLE
fix(ingestion): persist debris records and repair the model schema (fixes #117)

### DIFF
--- a/backend/models/db_models.py
+++ b/backend/models/db_models.py
@@ -418,7 +418,7 @@ class SpaceWeather(Base):
     k_index: Mapped[Optional[int]] = mapped_column(Integer)
     description: Mapped[Optional[str]] = mapped_column(Text)
     recorded_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), index=True
+        DateTime(timezone=True), server_default=func.now()
     )
 
     @property

--- a/backend/orbital/spacetrack.py
+++ b/backend/orbital/spacetrack.py
@@ -199,7 +199,9 @@ class SpaceTrackService:
         epoch        = _parse_epoch(rec.get("EPOCH", ""))
         tle1         = rec.get("TLE_LINE1") or rec.get("LINE1")
         tle2         = rec.get("TLE_LINE2") or rec.get("LINE2")
-        now          = datetime.datetime.utcnow().isoformat()
+        # A real, timezone-aware datetime: `updatedAt` is a DateTime(timezone=True)
+        # column, not the ISO string the MongoDB schema used to store.
+        now          = datetime.datetime.now(datetime.timezone.utc)
 
         return {
             "noradId":          norad_id,
@@ -237,6 +239,14 @@ class SpaceTrackService:
             return 0, []
 
         model = Debris if is_debris else Satellite
+
+        # `_gp_to_doc` emits one satellite-shaped dict for every provider, but `debris` is
+        # a narrower table (no objectType/status/updatedAt/…). Passing those through made
+        # every debris write fail — CompileError on PostgreSQL, TypeError on SQLite — so
+        # project each doc onto the columns the target model actually has.
+        columns = {c.name for c in model.__table__.columns}
+        docs = [{k: v for k, v in doc.items() if k in columns} for doc in docs]
+
         failed: List[str] = []
         written = 0
 

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -144,6 +144,48 @@ def test_rerun_does_not_create_duplicates(sqlite_db):
     assert sqlite_db.query(Satellite).count() == 1
 
 
+def test_debris_records_are_persisted(sqlite_db):
+    """
+    Regression: debris ingestion wrote nothing at all.
+
+    `_gp_to_doc` emits one satellite-shaped dict for every provider, but `debris` is a
+    narrower table. Passing the extra keys through made every debris write fail —
+    CompileError ("Unconsumed column names") on PostgreSQL, TypeError on SQLite — so the
+    catalog silently gained no debris on either backend.
+    """
+    from models.db_models import Debris
+
+    records = [
+        _make_gp_record("50032", "COSMOS 1408 DEB", "DEBRIS"),
+        _make_gp_record("50033", "FENGYUN 1C DEB", "DEBRIS"),
+    ]
+    svc = _build_service({"analyst": records})
+
+    status = svc.sync_group(sqlite_db, "analyst", "DEBRIS", limit=500)
+
+    assert status["upserted"] == 2
+    assert status["failed"] == 0
+    assert sqlite_db.query(Debris).count() == 2
+
+    row = sqlite_db.query(Debris).filter(Debris.noradId == "50032").one()
+    assert row.objectName == "COSMOS 1408 DEB"
+
+
+def test_satellite_timestamps_are_datetimes_not_strings(sqlite_db):
+    """
+    Regression: `updatedAt` was written as an ISO *string* (a MongoDB-era leftover) into a
+    DateTime(timezone=True) column, which SQLAlchemy's SQLite DateTime rejects outright.
+    """
+    import datetime
+    from models.db_models import Satellite
+
+    svc = _build_service({"active": [_make_gp_record("25544", "ISS")]})
+    svc.sync_group(sqlite_db, "active", "PAYLOAD", limit=500)
+
+    sat = sqlite_db.query(Satellite).one()
+    assert isinstance(sat.updatedAt, datetime.datetime)
+
+
 def test_all_groups_sync_returns_meaningful_status(sqlite_db):
     from models.db_models import Satellite, Debris
     payloads = {

--- a/backend/tests/test_models_schema.py
+++ b/backend/tests/test_models_schema.py
@@ -1,0 +1,65 @@
+"""
+Schema-level invariants for the SQLAlchemy models.
+
+These guard the metadata itself rather than any query, so a bad declaration is caught at
+collection time instead of surfacing as a confusing failure in an unrelated test.
+"""
+
+from collections import defaultdict
+
+import pytest
+from sqlalchemy import create_engine
+
+from database.session import Base
+import models.db_models  # noqa: F401 — registers all tables
+import orbital.providers.cache  # noqa: F401 — registers ProviderCache
+
+
+def test_index_names_are_unique_case_insensitively():
+    """
+    Regression: `spaceWeather.recorded_at` was indexed twice — once explicitly in
+    `__table_args__` as `ix_spaceweather_recorded_at`, and once implicitly via
+    `index=True`, which SQLAlchemy names `ix_spaceWeather_recorded_at`.
+
+    The two names differ only by case. SQLite treats identifiers case-insensitively, so
+    `create_all()` died with "index ix_spaceweather_recorded_at already exists" and took
+    every test that builds a schema down with it. PostgreSQL quotes the mixed-case name
+    and happily creates *two* redundant indexes on the same column instead.
+    """
+    collisions = []
+    for table in Base.metadata.sorted_tables:
+        by_lower = defaultdict(list)
+        for index in table.indexes:
+            by_lower[index.name.lower()].append(index.name)
+        collisions += [
+            f"{table.name}: {sorted(names)}"
+            for names in by_lower.values()
+            if len(names) > 1
+        ]
+
+    assert not collisions, f"Index names collide case-insensitively: {collisions}"
+
+
+def test_no_duplicate_indexes_on_the_same_columns():
+    """Two indexes over identical columns are dead weight on every write."""
+    duplicates = []
+    for table in Base.metadata.sorted_tables:
+        by_columns = defaultdict(list)
+        for index in table.indexes:
+            by_columns[tuple(c.name for c in index.columns)].append(index.name)
+        duplicates += [
+            f"{table.name}{cols}: {sorted(names)}"
+            for cols, names in by_columns.items()
+            if len(names) > 1
+        ]
+
+    assert not duplicates, f"Redundant indexes: {duplicates}"
+
+
+def test_create_all_succeeds_on_a_clean_database():
+    """The whole schema must build from scratch — this is what CI and a fresh dev setup do."""
+    engine = create_engine("sqlite://")
+    try:
+        Base.metadata.create_all(engine)
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## **User description**
## Description

Fixes three defects introduced by the MongoDB → PostgreSQL migration. Each has a one-line cause but an outsized effect — the first means **Kepler currently ingests no debris at all**, on either backend.

I found these while checking that the multi-source provider work (#15) still ran after the migration: the backend test suite does not pass on `main` today.

### 1. Debris ingestion persisted nothing 🔴

`_gp_to_doc` emits one *satellite-shaped* dict for every provider, but `debris` is a narrower table — no `objectType`, `countryCode`, `launchDate`, `updatedAt`, `status`, `fuel_percentage`, `operational_mode`. Passing those keys through made **every** debris write fail:

```
PostgreSQL: CompileError: Unconsumed column names: countryCode, launchDate, …
SQLite:     TypeError: 'objectType' is an invalid keyword argument for Debris
```

On PostgreSQL the whole batch is rolled back and marked failed; on SQLite it fails row by row. Either way the debris catalog stayed empty — on a platform built for debris collision avoidance.

**Fix:** project each document onto the target model's real columns at the write boundary, which covers both dialects and both models.

### 2. `updatedAt` written as a string into a `DateTime` column 🟠

`now = datetime.datetime.utcnow().isoformat()` produced a **string** for a `DateTime(timezone=True)` column — a MongoDB-era leftover (Mongo stored ISO strings, PostgreSQL does not). SQLAlchemy's SQLite `DateTime` rejects strings outright, so satellite ingestion failed there too.

**Fix:** a real timezone-aware `datetime`, which also drops the deprecated `utcnow()`.

### 3. `spaceWeather.recorded_at` indexed twice 🟠

Declared explicitly in `__table_args__` **and** implicitly via `index=True`. The generated names differ only by case:

```
CREATE INDEX "ix_spaceWeather_recorded_at" ON "spaceWeather" (recorded_at)
CREATE INDEX ix_spaceweather_recorded_at  ON "spaceWeather" (recorded_at)
```

- **SQLite** — identifiers are case-insensitive → `create_all()` aborts with *"index already exists"*, taking **10 tests** down at fixture setup.
- **PostgreSQL** — the mixed-case name is quoted → **two redundant indexes** on the same column. No error, but every write pays for both.

**Fix:** drop the redundant `index=True`, keeping the explicitly-named index that matches the convention used by the other tables (`ix_satellites_noradid`, `ix_alerts_created_at`, …).

## Related Issue

Fixes #117

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project guidelines
- [x] I have completed testing of my changes
- [x] Documentation has been updated (if applicable) — n/a, no API surface change

## Testing

| | Before | After |
|---|---|---|
| Backend test suite | 40 passed, **10 errors** | **55 passed** |
| Debris ingested | **0** | 25/25 real CelesTrak records |

**The 5 new tests fail without these fixes**, so they pin the regressions rather than merely describing them (verified by stashing the fixes and re-running):

- `tests/test_models_schema.py` — schema invariants: index names unique case-insensitively, no duplicate indexes on the same columns, and `create_all()` succeeds on a clean database. These guard the metadata itself, so a bad declaration fails at collection time instead of surfacing as a confusing error in an unrelated test.
- `tests/test_ingestion.py` — debris records are persisted, and `updatedAt` round-trips as a `datetime` rather than a string.

**Verified end to end against live CelesTrak data**, not just via tests: 25 real `COSMOS 1408 DEB` records now land in the `debris` table (previously 0), satellites ingest with a proper `datetime`, and a re-sync stays idempotent (no duplicates).

## Breaking Changes

None. No API contract or schema shape changes — the removed index was a duplicate of one that remains, so PostgreSQL deployments simply stop maintaining a second copy. Existing databases need no migration.

___

## **CodeAnt-AI Description**
Fix debris ingestion, timestamp storage, and schema setup failures

### What Changed
- Debris records now save correctly instead of being rejected by extra fields, so debris catalogs no longer stay empty
- Satellite records now store `updatedAt` as a real date and time value, which avoids ingestion failures from text timestamps
- The space weather table no longer defines the same index twice, so creating a fresh database no longer fails during setup
- Added regression tests to catch debris loss, bad timestamp types, duplicate indexes, and schema creation failures

### Impact
`✅ Debris objects now appear in the catalog`
`✅ Fewer ingestion failures on fresh databases`
`✅ Safer schema setup during test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Space-Track ingestion so debris records are saved correctly.
  * Stored satellite update timestamps in a consistent timezone-aware format.
  * Prevented redundant database indexing while preserving efficient lookups.

* **Tests**
  * Added coverage for debris persistence and timestamp handling.
  * Added validation for unique indexes, duplicate index prevention, and clean database setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs debris ingestion and removes a duplicate schema index. The main changes are:

- Filters provider records to the target ORM model’s columns before upsert.
- Stores satellite update timestamps as timezone-aware datetimes.
- Removes the redundant implicit SpaceWeather timestamp index.
- Adds ingestion and schema tests for these fixes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| backend/models/db_models.py | Removes the redundant implicit index while preserving the explicit recorded-at index. |
| backend/orbital/spacetrack.py | Filters ingestion documents by model columns and supplies a DateTime-compatible update timestamp. |
| backend/tests/test_ingestion.py | Adds tests for debris persistence and datetime timestamp storage. |
| backend/tests/test_models_schema.py | Adds checks for duplicate indexes and clean schema creation. |

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): persist debris records a..."](https://github.com/7-blocks/kepler/commit/7e0783910e87b7e8ff121c66160c45eccdeefbbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46099253)</sub>

<!-- /greptile_comment -->