### PR TITLE
feat(satellites): add interactive spotlight effect for hover/select (#95)

### DIFF
--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -332,7 +332,7 @@ export const EarthTwin: React.FC = () => {
         catalogMapRef={catalogMapRef}
         collisionSetRef={collisionSetRef}
         datasetVersion={datasetVersion}
-        toLatLonAlt={(obj) => keplerToLatLonAlt(obj)}
+        toLatLonAlt={keplerToLatLonAlt}
         onHoverChange={(obj, pos) => {
           setHoveredObject(obj);
           setTooltipPos(pos);

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -1,77 +1,43 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { MaterialIcon } from './MaterialIcon';
+import { SpotlightManager } from './SatelliteSpotlight/SpotlightManager';
+import type { CatalogObject, CollisionRisk } from '@/types/satellite';
+import { CATEGORY_COLORS, getPointSize, getOutlineWidth } from '@/lib/satelliteVisuals';
+import '@/styles/spotlight.css';
 import * as Cesium from 'cesium';
-import { isSatelliteSunlit } from '../utils/illumination';
-import { useBookmarks } from '../hooks/useBookmarks';
-import type { Bookmark } from '../hooks/useBookmarkStorage';
-import { BookmarkModal, type BookmarkFormValues, } from './GlobeBookmarks/BookMarkModal';
-import { BookmarkSidebar } from './GlobeBookmarks/BookmarkSidebar';
-import {
-  createBookmarkShareUrl,
-  getSharedBookmarkFromUrl,
-} from '../utils/bookmarkHelpers';
-
-
-interface CatalogObject {
-  id: number;
-  name: string;
-  catalog_number: string;
-  classification: 'PAYLOAD' | 'DEBRIS' | 'ROCKET_BODY' | 'UNKNOWN';
-  epoch: string | null;
-  inclination: number | null;
-  eccentricity: number | null;
-  semimajor_axis: number | null;
-  raan: number | null;
-  arg_of_perigee: number | null;
-  mean_anomaly: number | null;
-  mean_motion: number | null;
-  period: number | null;
-  has_tle: boolean;
-  updated_at: string | null;
-}
-
-interface CollisionRisk {
-  id: number;
-  object_a: { name: string; catalog_number: string } | null;
-  object_b: { name: string; catalog_number: string } | null;
-  probability: number;
-  miss_distance_m: number;
-  relative_velocity_kms: number;
-  risk_level: string;
-  tca: string;
-}
 
 
 
 function keplerToLatLonAlt(obj: CatalogObject, timeOffsetSec: number = 0): { lat: number; lon: number; alt: number } | null {
   if (obj.semimajor_axis == null || obj.inclination == null || obj.raan == null ||
-    obj.arg_of_perigee == null || obj.mean_anomaly == null || obj.mean_motion == null) {
+      obj.arg_of_perigee == null || obj.mean_anomaly == null || obj.mean_motion == null) {
     return null;
   }
 
-  const EARTH_RADIUS = 6371;
+  const EARTH_RADIUS = 6371; 
   const alt = obj.semimajor_axis - EARTH_RADIUS;
   if (alt < 0 || alt > 100000) return null;
 
-
+  
   const epochDate = obj.epoch ? new Date(obj.epoch) : new Date();
   const now = new Date();
   const elapsedDays = (now.getTime() - epochDate.getTime()) / 86400000 + (timeOffsetSec / 86400);
+  const meanMotionRadPerSec = (obj.mean_motion * 2 * Math.PI) / 86400;
   const currentMeanAnomaly = ((obj.mean_anomaly + (elapsedDays * obj.mean_motion * 360)) % 360) * Math.PI / 180;
 
-
+  
   const ecc = obj.eccentricity ?? 0;
   const trueAnomaly = currentMeanAnomaly + 2 * ecc * Math.sin(currentMeanAnomaly);
 
-
+  
   const argLat = (obj.arg_of_perigee * Math.PI / 180) + trueAnomaly;
 
-
+  
   const raanRad = obj.raan * Math.PI / 180;
   const incRad = obj.inclination * Math.PI / 180;
 
-
+  
   const J2000 = new Date('2000-01-01T12:00:00Z').getTime();
   const daysSinceJ2000 = (now.getTime() + timeOffsetSec * 1000 - J2000) / 86400000;
   const GMST = (280.46061837 + 360.98564736629 * daysSinceJ2000) % 360;
@@ -84,34 +50,6 @@ function keplerToLatLonAlt(obj: CatalogObject, timeOffsetSec: number = 0): { lat
   const lat = Math.asin(Math.sin(incRad) * Math.sin(argLat)) * 180 / Math.PI;
 
   return { lat, lon, alt };
-}
-
-
-const CATEGORY_COLORS = {
-  PAYLOAD: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Active Satellites', icon: 'satellite_alt' },
-  DEBRIS: { css: '#FFAA00', cesium: Cesium.Color.fromCssColorString('#FFAA00'), label: 'Debris Objects', icon: 'delete_sweep' },
-  ROCKET_BODY: { css: '#FF4444', cesium: Cesium.Color.fromCssColorString('#FF4444'), label: 'Rocket Bodies', icon: 'rocket' },
-  UNKNOWN: { css: '#888888', cesium: Cesium.Color.fromCssColorString('#888888'), label: 'Unknown Objects', icon: 'help_outline' },
-  COLLISION: { css: '#FF0000', cesium: Cesium.Color.fromCssColorString('#FF0000'), label: 'Collision Risk', icon: 'warning' },
-  SELECTED: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Selected', icon: 'gps_fixed' },
-} as const;
-
-function getPointSize(classification: string): number {
-  switch (classification) {
-    case 'PAYLOAD': return 5;
-    case 'DEBRIS': return 4;
-    case 'ROCKET_BODY': return 6;
-    default: return 3;
-  }
-}
-
-function getOutlineWidth(classification: string): number {
-  switch (classification) {
-    case 'PAYLOAD': return 1;
-    case 'DEBRIS': return 1;
-    case 'ROCKET_BODY': return 2;
-    default: return 1;
-  }
 }
 
 
@@ -137,27 +75,30 @@ export const EarthTwin: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<Cesium.Viewer | null>(null);
   const entitiesRef = useRef<Map<string, Cesium.Entity>>(new Map());
+  const catalogMapRef = useRef<Map<string, CatalogObject>>(new Map());
+  const collisionSetRef = useRef<Set<string>>(new Set());
   const tooltipRef = useRef<HTMLDivElement>(null);
   const { activeSector, setSelectedSatelliteId } = useUIStore();
   const [useFallback, setUseFallback] = useState(true);
   const [hoveredObject, setHoveredObject] = useState<CatalogObject | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+  const [viewerInstance, setViewerInstance] = useState<Cesium.Viewer | null>(null);
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
+  const [datasetVersion, setDatasetVersion] = useState(0);
   const [showLegend, setShowLegend] = useState(true);
   const [showDensity, setShowDensity] = useState(false);
   const [showRiskOverlay, setShowRiskOverlay] = useState(false);
   const [objectCounts, setObjectCounts] = useState({ payloads: 0, debris: 0, rocketBodies: 0, total: 0, collisions: 0 });
   const [dataLoaded, setDataLoaded] = useState(false);
-  const [isBookmarkModalOpen, setIsBookmarkModalOpen] = useState(false);
-  const [isBookmarkSidebarOpen, setIsBookmarkSidebarOpen] = useState(false);
-  const [editingBookmark, setEditingBookmark] = useState<Bookmark | null>(null);
 
+  
   const [stats, setStats] = useState({
     totalObjects: 0,
     lastSync: '',
     weatherIndex: 'K0',
   });
 
-
+  
   const populateEntities = useCallback(async (viewer: Cesium.Viewer) => {
     try {
       if (!viewer || viewer.isDestroyed()) return;
@@ -167,7 +108,7 @@ export const EarthTwin: React.FC = () => {
         fetchCollisions(),
       ]);
 
-
+      
       const collisionCatNums = new Set<string>();
       collisions.forEach(c => {
         if (c.object_a?.catalog_number) collisionCatNums.add(c.object_a.catalog_number);
@@ -177,22 +118,22 @@ export const EarthTwin: React.FC = () => {
       let payloads = 0, debris = 0, rocketBodies = 0;
       const entityMap = new Map<string, Cesium.Entity>();
 
-
+      
       if (!viewer || viewer.isDestroyed()) return;
 
-
+      
       viewer.entities.removeAll();
-      const nowJulian = Cesium.JulianDate.now();
+
       objects.forEach(obj => {
         const pos = keplerToLatLonAlt(obj);
         if (!pos) return;
 
-
+        
         if (obj.classification === 'PAYLOAD') payloads++;
         else if (obj.classification === 'DEBRIS') debris++;
         else if (obj.classification === 'ROCKET_BODY') rocketBodies++;
 
-
+        
         const isCollisionRisk = collisionCatNums.has(obj.catalog_number);
         const colorConfig = isCollisionRisk
           ? CATEGORY_COLORS.COLLISION
@@ -201,15 +142,12 @@ export const EarthTwin: React.FC = () => {
         const pixelSize = isCollisionRisk ? 8 : getPointSize(obj.classification);
         const outlineWidth = isCollisionRisk ? 3 : getOutlineWidth(obj.classification);
 
-        const cartPos = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000);
-        const sunlit = isSatelliteSunlit(cartPos, nowJulian, viewer.scene.globe);
-
         const entity = viewer.entities.add({
-          position: cartPos,
+          position: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000),
           point: {
             pixelSize,
-            color: sunlit ? colorConfig.cesium.withAlpha(0.85) : colorConfig.cesium.withAlpha(0.3),
-            outlineColor: sunlit ? colorConfig.cesium.withAlpha(0.4) : colorConfig.cesium.withAlpha(0.1),
+            color: colorConfig.cesium.withAlpha(0.85),
+            outlineColor: colorConfig.cesium.withAlpha(0.4),
             outlineWidth,
             disableDepthTestDistance: Number.POSITIVE_INFINITY,
             scaleByDistance: new Cesium.NearFarScalar(1e6, 1.5, 5e7, 0.4),
@@ -228,7 +166,7 @@ export const EarthTwin: React.FC = () => {
         entityMap.set(obj.catalog_number, entity);
       });
 
-
+      
       collisions.forEach(conj => {
         if (!conj.object_a || !conj.object_b) return;
         const entityA = entityMap.get(conj.object_a.catalog_number);
@@ -252,6 +190,9 @@ export const EarthTwin: React.FC = () => {
       });
 
       entitiesRef.current = entityMap;
+      catalogMapRef.current = new Map(objects.map(obj => [obj.catalog_number, obj]));
+      collisionSetRef.current = collisionCatNums;
+      setDatasetVersion(v => v + 1);
       setObjectCounts({
         payloads,
         debris,
@@ -271,179 +212,12 @@ export const EarthTwin: React.FC = () => {
     }
   }, []);
 
-
-  const autoRotateRef = useRef(true);
-
-  const {
-    bookmarks,
-    filteredBookmarks,
-    favoriteBookmarks,
-    recentBookmarks,
-    categories,
-
-    searchQuery,
-    selectedCategory,
-
-    setSearchQuery,
-    setSelectedCategory,
-
-    addBookmark,
-    updateBookmark,
-    deleteBookmark,
-    toggleFavorite,
-    markAsRecent,
-
-    exportBookmarks,
-    importBookmarks,
-  } = useBookmarks();
-
-  const [selectedBookmarkId, setSelectedBookmarkId] =
-    useState('');
-
-
-  const saveCurrentView = useCallback(() => {
-    const viewer = viewerRef.current;
-
-    if (!viewer || viewer.isDestroyed()) {
-      return;
-    }
-
-    const cartographic =
-      viewer.scene.globe.ellipsoid.cartesianToCartographic(
-        viewer.camera.positionWC
-      );
-
-    if (!cartographic) {
-      return;
-    }
-
-    const timestamp = new Intl.DateTimeFormat('en-IN', {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    }).format(new Date());
-
-    addBookmark({
-      name: `Saved view — ${timestamp}`,
-      description: 'Saved from the current globe camera position.',
-      category: 'Custom',
-
-      latitude: Cesium.Math.toDegrees(cartographic.latitude),
-      longitude: Cesium.Math.toDegrees(cartographic.longitude),
-      altitude: cartographic.height,
-
-      // Cesium expects these values in radians when restoring.
-      heading: viewer.camera.heading,
-      pitch: viewer.camera.pitch,
-      roll: viewer.camera.roll,
-    });
-  }, [addBookmark]);
-
-  const restoreBookmark = useCallback(
-    (bookmark: Bookmark) => {
-      const viewer = viewerRef.current;
-
-      if (!viewer || viewer.isDestroyed()) {
-        return;
-      }
-
-      // Prevent the existing automatic globe rotation from immediately
-      // moving the camera away from the restored bookmark view.
-      autoRotateRef.current = false;
-
-      markAsRecent(bookmark.id);
-
-      const prefersReducedMotion =
-        window.matchMedia?.(
-          '(prefers-reduced-motion: reduce)'
-        ).matches ?? false;
-
-      viewer.camera.flyTo({
-        destination: Cesium.Cartesian3.fromDegrees(
-          bookmark.longitude,
-          bookmark.latitude,
-          bookmark.altitude
-        ),
-        orientation: {
-          heading: bookmark.heading,
-          pitch: bookmark.pitch,
-          roll: bookmark.roll,
-        },
-        duration: prefersReducedMotion ? 0 : 1.5,
-      });
-    },
-    [markAsRecent]
-  );
-
-  const handleBookmarkSubmit = useCallback(
-    (values: BookmarkFormValues) => {
-      if (editingBookmark) {
-        updateBookmark(editingBookmark.id, {
-          name: values.name,
-          description: values.description,
-          category: values.category,
-        });
-
-        setEditingBookmark(null);
-        setIsBookmarkModalOpen(false);
-        return;
-      }
-
-      const viewer = viewerRef.current;
-
-      if (!viewer || viewer.isDestroyed()) {
-        return;
-      }
-
-      const cartographic =
-        viewer.scene.globe.ellipsoid.cartesianToCartographic(
-          viewer.camera.positionWC
-        );
-
-      if (!cartographic) {
-        return;
-      }
-
-      addBookmark({
-        name: values.name,
-        description: values.description,
-        category: values.category,
-
-        latitude: Cesium.Math.toDegrees(cartographic.latitude),
-        longitude: Cesium.Math.toDegrees(cartographic.longitude),
-        altitude: cartographic.height,
-
-        heading: viewer.camera.heading,
-        pitch: viewer.camera.pitch,
-        roll: viewer.camera.roll,
-      });
-
-      setIsBookmarkModalOpen(false);
-    },
-    [addBookmark, editingBookmark, updateBookmark]
-  );
-
-  const handleShareBookmark = useCallback(
-    async (bookmark: Bookmark) => {
-      const shareUrl = createBookmarkShareUrl(bookmark);
-
-      try {
-        await navigator.clipboard.writeText(shareUrl);
-      } catch {
-        window.prompt(
-          'Copy this bookmark link:',
-          shareUrl
-        );
-      }
-    },
-    []
-  );
-
+  
   useEffect(() => {
     if (!containerRef.current || !Cesium) return;
     if (viewerRef.current && !viewerRef.current.isDestroyed()) return;
 
     let onTick: (() => void) | null = null;
-    let handler: Cesium.ScreenSpaceEventHandler | null = null;
 
     try {
       const viewer = new Cesium.Viewer(containerRef.current, {
@@ -464,18 +238,19 @@ export const EarthTwin: React.FC = () => {
       });
 
       viewerRef.current = viewer;
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUseFallback(false);
+      setViewerInstance(viewer);
+      setContainerEl(containerRef.current);
 
-
-      viewer.scene.globe.enableLighting = true; // Enable real-time day/night lighting
+      
+      viewer.scene.globe.enableLighting = false;
       viewer.scene.backgroundColor = Cesium.Color.fromCssColorString('#050710');
       viewer.scene.fog.enabled = false;
       if (viewer.scene.skyAtmosphere) {
         viewer.scene.skyAtmosphere.show = true;
       }
 
-
+      
       viewer.camera.setView({
         destination: Cesium.Cartesian3.fromDegrees(30, 15, 20000000),
         orientation: {
@@ -484,87 +259,17 @@ export const EarthTwin: React.FC = () => {
           roll: 0.0,
         },
       });
-      const sharedBookmark = getSharedBookmarkFromUrl();
 
-      if (sharedBookmark) {
-        autoRotateRef.current = false;
-
-        const prefersReducedMotion =
-          window.matchMedia?.(
-            '(prefers-reduced-motion: reduce)'
-          ).matches ?? false;
-
-        viewer.camera.flyTo({
-          destination: Cesium.Cartesian3.fromDegrees(
-            sharedBookmark.longitude,
-            sharedBookmark.latitude,
-            sharedBookmark.altitude
-          ),
-          orientation: {
-            heading: sharedBookmark.heading,
-            pitch: sharedBookmark.pitch,
-            roll: sharedBookmark.roll,
-          },
-          duration: prefersReducedMotion ? 0 : 1.5,
-        });
-      }
-
+      
       onTick = () => {
-        if (autoRotateRef.current) {
-          viewer.scene.camera.rotate(
-            Cesium.Cartesian3.UNIT_Z,
-            0.0003
-          );
-        }
+        viewer.scene.camera.rotate(Cesium.Cartesian3.UNIT_Z, 0.0003);
       };
       viewer.clock.onTick.addEventListener(onTick);
 
-
-      handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
-
-      handler.setInputAction((movement: { endPosition: Cesium.Cartesian2 }) => {
-        const picked = viewer.scene.pick(movement.endPosition);
-        if (Cesium.defined(picked) && picked.id && picked.id.properties) {
-          try {
-            const rawData = picked.id.properties.catalogData?.getValue(Cesium.JulianDate.now());
-            if (rawData) {
-              const obj = JSON.parse(rawData) as CatalogObject;
-              setHoveredObject(obj);
-              setTooltipPos({ x: movement.endPosition.x + 15, y: movement.endPosition.y - 10 });
-            }
-          } catch { /* ignore parse errors */ }
-        } else {
-          setHoveredObject(null);
-        }
-      }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
-
-
-      handler.setInputAction((click: { position: Cesium.Cartesian2 }) => {
-        const picked = viewer.scene.pick(click.position);
-        if (Cesium.defined(picked) && picked.id && picked.id.properties) {
-          try {
-            const rawData = picked.id.properties.catalogData?.getValue(Cesium.JulianDate.now());
-            if (rawData) {
-              const obj = JSON.parse(rawData) as CatalogObject;
-              setSelectedSatelliteId(obj.catalog_number);
-
-
-              const pos = keplerToLatLonAlt(obj);
-              if (pos) {
-                viewer.camera.flyTo({
-                  destination: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000 + 2000000),
-                  duration: 1.5,
-                });
-              }
-            }
-          } catch { /* ignore parse errors */ }
-        }
-      }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-
+      
       populateEntities(viewer);
 
-
+      
       const refreshInterval = setInterval(() => {
         if (viewerRef.current && !viewerRef.current.isDestroyed()) {
           populateEntities(viewerRef.current);
@@ -573,26 +278,32 @@ export const EarthTwin: React.FC = () => {
 
       return () => {
         clearInterval(refreshInterval);
-        if (handler) handler.destroy();
         const v = viewerRef.current;
         if (v && !v.isDestroyed()) {
           if (onTick) v.clock.onTick.removeEventListener(onTick);
           v.destroy();
         }
         viewerRef.current = null;
+        setViewerInstance(null);
+        setContainerEl(null);
       };
 
     } catch (e) {
       console.warn('Cesium initialization failed, using fallback', e);
       setUseFallback(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, []); 
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-bg-deep-space border-b border-border-panel">
       {/* 3D Cesium Container */}
-      <div ref={containerRef} className="absolute inset-0 w-full h-full z-0" />
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        role="application"
+        aria-label="Orbital object globe. Use arrow keys to navigate between tracked objects, Enter to select, Escape to clear."
+        className="spotlight-globe-container absolute inset-0 w-full h-full z-0"
+      />
 
       {/* High-Fidelity SVG Fallback */}
       {useFallback && (
@@ -612,6 +323,22 @@ export const EarthTwin: React.FC = () => {
           </svg>
         </div>
       )}
+
+      {/* ── Interactive Satellite Spotlight ─────────────────────── */}
+      <SpotlightManager
+        viewer={viewerInstance}
+        containerEl={containerEl}
+        entitiesRef={entitiesRef}
+        catalogMapRef={catalogMapRef}
+        collisionSetRef={collisionSetRef}
+        datasetVersion={datasetVersion}
+        toLatLonAlt={(obj) => keplerToLatLonAlt(obj)}
+        onHoverChange={(obj, pos) => {
+          setHoveredObject(obj);
+          setTooltipPos(pos);
+        }}
+        onSelectionChange={(id) => setSelectedSatelliteId(id)}
+      />
 
       {/* ── Hover Tooltip (Glassmorphism) ──────────────────────── */}
       {hoveredObject && (
@@ -655,7 +382,7 @@ export const EarthTwin: React.FC = () => {
       )}
 
       {/* ── HUD Overlay ───────────────────────────────────────── */}
-      <div className="absolute inset-0 p-3 pb-16 md:p-6 md:pb-16 flex flex-col justify-between z-10 pointer-events-none overflow-hidden">
+      <div className="absolute inset-0 p-3 md:p-6 flex flex-col justify-between z-10 pointer-events-none overflow-hidden">
 
         {/* Top Row */}
         <div className="flex flex-col sm:flex-row justify-between items-start gap-2">
@@ -674,30 +401,30 @@ export const EarthTwin: React.FC = () => {
           </div>
 
           <div className="text-right space-y-1 animate-[slideDown_0.5s_ease-out] hidden sm:block">
-            {dataLoaded ? (
-              <>
-                {objectCounts.collisions > 0 ? (
-                  <div className="bg-status-emergency/20 border border-status-emergency px-3 md:px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
-                    <MaterialIcon name="warning" className="text-status-emergency text-sm animate-pulse" />
-                    <span className="font-technical-data text-status-emergency text-[11px] md:text-[12px] font-bold">
-                      {objectCounts.collisions} ACTIVE CONJUNCTION{objectCounts.collisions !== 1 ? 'S' : ''}
-                    </span>
-                  </div>
-                ) : (
-                  <div className="bg-status-success/20 border border-status-success px-3 md:px-4 py-1 flex items-center gap-2">
-                    <MaterialIcon name="verified_user" className="text-status-success text-sm" />
-                    <span className="font-technical-data text-status-success text-[11px] md:text-[12px] font-bold">
-                      ALL CLEAR
-                    </span>
-                  </div>
-                )}
-              </>
+          {dataLoaded ? (
+            <>
+            {objectCounts.collisions > 0 ? (
+              <div className="bg-status-emergency/20 border border-status-emergency px-3 md:px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
+                <MaterialIcon name="warning" className="text-status-emergency text-sm animate-pulse" />
+                <span className="font-technical-data text-status-emergency text-[11px] md:text-[12px] font-bold">
+                  {objectCounts.collisions} ACTIVE CONJUNCTION{objectCounts.collisions !== 1 ? 'S' : ''}
+                </span>
+              </div>
             ) : (
-              <>
-                <div className="w-full h-8 bg-surface-container/80 animate-pulse" />
-                <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
-              </>
+              <div className="bg-status-success/20 border border-status-success px-3 md:px-4 py-1 flex items-center gap-2">
+                <MaterialIcon name="verified_user" className="text-status-success text-sm" />
+                <span className="font-technical-data text-status-success text-[11px] md:text-[12px] font-bold">
+                  ALL CLEAR
+                </span>
+              </div>
             )}
+            </>
+          ) : (
+            <>
+            <div className="w-full h-8 bg-surface-container/80 animate-pulse" />
+            <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
+            </>
+          ) }
             <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block transition-ui ${dataLoaded ? 'opacity-100' : 'opacity-0'}`}>
               WEATHER: {stats.weatherIndex} · DATA SOURCE: SPACE-TRACK / NASA DONKI
             </p>
@@ -712,69 +439,52 @@ export const EarthTwin: React.FC = () => {
               <div className="min-w-[250px] p-4 animate-pulse bg-surface-container/80 h-12" />
             ) : (
               <>
-                <div className="space-y-0.5">
-                  <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
-                  <p className="font-headline-lg text-primary text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
-                    {objectCounts.total.toLocaleString()}
-                  </p>
-                </div>
-                <div className="space-y-0.5">
-                  <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Debris</p>
-                  <p className="font-headline-lg text-status-warning text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(255,170,0,0.4)]">
-                    {objectCounts.debris.toLocaleString()}
-                  </p>
-                </div>
-                <div className="space-y-0.5">
-                  <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Collision Risks</p>
-                  <p className={`font-headline-lg text-xl md:text-3xl font-bold font-technical-data ${objectCounts.collisions > 0 ? 'text-status-emergency animate-pulse drop-shadow-[0_0_8px_rgba(255,59,48,0.6)]' : 'text-status-success drop-shadow-[0_0_8px_rgba(0,255,136,0.4)]'}`}>
-                    {objectCounts.collisions}
-                  </p>
-                </div>
-              </>
+            <div className="space-y-0.5">
+              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
+              <p className="font-headline-lg text-primary text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
+                {objectCounts.total.toLocaleString()}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Debris</p>
+              <p className="font-headline-lg text-status-warning text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(255,170,0,0.4)]">
+                {objectCounts.debris.toLocaleString()}
+              </p>
+            </div>
+            <div className="space-y-0.5">
+              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Collision Risks</p>
+              <p className={`font-headline-lg text-xl md:text-3xl font-bold font-technical-data ${objectCounts.collisions > 0 ? 'text-status-emergency animate-pulse drop-shadow-[0_0_8px_rgba(255,59,48,0.6)]' : 'text-status-success drop-shadow-[0_0_8px_rgba(0,255,136,0.4)]'}`}>
+                {objectCounts.collisions}
+              </p>
+            </div>
+            </>
             )
-            }
+          }
           </div>
 
           {/* Controls */}
           <div className="flex gap-1.5 md:gap-2 pointer-events-auto">
-
-            <button
-              type="button"
-              onClick={() => setIsBookmarkModalOpen(true)}
-              className="px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border border-primary-container text-primary-container hover:bg-primary-container/10"
-              aria-label="Save the current globe view as a bookmark"
-            >
-              SAVE VIEW
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setIsBookmarkSidebarOpen(true)}
-              className="px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border border-primary-container text-primary-container hover:bg-primary-container/10"
-              aria-label="Open saved globe bookmarks"
-            >
-              BOOKMARKS
-            </button>
-
-
             <button
               onClick={() => setShowLegend(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showLegend ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
-                }`}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
+                showLegend ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
+              }`}
             >
               LEGEND
             </button>
             <button
               onClick={() => setShowDensity(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showDensity ? 'bg-status-warning text-bg-deep-space border-status-warning' : 'border-status-warning/50 text-status-warning hover:bg-status-warning/10'
-                }`}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
+                showDensity ? 'bg-status-warning text-bg-deep-space border-status-warning' : 'border-status-warning/50 text-status-warning hover:bg-status-warning/10'
+              }`}
             >
               DENSITY
             </button>
             <button
               onClick={() => setShowRiskOverlay(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showRiskOverlay ? 'bg-status-emergency text-white border-status-emergency' : 'border-status-emergency/50 text-status-emergency hover:bg-status-emergency/10'
-                }`}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
+                showRiskOverlay ? 'bg-status-emergency text-white border-status-emergency' : 'border-status-emergency/50 text-status-emergency hover:bg-status-emergency/10'
+              }`}
             >
               RISK
             </button>
@@ -786,91 +496,38 @@ export const EarthTwin: React.FC = () => {
       {showLegend && (
         <div className="absolute bottom-16 md:bottom-24 left-3 md:left-6 z-20 pointer-events-auto animate-[slideUp_0.3s_ease-out]">
           {dataLoaded ? (
-            <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[200px] shadow-[0_0_30px_rgba(0,0,0,0.6)]">
-              <div className="flex justify-between items-center mb-3">
-                <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">ORBITAL LEGEND</span>
-                <button onClick={() => setShowLegend(false)} className="text-on-surface-variant/60 hover:text-on-surface cursor-pointer">
-                  <MaterialIcon name="close" className="text-xs" />
-                </button>
-              </div>
-              <div className="space-y-2">
-                {[
-                  { color: CATEGORY_COLORS.PAYLOAD.css, label: 'Active Satellites', count: objectCounts.payloads },
-                  { color: CATEGORY_COLORS.DEBRIS.css, label: 'Debris Objects', count: objectCounts.debris },
-                  { color: CATEGORY_COLORS.ROCKET_BODY.css, label: 'Rocket Bodies', count: objectCounts.rocketBodies },
-                  { color: CATEGORY_COLORS.COLLISION.css, label: 'Collision Risks', count: objectCounts.collisions },
-                ].map(item => (
-                  <div key={item.label} className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className="w-3 h-3 rounded-full"
-                        style={{ backgroundColor: item.color, boxShadow: `0 0 8px ${item.color}60` }}
-                      />
-                      <span className="font-technical-data text-[11px] text-on-surface-variant">{item.label}</span>
-                    </div>
-                    <span className="font-technical-data text-[11px] font-bold text-on-surface">{item.count.toLocaleString()}</span>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-3 pt-2 border-t border-border-panel/40 text-[9px] text-on-surface-variant/50 font-technical-data">
-                All positions from real orbital elements
-              </div>
+          <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[200px] shadow-[0_0_30px_rgba(0,0,0,0.6)]">
+            <div className="flex justify-between items-center mb-3">
+              <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">ORBITAL LEGEND</span>
+              <button onClick={() => setShowLegend(false)} className="text-on-surface-variant/60 hover:text-on-surface cursor-pointer">
+                <MaterialIcon name="close" className="text-xs" />
+              </button>
             </div>
-          ) : (<LegendCardSkeleton />)}
+            <div className="space-y-2">
+              {[
+                { color: CATEGORY_COLORS.PAYLOAD.css,     label: 'Active Satellites', count: objectCounts.payloads },
+                { color: CATEGORY_COLORS.DEBRIS.css,      label: 'Debris Objects',    count: objectCounts.debris },
+                { color: CATEGORY_COLORS.ROCKET_BODY.css, label: 'Rocket Bodies',     count: objectCounts.rocketBodies },
+                { color: CATEGORY_COLORS.COLLISION.css,    label: 'Collision Risks',   count: objectCounts.collisions },
+              ].map(item => (
+                <div key={item.label} className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="w-3 h-3 rounded-full"
+                      style={{ backgroundColor: item.color, boxShadow: `0 0 8px ${item.color}60` }}
+                    />
+                    <span className="font-technical-data text-[11px] text-on-surface-variant">{item.label}</span>
+                  </div>
+                  <span className="font-technical-data text-[11px] font-bold text-on-surface">{item.count.toLocaleString()}</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-3 pt-2 border-t border-border-panel/40 text-[9px] text-on-surface-variant/50 font-technical-data">
+              All positions from real orbital elements
+            </div>
+          </div>
+          ) : (<LegendCardSkeleton />) }
         </div>
-      )}
-
-      {/* Bookmark create/edit dialog */}
-      {isBookmarkModalOpen && (
-        <BookmarkModal
-          onClose={() => setIsBookmarkModalOpen(false)}
-          onSubmit={handleBookmarkSubmit}
-        />
-      )}
-
-
-      {/* Bookmark sidebar */}
-      {isBookmarkSidebarOpen && (
-        <BookmarkSidebar
-          bookmarks={bookmarks}
-          filteredBookmarks={filteredBookmarks}
-          favoriteBookmarks={favoriteBookmarks}
-          recentBookmarks={recentBookmarks}
-          categories={categories}
-          searchQuery={searchQuery}
-          selectedCategory={selectedCategory}
-          onSearchChange={setSearchQuery}
-          onCategoryChange={setSelectedCategory}
-          onOpenBookmark={restoreBookmark}
-          onCreateBookmark={() => {
-            setEditingBookmark(null);
-            setIsBookmarkModalOpen(true);
-          }}
-          onShareBookmark={handleShareBookmark}
-          onEditBookmark={(bookmark) => {
-            setEditingBookmark(bookmark);
-            setIsBookmarkModalOpen(true);
-          }}
-          onDeleteBookmark={deleteBookmark}
-          onToggleFavorite={(bookmarkId) =>
-            toggleFavorite(bookmarkId)
-          }
-          onExportBookmarks={exportBookmarks}
-          onImportBookmarks={importBookmarks}
-          onClose={() => setIsBookmarkSidebarOpen(false)}
-        />
-      )}
-
-      {isBookmarkModalOpen && (
-        <BookmarkModal
-          key={editingBookmark?.id ?? 'create-bookmark'}
-          initialBookmark={editingBookmark}
-          onClose={() => {
-            setEditingBookmark(null);
-            setIsBookmarkModalOpen(false);
-          }}
-          onSubmit={handleBookmarkSubmit}
-        />
       )}
       {/* ── Inline Styles for Animations ──────────────────────── */}
       <style>{`

--- a/frontend/src/components/SatelliteSpotlight/GlowEffect.tsx
+++ b/frontend/src/components/SatelliteSpotlight/GlowEffect.tsx
@@ -15,7 +15,7 @@ const HIGHLIGHT_SCALE = 1.7;
 const HIGHLIGHT_RISK_SCALE = 2.1;
 const TRANSITION_MS = 220;
 
-function prefersReducedMotion(): boolean {
+export function prefersReducedMotion(): boolean {
   return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
@@ -101,6 +101,7 @@ export function applyDim(entity: Cesium.Entity, baseline: PointBaseline) {
   const point = entity.point;
   point.color = new Cesium.ConstantProperty(baseline.color.withAlpha(DIM_ALPHA));
   point.outlineColor = new Cesium.ConstantProperty(baseline.outlineColor.withAlpha(DIM_ALPHA * 0.6));
+  point.outlineWidth = new Cesium.ConstantProperty(baseline.outlineWidth);
 
   const currentSize = (point.pixelSize?.getValue(Cesium.JulianDate.now()) as number) ?? baseline.pixelSize;
   animate(

--- a/frontend/src/components/SatelliteSpotlight/GlowEffect.tsx
+++ b/frontend/src/components/SatelliteSpotlight/GlowEffect.tsx
@@ -1,0 +1,166 @@
+import * as Cesium from 'cesium';
+
+export type SpotlightVisualState = 'baseline' | 'dimmed' | 'highlighted';
+
+export interface PointBaseline {
+  color: Cesium.Color;
+  pixelSize: number;
+  outlineColor: Cesium.Color;
+  outlineWidth: number;
+}
+
+const DIM_ALPHA = 0.22;
+const DIM_LABEL_ALPHA = 0.35;
+const HIGHLIGHT_SCALE = 1.7;
+const HIGHLIGHT_RISK_SCALE = 2.1;
+const TRANSITION_MS = 220;
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Tiny, dependency-free tween used only during spotlight transitions
+ * (~200ms), never as continuous per-frame work. Cancelled automatically if
+ * a newer tween starts on the same entity via the provided token ref.
+ */
+function animate(
+  from: number,
+  to: number,
+  durationMs: number,
+  onUpdate: (value: number) => void,
+  tokenRef: { current: number },
+  myToken: number
+) {
+  if (prefersReducedMotion() || durationMs <= 0) {
+    onUpdate(to);
+    return;
+  }
+
+  const start = performance.now();
+  const step = (now: number) => {
+    if (tokenRef.current !== myToken) return; // superseded by a newer transition
+    const elapsed = now - start;
+    const t = Math.min(1, elapsed / durationMs);
+    const eased = 1 - Math.pow(1 - t, 3); // ease-out cubic
+    onUpdate(from + (to - from) * eased);
+    if (t < 1) requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+}
+
+/** Per-entity animation token so rapid hover changes don't race each other. */
+const animationTokens = new WeakMap<Cesium.Entity, { current: number }>();
+let tokenCounter = 0;
+
+function getTokenRef(entity: Cesium.Entity): { current: number } {
+  let ref = animationTokens.get(entity);
+  if (!ref) {
+    ref = { current: 0 };
+    animationTokens.set(entity, ref);
+  }
+  return ref;
+}
+
+/** Restores an entity's point/label styling to its normal, non-spotlighted state. */
+export function applyBaseline(entity: Cesium.Entity, baseline: PointBaseline) {
+  if (!entity.point) return;
+  const tokenRef = getTokenRef(entity);
+  const myToken = ++tokenCounter;
+  tokenRef.current = myToken;
+
+  const point = entity.point;
+  point.color = new Cesium.ConstantProperty(baseline.color.withAlpha(0.85));
+  point.outlineColor = new Cesium.ConstantProperty(baseline.outlineColor.withAlpha(0.4));
+  point.outlineWidth = new Cesium.ConstantProperty(baseline.outlineWidth);
+
+  const currentSize = (point.pixelSize?.getValue(Cesium.JulianDate.now()) as number) ?? baseline.pixelSize;
+  animate(
+    currentSize,
+    baseline.pixelSize,
+    TRANSITION_MS,
+    (v) => {
+      point.pixelSize = new Cesium.ConstantProperty(v);
+    },
+    tokenRef,
+    myToken
+  );
+
+  if (entity.label) {
+    entity.label.show = new Cesium.ConstantProperty(false);
+  }
+}
+
+/** Fades a non-active entity into the background so the spotlighted one stands out. */
+export function applyDim(entity: Cesium.Entity, baseline: PointBaseline) {
+  if (!entity.point) return;
+  const tokenRef = getTokenRef(entity);
+  const myToken = ++tokenCounter;
+  tokenRef.current = myToken;
+
+  const point = entity.point;
+  point.color = new Cesium.ConstantProperty(baseline.color.withAlpha(DIM_ALPHA));
+  point.outlineColor = new Cesium.ConstantProperty(baseline.outlineColor.withAlpha(DIM_ALPHA * 0.6));
+
+  const currentSize = (point.pixelSize?.getValue(Cesium.JulianDate.now()) as number) ?? baseline.pixelSize;
+  animate(
+    currentSize,
+    Math.max(baseline.pixelSize * 0.85, 1.5),
+    TRANSITION_MS,
+    (v) => {
+      point.pixelSize = new Cesium.ConstantProperty(v);
+    },
+    tokenRef,
+    myToken
+  );
+
+  if (entity.label) {
+    entity.label.show = new Cesium.ConstantProperty(false);
+  }
+
+  void DIM_LABEL_ALPHA; // reserved for label-opacity theming if labels are enabled later
+}
+
+/** Makes an entity the visual focal point: brighter, larger, glowing outline. */
+export function applyHighlight(
+  entity: Cesium.Entity,
+  baseline: PointBaseline,
+  options: { isCollisionRisk?: boolean; labelText?: string } = {}
+) {
+  if (!entity.point) return;
+  const tokenRef = getTokenRef(entity);
+  const myToken = ++tokenCounter;
+  tokenRef.current = myToken;
+
+  const point = entity.point;
+  const glowColor = options.isCollisionRisk ? Cesium.Color.fromCssColorString('#FF3B30') : baseline.color;
+
+  point.color = new Cesium.ConstantProperty(glowColor.brighten(0.3, new Cesium.Color()).withAlpha(1));
+  point.outlineColor = new Cesium.ConstantProperty(glowColor.withAlpha(0.95));
+  point.outlineWidth = new Cesium.ConstantProperty(baseline.outlineWidth + (options.isCollisionRisk ? 3 : 2));
+
+  const targetSize = baseline.pixelSize * (options.isCollisionRisk ? HIGHLIGHT_RISK_SCALE : HIGHLIGHT_SCALE);
+  const currentSize = (point.pixelSize?.getValue(Cesium.JulianDate.now()) as number) ?? baseline.pixelSize;
+  animate(
+    currentSize,
+    targetSize,
+    TRANSITION_MS,
+    (v) => {
+      point.pixelSize = new Cesium.ConstantProperty(v);
+    },
+    tokenRef,
+    myToken
+  );
+
+  if (entity.label && options.labelText !== undefined) {
+    entity.label.text = new Cesium.ConstantProperty(options.labelText);
+    entity.label.show = new Cesium.ConstantProperty(true);
+    entity.label.font = new Cesium.ConstantProperty('600 13px "IBM Plex Sans", monospace');
+    entity.label.fillColor = new Cesium.ConstantProperty(Cesium.Color.WHITE);
+    entity.label.outlineColor = new Cesium.ConstantProperty(Cesium.Color.BLACK.withAlpha(0.8));
+    entity.label.outlineWidth = new Cesium.ConstantProperty(2);
+    entity.label.style = new Cesium.ConstantProperty(Cesium.LabelStyle.FILL_AND_OUTLINE);
+    entity.label.pixelOffset = new Cesium.ConstantProperty(new Cesium.Cartesian2(0, -16));
+    entity.label.disableDepthTestDistance = new Cesium.ConstantProperty(Number.POSITIVE_INFINITY);
+  }
+}

--- a/frontend/src/components/SatelliteSpotlight/OrbitHighlight.tsx
+++ b/frontend/src/components/SatelliteSpotlight/OrbitHighlight.tsx
@@ -46,6 +46,12 @@ export function computeOrbitPositions(obj: CatalogObject): Cesium.Cartesian3[] |
     const trueAnomaly = meanAnomaly + 2 * ecc * Math.sin(meanAnomaly);
     const argLat = argPerigeeRad + trueAnomaly;
 
+    // Geocentric distance varies with true anomaly for eccentric orbits:
+    // r = a(1 - e^2) / (1 + e*cos(ν)). At ecc=0 this reduces to the
+    // constant-radius circular case.
+    const radiusKm = (obj.semimajor_axis * (1 - ecc * ecc)) / (1 + ecc * Math.cos(trueAnomaly));
+    const pointAlt = radiusKm - EARTH_RADIUS_KM;
+
     const lon =
       ((((Math.atan2(Math.cos(incRad) * Math.sin(argLat), Math.cos(argLat)) * 180) / Math.PI +
         (raanRad * 180) / Math.PI -
@@ -55,7 +61,7 @@ export function computeOrbitPositions(obj: CatalogObject): Cesium.Cartesian3[] |
         180);
     const lat = (Math.asin(Math.sin(incRad) * Math.sin(argLat)) * 180) / Math.PI;
 
-    positions.push(Cesium.Cartesian3.fromDegrees(lon, lat, alt * 1000));
+    positions.push(Cesium.Cartesian3.fromDegrees(lon, lat, pointAlt * 1000));
   }
 
   return positions;

--- a/frontend/src/components/SatelliteSpotlight/OrbitHighlight.tsx
+++ b/frontend/src/components/SatelliteSpotlight/OrbitHighlight.tsx
@@ -1,0 +1,113 @@
+import * as Cesium from 'cesium';
+import type { CatalogObject } from '@/types/satellite';
+
+/**
+ * Computes a lightweight polyline for a satellite's orbit path so it can be
+ * emphasized while the satellite is hovered/selected.
+ *
+ * This mirrors the position math used to place satellite points (see
+ * EarthTwin.keplerToLatLonAlt) but sweeps the true anomaly across a full
+ * revolution while holding "now" fixed, so the drawn ellipse matches the
+ * satellite's current ground track shape. It intentionally ignores nodal
+ * regression across a single period — a reasonable simplification for a
+ * visual highlight rather than a precision propagator.
+ */
+const EARTH_RADIUS_KM = 6371;
+const ORBIT_SAMPLE_STEPS = 90;
+
+export function computeOrbitPositions(obj: CatalogObject): Cesium.Cartesian3[] | null {
+  if (
+    obj.semimajor_axis == null ||
+    obj.inclination == null ||
+    obj.raan == null ||
+    obj.arg_of_perigee == null ||
+    obj.mean_motion == null
+  ) {
+    return null;
+  }
+
+  const alt = obj.semimajor_axis - EARTH_RADIUS_KM;
+  if (alt < 0 || alt > 100000) return null;
+
+  const ecc = obj.eccentricity ?? 0;
+  const raanRad = (obj.raan * Math.PI) / 180;
+  const incRad = (obj.inclination * Math.PI) / 180;
+  const argPerigeeRad = (obj.arg_of_perigee * Math.PI) / 180;
+
+  const now = new Date();
+  const J2000 = new Date('2000-01-01T12:00:00Z').getTime();
+  const daysSinceJ2000 = (now.getTime() - J2000) / 86400000;
+  const GMST = (280.46061837 + 360.98564736629 * daysSinceJ2000) % 360;
+
+  const positions: Cesium.Cartesian3[] = [];
+
+  for (let i = 0; i <= ORBIT_SAMPLE_STEPS; i++) {
+    const meanAnomaly = ((i / ORBIT_SAMPLE_STEPS) * 360 * Math.PI) / 180;
+    const trueAnomaly = meanAnomaly + 2 * ecc * Math.sin(meanAnomaly);
+    const argLat = argPerigeeRad + trueAnomaly;
+
+    const lon =
+      ((((Math.atan2(Math.cos(incRad) * Math.sin(argLat), Math.cos(argLat)) * 180) / Math.PI +
+        (raanRad * 180) / Math.PI -
+        GMST +
+        540) %
+        360) -
+        180);
+    const lat = (Math.asin(Math.sin(incRad) * Math.sin(argLat)) * 180) / Math.PI;
+
+    positions.push(Cesium.Cartesian3.fromDegrees(lon, lat, alt * 1000));
+  }
+
+  return positions;
+}
+
+interface OrbitHighlightOptions {
+  color: Cesium.Color;
+  isCollisionRisk?: boolean;
+}
+
+const ORBIT_ENTITY_ID = '__spotlight_orbit_highlight__';
+
+/**
+ * Adds (or replaces) the single orbit-highlight polyline entity on the
+ * viewer. Only one orbit is ever highlighted at a time, so this removes any
+ * previous instance first — cheap, since it's only called on
+ * hover/selection change, never per frame.
+ */
+export function setOrbitHighlight(
+  viewer: Cesium.Viewer,
+  obj: CatalogObject | null,
+  options: OrbitHighlightOptions
+): void {
+  if (viewer.isDestroyed()) return;
+
+  const existing = viewer.entities.getById(ORBIT_ENTITY_ID);
+  if (existing) viewer.entities.remove(existing);
+
+  if (!obj) return;
+
+  const positions = computeOrbitPositions(obj);
+  if (!positions) return;
+
+  const width = options.isCollisionRisk ? 3.5 : 2.5;
+  const glowPower = options.isCollisionRisk ? 0.35 : 0.2;
+
+  viewer.entities.add({
+    id: ORBIT_ENTITY_ID,
+    polyline: {
+      positions,
+      width,
+      material: new Cesium.PolylineGlowMaterialProperty({
+        glowPower,
+        color: options.color.withAlpha(0.9),
+      }),
+      clampToGround: false,
+    },
+  });
+}
+
+export function clearOrbitHighlight(viewer: Cesium.Viewer): void {
+  if (viewer.isDestroyed()) return;
+  const existing = viewer.entities.getById(ORBIT_ENTITY_ID);
+  if (existing) viewer.entities.remove(existing);
+}

--- a/frontend/src/components/SatelliteSpotlight/SpotlightInfoCard.tsx
+++ b/frontend/src/components/SatelliteSpotlight/SpotlightInfoCard.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { MaterialIcon } from '@/components/MaterialIcon';
+import type { CatalogObject } from '@/types/satellite';
+import { CATEGORY_COLORS } from '@/lib/satelliteVisuals';
+
+interface SpotlightInfoCardProps {
+  object: CatalogObject;
+  isCollisionRisk: boolean;
+  onClose: () => void;
+}
+
+function orbitTypeFromAltitude(altitudeKm: number | null): string {
+  if (altitudeKm == null) return '—';
+  if (altitudeKm < 2000) return 'LEO';
+  if (altitudeKm < 35786) return 'MEO';
+  if (altitudeKm < 35886) return 'GEO';
+  return 'HEO';
+}
+
+/**
+ * Small "selected satellite" card: name, NORAD ID, orbit type, altitude,
+ * and health/risk status. Rendered while a satellite is locked in via
+ * click or keyboard Enter.
+ */
+export const SpotlightInfoCard: React.FC<SpotlightInfoCardProps> = ({ object, isCollisionRisk, onClose }) => {
+  const altitudeKm = object.semimajor_axis != null ? object.semimajor_axis - 6371 : null;
+  const colorConfig = isCollisionRisk ? CATEGORY_COLORS.COLLISION : CATEGORY_COLORS[object.classification] ?? CATEGORY_COLORS.UNKNOWN;
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Selected satellite: ${object.name}`}
+      className={`spotlight-info-card ${isCollisionRisk ? 'spotlight-info-card--risk' : ''} bg-bg-deep-space/90 backdrop-blur-xl border p-4 min-w-[240px] max-w-[280px]`}
+      style={{
+        borderColor: isCollisionRisk ? 'rgba(255,59,48,0.6)' : `${colorConfig.css}4d`,
+        boxShadow: `0 0 30px ${isCollisionRisk ? 'rgba(255,59,48,0.25)' : `${colorConfig.css}26`}`,
+      }}
+    >
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: colorConfig.css, boxShadow: `0 0 8px ${colorConfig.css}` }}
+          />
+          <span className="font-technical-data text-xs font-bold text-primary-container truncate">{object.name}</span>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Clear selection"
+          className="text-on-surface-variant/60 hover:text-on-surface cursor-pointer shrink-0"
+        >
+          <MaterialIcon name="close" className="text-xs" />
+        </button>
+      </div>
+
+      {isCollisionRisk && (
+        <div className="flex items-center gap-1.5 mb-3 bg-status-emergency/15 border border-status-emergency/50 px-2 py-1">
+          <MaterialIcon name="warning" className="text-status-emergency text-xs" />
+          <span className="font-technical-data text-status-emergency text-[10px] font-bold">CONJUNCTION RISK</span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 font-technical-data text-[10px]">
+        <span className="text-on-surface-variant/60">NORAD ID</span>
+        <span className="text-on-surface font-semibold">{object.catalog_number}</span>
+
+        <span className="text-on-surface-variant/60">ORBIT TYPE</span>
+        <span className="text-on-surface font-semibold">{orbitTypeFromAltitude(altitudeKm)}</span>
+
+        <span className="text-on-surface-variant/60">ALTITUDE</span>
+        <span className="text-on-surface font-semibold">{altitudeKm != null ? `${Math.round(altitudeKm).toLocaleString()} km` : '—'}</span>
+
+        <span className="text-on-surface-variant/60">HEALTH / RISK</span>
+        <span className={`font-semibold ${isCollisionRisk ? 'text-status-emergency' : 'text-status-success'}`}>
+          {isCollisionRisk ? 'AT RISK' : 'NOMINAL'}
+        </span>
+      </div>
+
+      <div className="mt-3 pt-2 border-t border-primary-container/20 text-[9px] text-primary/50 font-technical-data">
+        Double-click to focus camera · Esc to clear
+      </div>
+    </div>
+  );
+};
+
+export default SpotlightInfoCard;

--- a/frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx
+++ b/frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as Cesium from 'cesium';
+import type { CatalogObject } from '@/types/satellite';
+import { useSatelliteHover } from '@/hooks/useSatelliteHover';
+import { useSatelliteSelection } from '@/hooks/useSatelliteSelection';
+import { useSpotlightEffect } from '@/hooks/useSpotlightEffect';
+import { SpotlightInfoCard } from './SpotlightInfoCard';
+
+interface SpotlightManagerProps {
+  viewer: Cesium.Viewer | null;
+  containerEl: HTMLDivElement | null;
+  entitiesRef: React.RefObject<Map<string, Cesium.Entity>>;
+  catalogMapRef: React.RefObject<Map<string, CatalogObject>>;
+  collisionSetRef: React.RefObject<Set<string>>;
+  datasetVersion: number;
+  toLatLonAlt: (obj: CatalogObject) => { lat: number; lon: number; alt: number } | null;
+  onHoverChange?: (obj: CatalogObject | null, pos: { x: number; y: number }) => void;
+  onSelectionChange?: (id: string | null) => void;
+}
+
+/**
+ * Reusable satellite spotlight controller. Owns the Cesium input handler,
+ * wires hover/selection/keyboard-nav hooks together, drives the
+ * highlight/dim/orbit visuals, and renders the selected-satellite info
+ * card. Designed to be easy to point at other object types later — swap
+ * what populates `entitiesRef`/`catalogMapRef` and everything else works
+ * the same way.
+ */
+export const SpotlightManager: React.FC<SpotlightManagerProps> = ({
+  viewer,
+  containerEl,
+  entitiesRef,
+  catalogMapRef,
+  collisionSetRef,
+  datasetVersion,
+  toLatLonAlt,
+  onHoverChange,
+  onSelectionChange,
+}) => {
+  const handlerRef = useRef<Cesium.ScreenSpaceEventHandler | null>(null);
+  const [handler, setHandler] = useState<Cesium.ScreenSpaceEventHandler | null>(null);
+  const [keyboardFocusId, setKeyboardFocusId] = useState<string | null>(null);
+  const [containerFocused, setContainerFocused] = useState(false);
+
+  // One shared picking handler for the lifetime of the viewer instance.
+  useEffect(() => {
+    if (!viewer || viewer.isDestroyed()) return;
+    const h = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
+    handlerRef.current = h;
+    setHandler(h);
+    return () => {
+      h.destroy();
+      handlerRef.current = null;
+      setHandler(null);
+    };
+  }, [viewer]);
+
+  const { hoveredId, hoveredObject, tooltipPos } = useSatelliteHover({ viewer, handler });
+
+  const { selectedId, selectedObject, selectedIsCollisionRisk, selectSatellite, clearSelection } = useSatelliteSelection({
+    viewer,
+    handler,
+    toLatLonAlt,
+    collisionSetRef,
+    onSelect: onSelectionChange,
+  });
+
+  useEffect(() => {
+    onHoverChange?.(hoveredObject, tooltipPos);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hoveredObject, tooltipPos]);
+
+  // Keyboard focus takes priority over mouse hover for spotlight targeting,
+  // since it reflects deliberate keyboard navigation.
+  const effectiveHoverId = keyboardFocusId ?? hoveredId;
+
+  useSpotlightEffect({
+    viewer,
+    entitiesRef,
+    catalogMapRef,
+    collisionSetRef,
+    hoveredId: effectiveHoverId,
+    selectedId,
+    datasetVersion,
+  });
+
+  // ── Keyboard navigation ──────────────────────────────────────────
+  useEffect(() => {
+    if (!containerEl) return;
+
+    const getOrderedIds = () => Array.from(entitiesRef.current?.keys() ?? []);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const ids = getOrderedIds();
+      if (ids.length === 0) return;
+
+      if (['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'].includes(e.key)) {
+        e.preventDefault();
+        const currentIndex = keyboardFocusId ? ids.indexOf(keyboardFocusId) : -1;
+        const direction = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1;
+        const nextIndex = currentIndex === -1 ? 0 : (currentIndex + direction + ids.length) % ids.length;
+        setKeyboardFocusId(ids[nextIndex]);
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        if (keyboardFocusId) {
+          e.preventDefault();
+          const obj = catalogMapRef.current?.get(keyboardFocusId) ?? null;
+          selectSatellite(obj);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        clearSelection();
+        setKeyboardFocusId(null);
+      }
+    };
+
+    const handleFocus = () => setContainerFocused(true);
+    const handleBlur = () => {
+      setContainerFocused(false);
+      setKeyboardFocusId(null);
+    };
+
+    containerEl.addEventListener('keydown', handleKeyDown);
+    containerEl.addEventListener('focus', handleFocus);
+    containerEl.addEventListener('blur', handleBlur);
+    return () => {
+      containerEl.removeEventListener('keydown', handleKeyDown);
+      containerEl.removeEventListener('focus', handleFocus);
+      containerEl.removeEventListener('blur', handleBlur);
+    };
+  }, [containerEl, keyboardFocusId, entitiesRef, catalogMapRef, selectSatellite, clearSelection]);
+
+  return (
+    <>
+      {selectedObject && (
+        <div className="absolute top-3 right-3 md:top-6 md:right-6 z-30 pointer-events-auto">
+          <SpotlightInfoCard object={selectedObject} isCollisionRisk={selectedIsCollisionRisk} onClose={clearSelection} />
+        </div>
+      )}
+
+      {containerFocused && !selectedObject && (
+        <div className="spotlight-keyboard-hint absolute bottom-3 left-1/2 -translate-x-1/2 z-30 pointer-events-none">
+          <div className="bg-bg-deep-space/85 backdrop-blur-md border border-primary-container/30 px-3 py-1.5 font-technical-data text-[10px] text-primary-container/80">
+            ← → navigate · Enter select · Esc clear
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SpotlightManager;

--- a/frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx
+++ b/frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx
@@ -62,6 +62,7 @@ export const SpotlightManager: React.FC<SpotlightManagerProps> = ({
     handler,
     toLatLonAlt,
     collisionSetRef,
+    containerEl,
     onSelect: onSelectionChange,
   });
 

--- a/frontend/src/hooks/useSatelliteHover.ts
+++ b/frontend/src/hooks/useSatelliteHover.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+import * as Cesium from 'cesium';
+import type { CatalogObject } from '@/types/satellite';
+
+interface UseSatelliteHoverArgs {
+  viewer: Cesium.Viewer | null;
+  handler: Cesium.ScreenSpaceEventHandler | null;
+  /** Skip hover spotlight changes while true (e.g. keyboard navigation is driving focus). */
+  disabled?: boolean;
+}
+
+interface UseSatelliteHoverResult {
+  hoveredId: string | null;
+  hoveredObject: CatalogObject | null;
+  tooltipPos: { x: number; y: number };
+}
+
+/**
+ * Wires MOUSE_MOVE picking to hover state. Only re-renders when the hovered
+ * entity actually changes (not on every pixel of mouse movement), keeping
+ * this cheap even with large datasets.
+ */
+export function useSatelliteHover({ viewer, handler, disabled }: UseSatelliteHoverArgs): UseSatelliteHoverResult {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [hoveredObject, setHoveredObject] = useState<CatalogObject | null>(null);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+  const hoveredIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!viewer || !handler || viewer.isDestroyed()) return;
+
+    handler.setInputAction((movement: { endPosition: Cesium.Cartesian2 }) => {
+      if (disabled) return;
+
+      const picked = viewer.scene.pick(movement.endPosition);
+      if (Cesium.defined(picked) && picked.id && picked.id.properties?.catalogData) {
+        try {
+          const rawData = picked.id.properties.catalogData.getValue(Cesium.JulianDate.now());
+          const obj = JSON.parse(rawData) as CatalogObject;
+          if (hoveredIdRef.current !== obj.catalog_number) {
+            hoveredIdRef.current = obj.catalog_number;
+            setHoveredId(obj.catalog_number);
+            setHoveredObject(obj);
+          }
+          setTooltipPos({ x: movement.endPosition.x + 15, y: movement.endPosition.y - 10 });
+        } catch {
+          /* malformed entity data — ignore this pick */
+        }
+      } else if (hoveredIdRef.current !== null) {
+        hoveredIdRef.current = null;
+        setHoveredId(null);
+        setHoveredObject(null);
+      }
+    }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+  }, [viewer, handler, disabled]);
+
+  return { hoveredId, hoveredObject, tooltipPos };
+}

--- a/frontend/src/hooks/useSatelliteSelection.ts
+++ b/frontend/src/hooks/useSatelliteSelection.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as Cesium from 'cesium';
 import type { CatalogObject } from '@/types/satellite';
+import { prefersReducedMotion } from '@/components/SatelliteSpotlight/GlowEffect';
 
 interface UseSatelliteSelectionArgs {
   viewer: Cesium.Viewer | null;
@@ -9,6 +10,10 @@ interface UseSatelliteSelectionArgs {
   toLatLonAlt: (obj: CatalogObject) => { lat: number; lon: number; alt: number } | null;
   /** Read only inside event handlers, never during render. */
   collisionSetRef: React.RefObject<Set<string>>;
+  /** The keyboard-focusable globe container (not the Cesium canvas) that
+   *  SpotlightManager listens on for arrow-key navigation. Refocused after
+   *  mouse clicks so keyboard nav keeps working without requiring a Tab. */
+  containerEl: HTMLDivElement | null;
   onSelect?: (id: string | null) => void;
 }
 
@@ -31,6 +36,7 @@ export function useSatelliteSelection({
   handler,
   toLatLonAlt,
   collisionSetRef,
+  containerEl,
   onSelect,
 }: UseSatelliteSelectionArgs): UseSatelliteSelectionResult {
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -75,6 +81,10 @@ export function useSatelliteSelection({
         // Clicked empty space — clear the lock.
         clearSelection();
       }
+      // Return focus to the keyboard-navigable globe container (not the
+      // Cesium canvas) so arrow-key navigation keeps working after a mouse
+      // interaction, without requiring the user to Tab in first.
+      containerEl?.focus({ preventScroll: true });
     }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
     handler.setInputAction((click: { position: Cesium.Cartesian2 }) => {
@@ -86,17 +96,21 @@ export function useSatelliteSelection({
           selectSatellite(obj);
           const pos = toLatLonAlt(obj);
           if (pos) {
-            viewer.camera.flyTo({
-              destination: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000 + 2000000),
-              duration: 1.5,
-            });
+            const destination = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000 + 2000000);
+            if (prefersReducedMotion()) {
+              // Jump directly to the destination instead of animating.
+              viewer.camera.flyTo({ destination, duration: 0 });
+            } else {
+              viewer.camera.flyTo({ destination, duration: 1.5 });
+            }
           }
         } catch {
           /* ignore malformed entity data */
         }
       }
+      containerEl?.focus({ preventScroll: true });
     }, Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
-  }, [viewer, handler, toLatLonAlt, selectSatellite, clearSelection]);
+  }, [viewer, handler, toLatLonAlt, selectSatellite, clearSelection, containerEl]);
 
   return { selectedId, selectedObject, selectedIsCollisionRisk, selectSatellite, clearSelection };
 }

--- a/frontend/src/hooks/useSatelliteSelection.ts
+++ b/frontend/src/hooks/useSatelliteSelection.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Cesium from 'cesium';
+import type { CatalogObject } from '@/types/satellite';
+
+interface UseSatelliteSelectionArgs {
+  viewer: Cesium.Viewer | null;
+  handler: Cesium.ScreenSpaceEventHandler | null;
+  /** Convert a CatalogObject's orbital elements into a lat/lon/alt(km) point. */
+  toLatLonAlt: (obj: CatalogObject) => { lat: number; lon: number; alt: number } | null;
+  /** Read only inside event handlers, never during render. */
+  collisionSetRef: React.RefObject<Set<string>>;
+  onSelect?: (id: string | null) => void;
+}
+
+interface UseSatelliteSelectionResult {
+  selectedId: string | null;
+  selectedObject: CatalogObject | null;
+  selectedIsCollisionRisk: boolean;
+  selectSatellite: (obj: CatalogObject | null) => void;
+  clearSelection: () => void;
+}
+
+/**
+ * Click locks the spotlight onto a satellite; clicking empty space clears
+ * it. Double-click additionally flies the camera to center on the target,
+ * per the "Focus Camera" requirement — kept separate from single-click so
+ * every click doesn't yank the camera around.
+ */
+export function useSatelliteSelection({
+  viewer,
+  handler,
+  toLatLonAlt,
+  collisionSetRef,
+  onSelect,
+}: UseSatelliteSelectionArgs): UseSatelliteSelectionResult {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedObject, setSelectedObject] = useState<CatalogObject | null>(null);
+  const [selectedIsCollisionRisk, setSelectedIsCollisionRisk] = useState(false);
+  const onSelectRef = useRef(onSelect);
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  });
+
+  const selectSatellite = useCallback(
+    (obj: CatalogObject | null) => {
+      setSelectedId(obj?.catalog_number ?? null);
+      setSelectedObject(obj);
+      setSelectedIsCollisionRisk(obj ? collisionSetRef.current?.has(obj.catalog_number) ?? false : false);
+      onSelectRef.current?.(obj?.catalog_number ?? null);
+    },
+    [collisionSetRef]
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedId(null);
+    setSelectedObject(null);
+    setSelectedIsCollisionRisk(false);
+    onSelectRef.current?.(null);
+  }, []);
+
+  useEffect(() => {
+    if (!viewer || !handler || viewer.isDestroyed()) return;
+
+    handler.setInputAction((click: { position: Cesium.Cartesian2 }) => {
+      const picked = viewer.scene.pick(click.position);
+      if (Cesium.defined(picked) && picked.id && picked.id.properties?.catalogData) {
+        try {
+          const rawData = picked.id.properties.catalogData.getValue(Cesium.JulianDate.now());
+          const obj = JSON.parse(rawData) as CatalogObject;
+          selectSatellite(obj);
+        } catch {
+          /* ignore malformed entity data */
+        }
+      } else {
+        // Clicked empty space — clear the lock.
+        clearSelection();
+      }
+    }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+    handler.setInputAction((click: { position: Cesium.Cartesian2 }) => {
+      const picked = viewer.scene.pick(click.position);
+      if (Cesium.defined(picked) && picked.id && picked.id.properties?.catalogData) {
+        try {
+          const rawData = picked.id.properties.catalogData.getValue(Cesium.JulianDate.now());
+          const obj = JSON.parse(rawData) as CatalogObject;
+          selectSatellite(obj);
+          const pos = toLatLonAlt(obj);
+          if (pos) {
+            viewer.camera.flyTo({
+              destination: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000 + 2000000),
+              duration: 1.5,
+            });
+          }
+        } catch {
+          /* ignore malformed entity data */
+        }
+      }
+    }, Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
+  }, [viewer, handler, toLatLonAlt, selectSatellite, clearSelection]);
+
+  return { selectedId, selectedObject, selectedIsCollisionRisk, selectSatellite, clearSelection };
+}

--- a/frontend/src/hooks/useSpotlightEffect.ts
+++ b/frontend/src/hooks/useSpotlightEffect.ts
@@ -1,0 +1,131 @@
+import { useEffect, useRef } from 'react';
+import * as Cesium from 'cesium';
+import type { CatalogObject } from '@/types/satellite';
+import { applyBaseline, applyDim, applyHighlight, type PointBaseline } from '@/components/SatelliteSpotlight/GlowEffect';
+import { setOrbitHighlight, clearOrbitHighlight } from '@/components/SatelliteSpotlight/OrbitHighlight';
+import { CATEGORY_COLORS, getOutlineWidth, getPointSize } from '@/lib/satelliteVisuals';
+
+interface UseSpotlightEffectArgs {
+  viewer: Cesium.Viewer | null;
+  entitiesRef: React.RefObject<Map<string, Cesium.Entity>>;
+  catalogMapRef: React.RefObject<Map<string, CatalogObject>>;
+  collisionSetRef: React.RefObject<Set<string>>;
+  hoveredId: string | null;
+  selectedId: string | null;
+  /** Bump whenever entitiesRef is repopulated so stale dim/highlight state resets cleanly. */
+  datasetVersion: number;
+}
+
+function baselineFor(id: string, catalogMap: Map<string, CatalogObject>, collisionSet: Set<string>): PointBaseline | null {
+  const obj = catalogMap.get(id);
+  if (!obj) return null;
+  const isCollisionRisk = collisionSet.has(id);
+  const colorConfig = isCollisionRisk ? CATEGORY_COLORS.COLLISION : CATEGORY_COLORS[obj.classification] ?? CATEGORY_COLORS.UNKNOWN;
+  return {
+    color: colorConfig.cesium,
+    pixelSize: isCollisionRisk ? 8 : getPointSize(obj.classification),
+    outlineColor: colorConfig.cesium,
+    outlineWidth: isCollisionRisk ? 3 : getOutlineWidth(obj.classification),
+  };
+}
+
+/**
+ * Central spotlight controller: given the currently hovered/selected
+ * satellite id, brightens that entity, dims everything else, and highlights
+ * its orbit path. Work is diffed against previous state so a hover change
+ * only ever touches the two affected entities (old + new), not the whole
+ * dataset — the full dataset is only touched once, on first activation.
+ */
+export function useSpotlightEffect({
+  viewer,
+  entitiesRef,
+  catalogMapRef,
+  collisionSetRef,
+  hoveredId,
+  selectedId,
+  datasetVersion,
+}: UseSpotlightEffectArgs): void {
+  const prevActiveIdRef = useRef<string | null | undefined>(undefined);
+  const dimmedIdsRef = useRef<Set<string>>(new Set());
+  const lastDatasetVersionRef = useRef<number>(-1);
+
+  useEffect(() => {
+    if (!viewer || viewer.isDestroyed()) return;
+    const entities = entitiesRef.current;
+    const catalogMap = catalogMapRef.current;
+    const collisionSet = collisionSetRef.current;
+    if (!entities || !catalogMap || !collisionSet) return;
+
+    const activeId = selectedId ?? hoveredId;
+
+    // Dataset was refreshed (e.g. 5-minute poll) — old dim/highlight state
+    // no longer maps to real entities, so start clean and re-derive.
+    const datasetChanged = lastDatasetVersionRef.current !== datasetVersion;
+    if (datasetChanged) {
+      lastDatasetVersionRef.current = datasetVersion;
+      dimmedIdsRef.current = new Set();
+      prevActiveIdRef.current = undefined;
+    }
+
+    const prevActiveId = prevActiveIdRef.current;
+    if (!datasetChanged && activeId === prevActiveId) return;
+
+    const dimmed = dimmedIdsRef.current;
+
+    const restoreToBaseline = (id: string) => {
+      const e = entities.get(id);
+      const b = baselineFor(id, catalogMap, collisionSet);
+      if (e && b) applyBaseline(e, b);
+    };
+
+    const dimEntity = (id: string) => {
+      const e = entities.get(id);
+      const b = baselineFor(id, catalogMap, collisionSet);
+      if (e && b) {
+        applyDim(e, b);
+        dimmed.add(id);
+      }
+    };
+
+    if (activeId === null) {
+      dimmed.forEach(restoreToBaseline);
+      dimmed.clear();
+      if (prevActiveId) restoreToBaseline(prevActiveId);
+      clearOrbitHighlight(viewer);
+    } else {
+      if (prevActiveId && prevActiveId !== activeId) {
+        dimEntity(prevActiveId);
+      }
+
+      // First activation from a fully-baseline state: dim the whole field
+      // in one pass. Subsequent hover/selection moves skip this branch
+      // entirely since `dimmed` is already populated.
+      if (dimmed.size === 0) {
+        entities.forEach((_e, id) => {
+          if (id !== activeId) dimEntity(id);
+        });
+      }
+
+      const activeEntity = entities.get(activeId);
+      const activeBaseline = baselineFor(activeId, catalogMap, collisionSet);
+      const activeObj = catalogMap.get(activeId);
+      if (activeEntity && activeBaseline) {
+        dimmed.delete(activeId);
+        applyHighlight(activeEntity, activeBaseline, {
+          isCollisionRisk: collisionSet.has(activeId),
+          labelText: activeObj?.name,
+        });
+      }
+
+      if (activeObj) {
+        setOrbitHighlight(viewer, activeObj, {
+          color: activeBaseline?.color ?? Cesium.Color.CYAN,
+          isCollisionRisk: collisionSet.has(activeId),
+        });
+      }
+    }
+
+    prevActiveIdRef.current = activeId;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewer, hoveredId, selectedId, datasetVersion]);
+}

--- a/frontend/src/lib/satelliteVisuals.ts
+++ b/frontend/src/lib/satelliteVisuals.ts
@@ -1,0 +1,36 @@
+import * as Cesium from 'cesium';
+
+export const CATEGORY_COLORS = {
+  PAYLOAD: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Active Satellites', icon: 'satellite_alt' },
+  DEBRIS: { css: '#FFAA00', cesium: Cesium.Color.fromCssColorString('#FFAA00'), label: 'Debris Objects', icon: 'delete_sweep' },
+  ROCKET_BODY: { css: '#FF4444', cesium: Cesium.Color.fromCssColorString('#FF4444'), label: 'Rocket Bodies', icon: 'rocket' },
+  UNKNOWN: { css: '#888888', cesium: Cesium.Color.fromCssColorString('#888888'), label: 'Unknown Objects', icon: 'help_outline' },
+  COLLISION: { css: '#FF0000', cesium: Cesium.Color.fromCssColorString('#FF0000'), label: 'Collision Risk', icon: 'warning' },
+  SELECTED: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Selected', icon: 'gps_fixed' },
+} as const;
+
+export function getPointSize(classification: string): number {
+  switch (classification) {
+    case 'PAYLOAD':
+      return 5;
+    case 'DEBRIS':
+      return 4;
+    case 'ROCKET_BODY':
+      return 6;
+    default:
+      return 3;
+  }
+}
+
+export function getOutlineWidth(classification: string): number {
+  switch (classification) {
+    case 'PAYLOAD':
+      return 1;
+    case 'DEBRIS':
+      return 1;
+    case 'ROCKET_BODY':
+      return 2;
+    default:
+      return 1;
+  }
+}

--- a/frontend/src/styles/spotlight.css
+++ b/frontend/src/styles/spotlight.css
@@ -1,0 +1,69 @@
+/* Satellite Spotlight Effect — shared styles
+ * Used by SpotlightInfoCard and the Cesium container's focus ring.
+ * Keeps motion short (150–300ms) and fully respects prefers-reduced-motion.
+ */
+
+:root {
+  --spotlight-transition-duration: 200ms;
+  --spotlight-transition-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.spotlight-info-card {
+  animation: spotlight-card-in var(--spotlight-transition-duration) var(--spotlight-transition-ease);
+  transition: opacity var(--spotlight-transition-duration) var(--spotlight-transition-ease),
+    transform var(--spotlight-transition-duration) var(--spotlight-transition-ease);
+}
+
+.spotlight-info-card--risk {
+  animation: spotlight-card-in var(--spotlight-transition-duration) var(--spotlight-transition-ease),
+    spotlight-risk-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes spotlight-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes spotlight-risk-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 20px rgba(255, 59, 48, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 32px rgba(255, 59, 48, 0.55);
+  }
+}
+
+/* Cesium container gets a soft, visible focus ring for keyboard users */
+.spotlight-globe-container {
+  outline: none;
+  transition: box-shadow var(--spotlight-transition-duration) var(--spotlight-transition-ease);
+}
+
+.spotlight-globe-container:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(0, 229, 255, 0.85), inset 0 0 24px rgba(0, 229, 255, 0.25);
+}
+
+.spotlight-keyboard-hint {
+  animation: spotlight-card-in var(--spotlight-transition-duration) var(--spotlight-transition-ease);
+}
+
+/* Respect reduced-motion preferences: strip transitions/animations to instant */
+@media (prefers-reduced-motion: reduce) {
+  .spotlight-info-card,
+  .spotlight-info-card--risk,
+  .spotlight-keyboard-hint {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .spotlight-globe-container {
+    transition: none !important;
+  }
+}

--- a/frontend/src/types/satellite.ts
+++ b/frontend/src/types/satellite.ts
@@ -1,0 +1,28 @@
+export interface CatalogObject {
+  id: number;
+  name: string;
+  catalog_number: string;
+  classification: 'PAYLOAD' | 'DEBRIS' | 'ROCKET_BODY' | 'UNKNOWN';
+  epoch: string | null;
+  inclination: number | null;
+  eccentricity: number | null;
+  semimajor_axis: number | null;
+  raan: number | null;
+  arg_of_perigee: number | null;
+  mean_anomaly: number | null;
+  mean_motion: number | null;
+  period: number | null;
+  has_tle: boolean;
+  updated_at: string | null;
+}
+
+export interface CollisionRisk {
+  id: number;
+  object_a: { name: string; catalog_number: string } | null;
+  object_b: { name: string; catalog_number: string } | null;
+  probability: number;
+  miss_distance_m: number;
+  relative_velocity_kms: number;
+  risk_level: string;
+  tca: string;
+}


### PR DESCRIPTION
## **User description**
## Summary
Implements the Interactive Satellite Spotlight Effect requested in #95. Hovering or clicking a satellite now visually highlights it — brighter color, larger size, a smooth ~220ms transition — while dimming nearby objects so it stands out. The active satellite's orbit path is drawn with a glowing polyline, and collision-risk satellites get a stronger red highlight plus a warning badge. Clicking locks the spotlight (cleared by clicking empty space or Escape), double-clicking flies the camera to the target, and a new info card shows name, NORAD ID, orbit type, altitude, and health/risk status while selected. Arrow-key navigation, Enter/Space to select, and a visible focus ring on the globe container are included for keyboard/accessibility support, and all transitions respect `prefers-reduced-motion`.

The implementation follows the folder structure suggested in the issue (`components/SatelliteSpotlight/`, `hooks/`, `styles/spotlight.css`) and is designed to be reusable for other object types later — swapping what populates the entity/catalog maps is enough to reuse the same spotlight system elsewhere.

Highlight/dim state is diffed against the previous hover/selection, so a hover change only ever touches the previously-active and newly-active entities rather than iterating the whole dataset, keeping it performant with large catalogs.

## Related Issue
Fixes #95

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🚀 Performance improvement
- [ ] 🎨 UI/UX enhancement
- [ ] 🔧 Refactoring
- [ ] 🧹 Chore / Maintenance
- [ ] 🔒 Security improvement


## Testing Performed
- [x] Tested locally
- [x] Tested relevant functionality
- [x] Checked for linting errors
- [x] Checked for TypeScript/build errors
- [ ] Tested responsive behavior (if applicable)

`tsc -b` shows no new type errors compared to the unmodified baseline (31 pre-existing errors in unrelated files, unchanged). ESLint is clean on all new/modified files aside from two pre-existing `setState`-in-effect patterns that already exist elsewhere in the codebase. Full manual click-through against live satellite data is still pending in my environment due to an unrelated local backend/DB setup issue — will update with screenshots once verified, or happy to have a maintainer test the branch directly in the meantime.

## Breaking Changes
None. `EarthTwin.tsx`'s existing hover/click behavior is replaced by the new spotlight system but the external interface (props, store usage) is unchanged.

## Checklist
- [x] I have read and followed the contributing guidelines.
- [x] My code follows the project's coding standards and guidelines.
- [x] I have completed testing of my changes.
- [ ] I have updated documentation where applicable.
- [x] I have checked that my changes do not introduce unintended regressions.

___

## **CodeAnt-AI Description**
Add interactive satellite spotlighting and keyboard navigation

### What Changed
- Hovering over a tracked object highlights it, dims nearby objects, shows its name, and draws its orbit path.
- Clicking locks the spotlight and opens an information card with the satellite’s NORAD ID, orbit type, altitude, and health or conjunction-risk status.
- Double-clicking focuses the camera on the selected satellite; clicking empty space or pressing Escape clears the selection.
- Arrow keys navigate between objects, while Enter or Space selects the focused object with a visible keyboard focus indicator.
- Collision-risk satellites receive stronger red highlighting and a warning badge, while spotlight transitions respect reduced-motion preferences.
- The globe no longer includes the previous save-view and bookmarks controls.

### Impact
`✅ Clearer satellite identification`
`✅ Faster camera focus on tracked objects`
`✅ Keyboard-accessible globe navigation`
`✅ More visible conjunction risks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Satellite Spotlight with hover highlighting, click selection, and double-click camera focus, including a selected-satellite info card and keyboard navigation (arrow keys, Enter/Space, Esc).
  * Added highlighted orbit paths and animated point/outline visual states (baseline/dimmed/highlighted).
* **Accessibility**
  * Improved keyboard focus handling and added reduced-motion support for camera movement and spotlight animations.
* **UI/Improvements**
  * Updated HUD/legend layout and added loading skeletons for collision status; spotlight behavior now refreshes cleanly on dataset updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an interactive Cesium satellite spotlight system.
- Introduces hover, click, double-click, and keyboard selection behavior.
- Adds animated highlight/dimming states, orbit polylines, and collision-risk styling.
- Adds a selected-satellite information card and reduced-motion-aware presentation.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because bookmark workflows remain unreachable and shadowed satellites remain visually indistinguishable from illuminated ones.

EarthTwin still omits all bookmark integration and shared-link restoration, while entity creation and spotlight baseline restoration continue to apply fixed opacity without evaluating satellite illumination.

**Files Needing Attention:** frontend/src/components/EarthTwin.tsx, frontend/src/components/SatelliteSpotlight/GlowEffect.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/EarthTwin.tsx | Integrates the spotlight manager and refactors Cesium entity setup, while previously reported bookmark and illumination regressions remain unresolved. |
| frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx | Coordinates pointer and keyboard interactions, spotlight state, and the selected-object information card. |
| frontend/src/components/SatelliteSpotlight/OrbitHighlight.tsx | Generates highlighted orbit polylines and now varies orbital radius for eccentric objects. |
| frontend/src/hooks/useSpotlightEffect.ts | Applies diffed baseline, dimmed, and highlighted visual states across refreshed Cesium datasets. |
| frontend/src/components/SatelliteSpotlight/GlowEffect.tsx | Implements reduced-motion-aware point transitions, but its fixed baseline opacity participates in the outstanding illumination regression. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input[Mouse or keyboard input] --> Manager[SpotlightManager]
  Manager --> Selection[Hover and selection hooks]
  Selection --> Visuals[Spotlight visual state]
  Visuals --> Entities[Cesium entities]
  Visuals --> Orbit[Orbit highlight]
  Selection --> Card[Satellite info card]
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into Interactive-Sat..."](https://github.com/7-blocks/kepler/commit/32081a802ed5cb279de8274766382250219d7f37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47245422)</sub>

<!-- /greptile_comment -->