### PR TITLE
Increase TLE line string length to 200 characters

### DIFF
--- a/backend/models/db_models.py
+++ b/backend/models/db_models.py
@@ -101,8 +101,8 @@ class SpaceObject(Base):
     mean_anomaly: Mapped[Optional[float]] = mapped_column(Float)
     mean_motion: Mapped[Optional[float]] = mapped_column(Float)
     period: Mapped[Optional[float]] = mapped_column(Float)
-    tle_line1: Mapped[Optional[str]] = mapped_column(String(100))
-    tle_line2: Mapped[Optional[str]] = mapped_column(String(100))
+    tle_line1: Mapped[Optional[str]] = mapped_column(String(200))
+    tle_line2: Mapped[Optional[str]] = mapped_column(String(200))
     updated_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
@@ -165,8 +165,8 @@ class Satellite(Base):
     operational_mode: Mapped[str] = mapped_column(String(20), default="NORMAL")
     semimajor_axis: Mapped[Optional[float]] = mapped_column(Float)
     period: Mapped[Optional[float]] = mapped_column(Float)
-    tle_line1: Mapped[Optional[str]] = mapped_column(String(100))
-    tle_line2: Mapped[Optional[str]] = mapped_column(String(100))
+    tle_line1: Mapped[Optional[str]] = mapped_column(String(200))
+    tle_line2: Mapped[Optional[str]] = mapped_column(String(200))
 
     organization: Mapped[Optional["Organization"]] = relationship("Organization", back_populates="satellites")
     space_object_rel: Mapped[Optional["SpaceObject"]] = relationship(
@@ -220,8 +220,8 @@ class Debris(Base):
     average_mass: Mapped[Optional[float]] = mapped_column(Float)
     semimajor_axis: Mapped[Optional[float]] = mapped_column(Float)
     period: Mapped[Optional[float]] = mapped_column(Float)
-    tle_line1: Mapped[Optional[str]] = mapped_column(String(100))
-    tle_line2: Mapped[Optional[str]] = mapped_column(String(100))
+    tle_line1: Mapped[Optional[str]] = mapped_column(String(200))
+    tle_line2: Mapped[Optional[str]] = mapped_column(String(200))
 
     space_object_rel: Mapped[Optional["SpaceObject"]] = relationship(
         "SpaceObject", back_populates="debris_details"


### PR DESCRIPTION
## **User description**
## Description

<The standard length of a TLE line is 69 characters. String(100) is enough but leaves a small margin. In fact, some extended formats can exceed 100 characters.>

## Related Issue

<!-- Link to the issue this PR resolves: e.g. Fixes #123 -->

## Checklist

- [✔] I have read the contributing guidelines
- [✔] My code follows the project guidelines
- [✔] I have completed testing of my changes
- [✔] Documentation has been updated (if applicable)

## Screenshots / Screen Recordings

<img width="524" height="41" alt="image" src="https://github.com/user-attachments/assets/e2aa39e3-dc28-4c77-930a-3ebca8390bb2" />
<img width="515" height="38" alt="image" src="https://github.com/user-attachments/assets/bbbb4931-543d-4bd9-851c-a713a4c11264" />
<img width="495" height="38" alt="image" src="https://github.com/user-attachments/assets/55914c22-03a1-4a45-8d94-f2ace7a1c934" />

## Breaking Changes

<!-- Does this PR introduce a breaking change? Please describe it -->

no

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [✔] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

___

## **CodeAnt-AI Description**
**Allow longer TLE lines to be saved**

### What Changed
- TLE line 1 and line 2 can now store up to 200 characters instead of 100
- This applies to space objects, satellites, and debris records, so longer orbit data is no longer cut off

### Impact
`✅ Fewer truncated TLE records`
`✅ More complete orbit data storage`
`✅ Fewer import errors for extended TLE formats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the supported storage length for both TLE data lines.
  - Prevented longer TLE values from being truncated or rejected when saving space object, satellite, and debris records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR widens the `tle_line1` and `tle_line2` database columns from `String(100)` to `String(200)` across the `SpaceObject`, `Satellite`, and `Debris` models to accommodate extended TLE formats that can exceed 100 characters.

- The model change is applied consistently across all three tables that store TLE data.
- No database migration (Alembic or manual `ALTER TABLE`) is included, meaning existing databases will retain `VARCHAR(100)` columns and reject any TLE strings longer than 100 characters at the database layer — only fresh deployments will see the new limit.

<h3>Confidence Score: 3/5</h3>

The model change is correct in intent but incomplete — existing databases will not reflect the new column width without an accompanying migration, causing runtime errors when extended TLE strings are written.

The Python model is updated consistently across all three affected tables, but create_all() never alters existing columns. Any deployed database initialized before this merge will continue to enforce VARCHAR(100), and attempts to store TLE lines exceeding that length will fail with a database error. A backfill helper (following the existing _ensure_user_auth_columns pattern) or a proper migration is required to make this change effective on live instances.

backend/models/db_models.py has the model fix, but backend/app/main.py needs a companion ALTER TABLE helper (similar to _ensure_user_auth_columns) to widen the six TLE columns on existing databases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| backend/models/db_models.py | Increases tle_line1/tle_line2 column limits from String(100) to String(200) across SpaceObject, Satellite, and Debris models, but no corresponding ALTER TABLE migration is provided for existing databases. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as FastAPI Startup
    participant SA as SQLAlchemy create_all()
    participant DB as PostgreSQL (existing DB)

    App->>SA: Base.metadata.create_all(engine)
    SA->>DB: CREATE TABLE IF NOT EXISTS space_objects (... tle_line1 VARCHAR(100) ...)
    DB-->>SA: Table already exists — no-op
    SA-->>App: Done (existing columns unchanged)

    Note over DB: tle_line1 / tle_line2 remain VARCHAR(100) — Model now expects VARCHAR(200)

    App->>DB: "INSERT tle_line1 = string longer than 100 chars"
    DB-->>App: ERROR: value too long for type character varying(100)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/models/db_models.py:103-104
**Missing ALTER TABLE migration for existing databases**

`Base.metadata.create_all()` (called in `on_startup`) only creates tables that don't yet exist — it never alters column definitions on existing tables. On any database that was initialized before this change, the `tle_line1` and `tle_line2` columns will remain `VARCHAR(100)`, so inserting an extended TLE string longer than 100 characters will raise a database error. Only fresh deployments will pick up `VARCHAR(200)`.

The project already has a precedent for this pattern: `_ensure_user_auth_columns()` in `app/main.py` uses runtime `ALTER TABLE` statements to patch columns that `create_all` won't touch. A similar helper is needed here (or an Alembic migration) to widen these six columns on existing databases — otherwise the model and the live schema will disagree indefinitely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Increase TLE line string length to 200 c..."](https://github.com/7-blocks/kepler/commit/17ce8ed6d00f20b16a50f50545f54ca1fc0d24f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46538192)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->