### PR TITLE
feat: Add voice command support

### DIFF
--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -211,7 +211,7 @@ export const EarthTwin: React.FC = () => {
   }, []);
 
   const handleToggleSpaceWeather = useCallback(() => {
-    navigate('/space-weather')
+    navigate('/dashboard/space-weather')
   }, [navigate]);
   const [stats, setStats] = useState({
     totalObjects: 0,

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { MaterialIcon } from './MaterialIcon';
-import { SpotlightManager } from './SatelliteSpotlight/SpotlightManager';
-import type { CatalogObject, CollisionRisk } from '@/types/satellite';
-import { CATEGORY_COLORS, getPointSize, getOutlineWidth } from '@/lib/satelliteVisuals';
-import '@/styles/spotlight.css';
+import { useNavigate } from 'react-router-dom';
 import * as Cesium from 'cesium';
 import { isSatelliteSunlit } from '../utils/illumination';
 import { useBookmarks } from '../hooks/useBookmarks';
@@ -16,6 +13,8 @@ import {
   getSharedBookmarkFromUrl,
 } from '../utils/bookmarkHelpers';
 
+import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
+import { executeVoiceCommand } from '../lib/voiceCommands';
 
 interface CatalogObject {
   id: number;
@@ -50,33 +49,32 @@ interface CollisionRisk {
 
 function keplerToLatLonAlt(obj: CatalogObject, timeOffsetSec: number = 0): { lat: number; lon: number; alt: number } | null {
   if (obj.semimajor_axis == null || obj.inclination == null || obj.raan == null ||
-      obj.arg_of_perigee == null || obj.mean_anomaly == null || obj.mean_motion == null) {
+    obj.arg_of_perigee == null || obj.mean_anomaly == null || obj.mean_motion == null) {
     return null;
   }
 
-  const EARTH_RADIUS = 6371; 
+  const EARTH_RADIUS = 6371;
   const alt = obj.semimajor_axis - EARTH_RADIUS;
   if (alt < 0 || alt > 100000) return null;
 
-  
+
   const epochDate = obj.epoch ? new Date(obj.epoch) : new Date();
   const now = new Date();
   const elapsedDays = (now.getTime() - epochDate.getTime()) / 86400000 + (timeOffsetSec / 86400);
-  const meanMotionRadPerSec = (obj.mean_motion * 2 * Math.PI) / 86400;
   const currentMeanAnomaly = ((obj.mean_anomaly + (elapsedDays * obj.mean_motion * 360)) % 360) * Math.PI / 180;
 
-  
+
   const ecc = obj.eccentricity ?? 0;
   const trueAnomaly = currentMeanAnomaly + 2 * ecc * Math.sin(currentMeanAnomaly);
 
-  
+
   const argLat = (obj.arg_of_perigee * Math.PI / 180) + trueAnomaly;
 
-  
+
   const raanRad = obj.raan * Math.PI / 180;
   const incRad = obj.inclination * Math.PI / 180;
 
-  
+
   const J2000 = new Date('2000-01-01T12:00:00Z').getTime();
   const daysSinceJ2000 = (now.getTime() + timeOffsetSec * 1000 - J2000) / 86400000;
   const GMST = (280.46061837 + 360.98564736629 * daysSinceJ2000) % 360;
@@ -89,6 +87,34 @@ function keplerToLatLonAlt(obj: CatalogObject, timeOffsetSec: number = 0): { lat
   const lat = Math.asin(Math.sin(incRad) * Math.sin(argLat)) * 180 / Math.PI;
 
   return { lat, lon, alt };
+}
+
+
+const CATEGORY_COLORS = {
+  PAYLOAD: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Active Satellites', icon: 'satellite_alt' },
+  DEBRIS: { css: '#FFAA00', cesium: Cesium.Color.fromCssColorString('#FFAA00'), label: 'Debris Objects', icon: 'delete_sweep' },
+  ROCKET_BODY: { css: '#FF4444', cesium: Cesium.Color.fromCssColorString('#FF4444'), label: 'Rocket Bodies', icon: 'rocket' },
+  UNKNOWN: { css: '#888888', cesium: Cesium.Color.fromCssColorString('#888888'), label: 'Unknown Objects', icon: 'help_outline' },
+  COLLISION: { css: '#FF0000', cesium: Cesium.Color.fromCssColorString('#FF0000'), label: 'Collision Risk', icon: 'warning' },
+  SELECTED: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Selected', icon: 'gps_fixed' },
+} as const;
+
+function getPointSize(classification: string): number {
+  switch (classification) {
+    case 'PAYLOAD': return 5;
+    case 'DEBRIS': return 4;
+    case 'ROCKET_BODY': return 6;
+    default: return 3;
+  }
+}
+
+function getOutlineWidth(classification: string): number {
+  switch (classification) {
+    case 'PAYLOAD': return 1;
+    case 'DEBRIS': return 1;
+    case 'ROCKET_BODY': return 2;
+    default: return 1;
+  }
 }
 
 
@@ -111,33 +137,89 @@ const LegendCardSkeleton = () => (
 );
 
 export const EarthTwin: React.FC = () => {
+  const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<Cesium.Viewer | null>(null);
   const entitiesRef = useRef<Map<string, Cesium.Entity>>(new Map());
-  const catalogMapRef = useRef<Map<string, CatalogObject>>(new Map());
-  const collisionSetRef = useRef<Set<string>>(new Set());
   const tooltipRef = useRef<HTMLDivElement>(null);
   const { activeSector, setSelectedSatelliteId } = useUIStore();
   const [useFallback, setUseFallback] = useState(true);
   const [hoveredObject, setHoveredObject] = useState<CatalogObject | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
-  const [viewerInstance, setViewerInstance] = useState<Cesium.Viewer | null>(null);
-  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
-  const [datasetVersion, setDatasetVersion] = useState(0);
   const [showLegend, setShowLegend] = useState(true);
   const [showDensity, setShowDensity] = useState(false);
   const [showRiskOverlay, setShowRiskOverlay] = useState(false);
   const [objectCounts, setObjectCounts] = useState({ payloads: 0, debris: 0, rocketBodies: 0, total: 0, collisions: 0 });
   const [dataLoaded, setDataLoaded] = useState(false);
+  const [isBookmarkModalOpen, setIsBookmarkModalOpen] = useState(false);
+  const [isBookmarkSidebarOpen, setIsBookmarkSidebarOpen] = useState(false);
+  const [editingBookmark, setEditingBookmark] = useState<Bookmark | null>(null);
+  const handleTrackISS = useCallback(() => {
+    const viewer = viewerRef.current;
 
-  
+  if (!viewer || viewer.isDestroyed()) {
+    return;
+  }
+
+  autoRotateRef.current = false;
+
+  viewer.camera.flyTo({
+    destination: Cesium.Cartesian3.fromDegrees(
+      0,
+      0,
+      2_200_000
+    ),
+    orientation: {
+      heading:  0,
+      pitch: Cesium.Math.toRadians(-85),
+      roll: 0,
+    },
+    duration: 1.5,
+  });
+  }, []);
+
+  const handleShowDebris = useCallback(() => {
+    navigate('/Debris');
+  }, [navigate]);
+
+  const handleOpenCollisionCenter = useCallback(() => {
+    navigate('/dashboard/collision-center');
+  }, [navigate]);
+
+  const handleZoomToIndia = useCallback(() => {
+    const viewer = viewerRef.current;
+
+    if (!viewer || viewer.isDestroyed()) {
+      return;
+    }
+
+    autoRotateRef.current = false;
+
+    viewer.camera.flyTo({
+      destination: Cesium.Cartesian3.fromDegrees(
+        78.9629,
+        20.5937,
+        3_000_000
+      ),
+      orientation: {
+        heading: 0,
+        pitch: Cesium.Math.toRadians(-85),
+        roll: 0,
+      },
+      duration: 1.5,
+    });
+  }, []);
+
+  const handleToggleSpaceWeather = useCallback(() => {
+    navigate('/space-weather')
+  }, [navigate]);
   const [stats, setStats] = useState({
     totalObjects: 0,
     lastSync: '',
     weatherIndex: 'K0',
   });
 
-  
+
   const populateEntities = useCallback(async (viewer: Cesium.Viewer) => {
     try {
       if (!viewer || viewer.isDestroyed()) return;
@@ -147,7 +229,7 @@ export const EarthTwin: React.FC = () => {
         fetchCollisions(),
       ]);
 
-      
+
       const collisionCatNums = new Set<string>();
       collisions.forEach(c => {
         if (c.object_a?.catalog_number) collisionCatNums.add(c.object_a.catalog_number);
@@ -157,22 +239,22 @@ export const EarthTwin: React.FC = () => {
       let payloads = 0, debris = 0, rocketBodies = 0;
       const entityMap = new Map<string, Cesium.Entity>();
 
-      
+
       if (!viewer || viewer.isDestroyed()) return;
 
-      
-      viewer.entities.removeAll();
 
+      viewer.entities.removeAll();
+      const nowJulian = Cesium.JulianDate.now();
       objects.forEach(obj => {
         const pos = keplerToLatLonAlt(obj);
         if (!pos) return;
 
-        
+
         if (obj.classification === 'PAYLOAD') payloads++;
         else if (obj.classification === 'DEBRIS') debris++;
         else if (obj.classification === 'ROCKET_BODY') rocketBodies++;
 
-        
+
         const isCollisionRisk = collisionCatNums.has(obj.catalog_number);
         const colorConfig = isCollisionRisk
           ? CATEGORY_COLORS.COLLISION
@@ -181,12 +263,15 @@ export const EarthTwin: React.FC = () => {
         const pixelSize = isCollisionRisk ? 8 : getPointSize(obj.classification);
         const outlineWidth = isCollisionRisk ? 3 : getOutlineWidth(obj.classification);
 
+        const cartPos = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000);
+        const sunlit = isSatelliteSunlit(cartPos, nowJulian, viewer.scene.globe);
+
         const entity = viewer.entities.add({
-          position: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000),
+          position: cartPos,
           point: {
             pixelSize,
-            color: colorConfig.cesium.withAlpha(0.85),
-            outlineColor: colorConfig.cesium.withAlpha(0.4),
+            color: sunlit ? colorConfig.cesium.withAlpha(0.85) : colorConfig.cesium.withAlpha(0.3),
+            outlineColor: sunlit ? colorConfig.cesium.withAlpha(0.4) : colorConfig.cesium.withAlpha(0.1),
             outlineWidth,
             disableDepthTestDistance: Number.POSITIVE_INFINITY,
             scaleByDistance: new Cesium.NearFarScalar(1e6, 1.5, 5e7, 0.4),
@@ -205,7 +290,7 @@ export const EarthTwin: React.FC = () => {
         entityMap.set(obj.catalog_number, entity);
       });
 
-      
+
       collisions.forEach(conj => {
         if (!conj.object_a || !conj.object_b) return;
         const entityA = entityMap.get(conj.object_a.catalog_number);
@@ -229,9 +314,6 @@ export const EarthTwin: React.FC = () => {
       });
 
       entitiesRef.current = entityMap;
-      catalogMapRef.current = new Map(objects.map(obj => [obj.catalog_number, obj]));
-      collisionSetRef.current = collisionCatNums;
-      setDatasetVersion(v => v + 1);
       setObjectCounts({
         payloads,
         debris,
@@ -251,12 +333,211 @@ export const EarthTwin: React.FC = () => {
     }
   }, []);
 
-  
+
+  const autoRotateRef = useRef(true);
+
+  const {
+    bookmarks,
+    filteredBookmarks,
+    favoriteBookmarks,
+    recentBookmarks,
+    categories,
+
+    searchQuery,
+    selectedCategory,
+
+    setSearchQuery,
+    setSelectedCategory,
+
+    addBookmark,
+    updateBookmark,
+    deleteBookmark,
+    toggleFavorite,
+    markAsRecent,
+
+    exportBookmarks,
+    importBookmarks,
+  } = useBookmarks();
+
+  const [selectedBookmarkId, setSelectedBookmarkId] =
+    useState('');
+
+
+  const saveCurrentView = useCallback(() => {
+    const viewer = viewerRef.current;
+
+    if (!viewer || viewer.isDestroyed()) {
+      return;
+    }
+
+    const cartographic =
+      viewer.scene.globe.ellipsoid.cartesianToCartographic(
+        viewer.camera.positionWC
+      );
+
+    if (!cartographic) {
+      return;
+    }
+
+    const timestamp = new Intl.DateTimeFormat('en-IN', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date());
+
+    addBookmark({
+      name: `Saved view — ${timestamp}`,
+      description: 'Saved from the current globe camera position.',
+      category: 'Custom',
+
+      latitude: Cesium.Math.toDegrees(cartographic.latitude),
+      longitude: Cesium.Math.toDegrees(cartographic.longitude),
+      altitude: cartographic.height,
+
+      // Cesium expects these values in radians when restoring.
+      heading: viewer.camera.heading,
+      pitch: viewer.camera.pitch,
+      roll: viewer.camera.roll,
+    });
+  }, [addBookmark]);
+
+  const restoreBookmark = useCallback(
+    (bookmark: Bookmark) => {
+      const viewer = viewerRef.current;
+
+      if (!viewer || viewer.isDestroyed()) {
+        return;
+      }
+
+      // Prevent the existing automatic globe rotation from immediately
+      // moving the camera away from the restored bookmark view.
+      autoRotateRef.current = false;
+
+      markAsRecent(bookmark.id);
+
+      const prefersReducedMotion =
+        window.matchMedia?.(
+          '(prefers-reduced-motion: reduce)'
+        ).matches ?? false;
+
+      viewer.camera.flyTo({
+        destination: Cesium.Cartesian3.fromDegrees(
+          bookmark.longitude,
+          bookmark.latitude,
+          bookmark.altitude
+        ),
+        orientation: {
+          heading: bookmark.heading,
+          pitch: bookmark.pitch,
+          roll: bookmark.roll,
+        },
+        duration: prefersReducedMotion ? 0 : 1.5,
+      });
+    },
+    [markAsRecent]
+  );
+
+
+  const handleBookmarkSubmit = useCallback(
+    (values: BookmarkFormValues) => {
+      if (editingBookmark) {
+        updateBookmark(editingBookmark.id, {
+          name: values.name,
+          description: values.description,
+          category: values.category,
+        });
+
+        setEditingBookmark(null);
+        setIsBookmarkModalOpen(false);
+        return;
+      }
+
+      const viewer = viewerRef.current;
+
+      if (!viewer || viewer.isDestroyed()) {
+        return;
+      }
+
+      const cartographic =
+        viewer.scene.globe.ellipsoid.cartesianToCartographic(
+          viewer.camera.positionWC
+        );
+
+      if (!cartographic) {
+        return;
+      }
+
+      addBookmark({
+        name: values.name,
+        description: values.description,
+        category: values.category,
+
+        latitude: Cesium.Math.toDegrees(cartographic.latitude),
+        longitude: Cesium.Math.toDegrees(cartographic.longitude),
+        altitude: cartographic.height,
+
+        heading: viewer.camera.heading,
+        pitch: viewer.camera.pitch,
+        roll: viewer.camera.roll,
+      });
+
+      setIsBookmarkModalOpen(false);
+    },
+    [addBookmark, editingBookmark, updateBookmark]
+  );
+
+  const handleShareBookmark = useCallback(
+    async (bookmark: Bookmark) => {
+      const shareUrl = createBookmarkShareUrl(bookmark);
+
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+      } catch {
+        window.prompt(
+          'Copy this bookmark link:',
+          shareUrl
+        );
+      }
+    },
+    []
+  );
+
+
+  const handleVoiceCommand = useCallback(
+    (transcript: string) => {
+      executeVoiceCommand(transcript, {
+        trackISS: handleTrackISS,
+        showDebris: handleShowDebris,
+        openCollisionCenter: handleOpenCollisionCenter,
+        zoomToIndia: handleZoomToIndia,
+        toggleSpaceWeather: handleToggleSpaceWeather,
+      });
+    },
+    [
+      handleTrackISS,
+      handleShowDebris,
+      handleOpenCollisionCenter,
+      handleZoomToIndia,
+      handleToggleSpaceWeather,
+    ]
+  );
+
+  const {
+    isSupported,
+    isListening,
+    transcript,
+    error,
+    startListening,
+    stopListening,
+  } = useSpeechRecognition({
+    onCommand: handleVoiceCommand,
+  });
+
   useEffect(() => {
     if (!containerRef.current || !Cesium) return;
     if (viewerRef.current && !viewerRef.current.isDestroyed()) return;
 
     let onTick: (() => void) | null = null;
+    let handler: Cesium.ScreenSpaceEventHandler | null = null;
 
     try {
       const viewer = new Cesium.Viewer(containerRef.current, {
@@ -277,19 +558,18 @@ export const EarthTwin: React.FC = () => {
       });
 
       viewerRef.current = viewer;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUseFallback(false);
-      setViewerInstance(viewer);
-      setContainerEl(containerRef.current);
 
-      
-      viewer.scene.globe.enableLighting = false;
+
+      viewer.scene.globe.enableLighting = true; // Enable real-time day/night lighting
       viewer.scene.backgroundColor = Cesium.Color.fromCssColorString('#050710');
       viewer.scene.fog.enabled = false;
       if (viewer.scene.skyAtmosphere) {
         viewer.scene.skyAtmosphere.show = true;
       }
 
-      
+
       viewer.camera.setView({
         destination: Cesium.Cartesian3.fromDegrees(30, 15, 20000000),
         orientation: {
@@ -298,17 +578,87 @@ export const EarthTwin: React.FC = () => {
           roll: 0.0,
         },
       });
+      const sharedBookmark = getSharedBookmarkFromUrl();
 
-      
+      if (sharedBookmark) {
+        autoRotateRef.current = false;
+
+        const prefersReducedMotion =
+          window.matchMedia?.(
+            '(prefers-reduced-motion: reduce)'
+          ).matches ?? false;
+
+        viewer.camera.flyTo({
+          destination: Cesium.Cartesian3.fromDegrees(
+            sharedBookmark.longitude,
+            sharedBookmark.latitude,
+            sharedBookmark.altitude
+          ),
+          orientation: {
+            heading: sharedBookmark.heading,
+            pitch: sharedBookmark.pitch,
+            roll: sharedBookmark.roll,
+          },
+          duration: prefersReducedMotion ? 0 : 1.5,
+        });
+      }
+
       onTick = () => {
-        viewer.scene.camera.rotate(Cesium.Cartesian3.UNIT_Z, 0.0003);
+        if (autoRotateRef.current) {
+          viewer.scene.camera.rotate(
+            Cesium.Cartesian3.UNIT_Z,
+            0.0003
+          );
+        }
       };
       viewer.clock.onTick.addEventListener(onTick);
 
-      
+
+      handler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
+
+      handler.setInputAction((movement: { endPosition: Cesium.Cartesian2 }) => {
+        const picked = viewer.scene.pick(movement.endPosition);
+        if (Cesium.defined(picked) && picked.id && picked.id.properties) {
+          try {
+            const rawData = picked.id.properties.catalogData?.getValue(Cesium.JulianDate.now());
+            if (rawData) {
+              const obj = JSON.parse(rawData) as CatalogObject;
+              setHoveredObject(obj);
+              setTooltipPos({ x: movement.endPosition.x + 15, y: movement.endPosition.y - 10 });
+            }
+          } catch { /* ignore parse errors */ }
+        } else {
+          setHoveredObject(null);
+        }
+      }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+
+
+      handler.setInputAction((click: { position: Cesium.Cartesian2 }) => {
+        const picked = viewer.scene.pick(click.position);
+        if (Cesium.defined(picked) && picked.id && picked.id.properties) {
+          try {
+            const rawData = picked.id.properties.catalogData?.getValue(Cesium.JulianDate.now());
+            if (rawData) {
+              const obj = JSON.parse(rawData) as CatalogObject;
+              setSelectedSatelliteId(obj.catalog_number);
+
+
+              const pos = keplerToLatLonAlt(obj);
+              if (pos) {
+                viewer.camera.flyTo({
+                  destination: Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000 + 2000000),
+                  duration: 1.5,
+                });
+              }
+            }
+          } catch { /* ignore parse errors */ }
+        }
+      }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+
       populateEntities(viewer);
 
-      
+
       const refreshInterval = setInterval(() => {
         if (viewerRef.current && !viewerRef.current.isDestroyed()) {
           populateEntities(viewerRef.current);
@@ -317,32 +667,26 @@ export const EarthTwin: React.FC = () => {
 
       return () => {
         clearInterval(refreshInterval);
+        if (handler) handler.destroy();
         const v = viewerRef.current;
         if (v && !v.isDestroyed()) {
           if (onTick) v.clock.onTick.removeEventListener(onTick);
           v.destroy();
         }
         viewerRef.current = null;
-        setViewerInstance(null);
-        setContainerEl(null);
       };
 
     } catch (e) {
       console.warn('Cesium initialization failed, using fallback', e);
       setUseFallback(true);
     }
-  }, []); 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-bg-deep-space border-b border-border-panel">
       {/* 3D Cesium Container */}
-      <div
-        ref={containerRef}
-        tabIndex={0}
-        role="application"
-        aria-label="Orbital object globe. Use arrow keys to navigate between tracked objects, Enter to select, Escape to clear."
-        className="spotlight-globe-container absolute inset-0 w-full h-full z-0"
-      />
+      <div ref={containerRef} className="absolute inset-0 w-full h-full z-0" />
 
       {/* High-Fidelity SVG Fallback */}
       {useFallback && (
@@ -362,22 +706,6 @@ export const EarthTwin: React.FC = () => {
           </svg>
         </div>
       )}
-
-      {/* ── Interactive Satellite Spotlight ─────────────────────── */}
-      <SpotlightManager
-        viewer={viewerInstance}
-        containerEl={containerEl}
-        entitiesRef={entitiesRef}
-        catalogMapRef={catalogMapRef}
-        collisionSetRef={collisionSetRef}
-        datasetVersion={datasetVersion}
-        toLatLonAlt={keplerToLatLonAlt}
-        onHoverChange={(obj, pos) => {
-          setHoveredObject(obj);
-          setTooltipPos(pos);
-        }}
-        onSelectionChange={(id) => setSelectedSatelliteId(id)}
-      />
 
       {/* ── Hover Tooltip (Glassmorphism) ──────────────────────── */}
       {hoveredObject && (
@@ -421,7 +749,7 @@ export const EarthTwin: React.FC = () => {
       )}
 
       {/* ── HUD Overlay ───────────────────────────────────────── */}
-      <div className="absolute inset-0 p-3 md:p-6 flex flex-col justify-between z-10 pointer-events-none overflow-hidden">
+      <div className="absolute inset-0 p-3 pb-16 md:p-6 md:pb-16 flex flex-col justify-between z-10 pointer-events-none overflow-hidden">
 
         {/* Top Row */}
         <div className="flex flex-col sm:flex-row justify-between items-start gap-2">
@@ -440,30 +768,30 @@ export const EarthTwin: React.FC = () => {
           </div>
 
           <div className="text-right space-y-1 animate-[slideDown_0.5s_ease-out] hidden sm:block">
-          {dataLoaded ? (
-            <>
-            {objectCounts.collisions > 0 ? (
-              <div className="bg-status-emergency/20 border border-status-emergency px-3 md:px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
-                <MaterialIcon name="warning" className="text-status-emergency text-sm animate-pulse" />
-                <span className="font-technical-data text-status-emergency text-[11px] md:text-[12px] font-bold">
-                  {objectCounts.collisions} ACTIVE CONJUNCTION{objectCounts.collisions !== 1 ? 'S' : ''}
-                </span>
-              </div>
+            {dataLoaded ? (
+              <>
+                {objectCounts.collisions > 0 ? (
+                  <div className="bg-status-emergency/20 border border-status-emergency px-3 md:px-4 py-1 flex items-center gap-2 drop-shadow-[0_0_12px_rgba(255,59,48,0.4)]">
+                    <MaterialIcon name="warning" className="text-status-emergency text-sm animate-pulse" />
+                    <span className="font-technical-data text-status-emergency text-[11px] md:text-[12px] font-bold">
+                      {objectCounts.collisions} ACTIVE CONJUNCTION{objectCounts.collisions !== 1 ? 'S' : ''}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="bg-status-success/20 border border-status-success px-3 md:px-4 py-1 flex items-center gap-2">
+                    <MaterialIcon name="verified_user" className="text-status-success text-sm" />
+                    <span className="font-technical-data text-status-success text-[11px] md:text-[12px] font-bold">
+                      ALL CLEAR
+                    </span>
+                  </div>
+                )}
+              </>
             ) : (
-              <div className="bg-status-success/20 border border-status-success px-3 md:px-4 py-1 flex items-center gap-2">
-                <MaterialIcon name="verified_user" className="text-status-success text-sm" />
-                <span className="font-technical-data text-status-success text-[11px] md:text-[12px] font-bold">
-                  ALL CLEAR
-                </span>
-              </div>
+              <>
+                <div className="w-full h-8 bg-surface-container/80 animate-pulse" />
+                <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
+              </>
             )}
-            </>
-          ) : (
-            <>
-            <div className="w-full h-8 bg-surface-container/80 animate-pulse" />
-            <div className="w-full h-4 bg-surface-container/80 animate-pulse" />
-            </>
-          ) }
             <p className={`font-technical-data text-[9px] md:text-[10px] text-primary/70 hidden md:block transition-ui ${dataLoaded ? 'opacity-100' : 'opacity-0'}`}>
               WEATHER: {stats.weatherIndex} · DATA SOURCE: SPACE-TRACK / NASA DONKI
             </p>
@@ -478,52 +806,107 @@ export const EarthTwin: React.FC = () => {
               <div className="min-w-[250px] p-4 animate-pulse bg-surface-container/80 h-12" />
             ) : (
               <>
-            <div className="space-y-0.5">
-              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
-              <p className="font-headline-lg text-primary text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
-                {objectCounts.total.toLocaleString()}
-              </p>
-            </div>
-            <div className="space-y-0.5">
-              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Debris</p>
-              <p className="font-headline-lg text-status-warning text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(255,170,0,0.4)]">
-                {objectCounts.debris.toLocaleString()}
-              </p>
-            </div>
-            <div className="space-y-0.5">
-              <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Collision Risks</p>
-              <p className={`font-headline-lg text-xl md:text-3xl font-bold font-technical-data ${objectCounts.collisions > 0 ? 'text-status-emergency animate-pulse drop-shadow-[0_0_8px_rgba(255,59,48,0.6)]' : 'text-status-success drop-shadow-[0_0_8px_rgba(0,255,136,0.4)]'}`}>
-                {objectCounts.collisions}
-              </p>
-            </div>
-            </>
+                <div className="space-y-0.5">
+                  <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Objects Tracked</p>
+                  <p className="font-headline-lg text-primary text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(0,229,255,0.4)]">
+                    {objectCounts.total.toLocaleString()}
+                  </p>
+                </div>
+                <div className="space-y-0.5">
+                  <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Debris</p>
+                  <p className="font-headline-lg text-status-warning text-xl md:text-3xl font-bold font-technical-data drop-shadow-[0_0_8px_rgba(255,170,0,0.4)]">
+                    {objectCounts.debris.toLocaleString()}
+                  </p>
+                </div>
+                <div className="space-y-0.5">
+                  <p className="font-label-caps text-[9px] md:text-[10px] text-primary/70 uppercase">Collision Risks</p>
+                  <p className={`font-headline-lg text-xl md:text-3xl font-bold font-technical-data ${objectCounts.collisions > 0 ? 'text-status-emergency animate-pulse drop-shadow-[0_0_8px_rgba(255,59,48,0.6)]' : 'text-status-success drop-shadow-[0_0_8px_rgba(0,255,136,0.4)]'}`}>
+                    {objectCounts.collisions}
+                  </p>
+                </div>
+              </>
             )
-          }
+            }
           </div>
 
           {/* Controls */}
           <div className="flex gap-1.5 md:gap-2 pointer-events-auto">
             <button
+              type="button"
+              onClick={isListening ? stopListening : startListening}
+              disabled={!isSupported}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui border ${isListening
+                ? 'bg-status-emergency text-white border-status-emergency animate-pulse'
+                : 'border-primary-container text-primary-container hover:bg-primary-container/10'
+                }`}
+              aria-label={
+                isListening
+                  ? 'Stop listening'
+                  : 'Start voice commands'
+              }
+            >
+              {isListening ? 'LISTENING...' : 'VOICE COMMAND'}
+            </button>
+            {(isListening || transcript || error) && (
+              <div className="absolute top-20 left-1/2 -translate-x-1/2 z-30 pointer-events-none">
+                <div className="glass-panel px-4 py-3 text-center">
+                  {isListening && (
+                    <p className="font-label-caps text-[10px] text-primary-container animate-pulse">
+                      LISTENING FOR COMMAND...
+                    </p>
+                  )}
+
+                  {transcript && (
+                    <p className="mt-1 font-technical-data text-xs text-on-surface">
+                      "{transcript}"
+                    </p>
+                  )}
+
+                  {error && (
+                    <p className="mt-1 font-technical-data text-xs text-status-emergency">
+                      Voice error: {error}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={() => setIsBookmarkModalOpen(true)}
+              className="px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border border-primary-container text-primary-container hover:bg-primary-container/10"
+              aria-label="Save the current globe view as a bookmark"
+            >
+              SAVE VIEW
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setIsBookmarkSidebarOpen(true)}
+              className="px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border border-primary-container text-primary-container hover:bg-primary-container/10"
+              aria-label="Open saved globe bookmarks"
+            >
+              BOOKMARKS
+            </button>
+
+
+            <button
               onClick={() => setShowLegend(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
-                showLegend ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
-              }`}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showLegend ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
+                }`}
             >
               LEGEND
             </button>
             <button
               onClick={() => setShowDensity(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
-                showDensity ? 'bg-status-warning text-bg-deep-space border-status-warning' : 'border-status-warning/50 text-status-warning hover:bg-status-warning/10'
-              }`}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showDensity ? 'bg-status-warning text-bg-deep-space border-status-warning' : 'border-status-warning/50 text-status-warning hover:bg-status-warning/10'
+                }`}
             >
               DENSITY
             </button>
             <button
               onClick={() => setShowRiskOverlay(v => !v)}
-              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${
-                showRiskOverlay ? 'bg-status-emergency text-white border-status-emergency' : 'border-status-emergency/50 text-status-emergency hover:bg-status-emergency/10'
-              }`}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showRiskOverlay ? 'bg-status-emergency text-white border-status-emergency' : 'border-status-emergency/50 text-status-emergency hover:bg-status-emergency/10'
+                }`}
             >
               RISK
             </button>
@@ -535,38 +918,91 @@ export const EarthTwin: React.FC = () => {
       {showLegend && (
         <div className="absolute bottom-16 md:bottom-24 left-3 md:left-6 z-20 pointer-events-auto animate-[slideUp_0.3s_ease-out]">
           {dataLoaded ? (
-          <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[200px] shadow-[0_0_30px_rgba(0,0,0,0.6)]">
-            <div className="flex justify-between items-center mb-3">
-              <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">ORBITAL LEGEND</span>
-              <button onClick={() => setShowLegend(false)} className="text-on-surface-variant/60 hover:text-on-surface cursor-pointer">
-                <MaterialIcon name="close" className="text-xs" />
-              </button>
-            </div>
-            <div className="space-y-2">
-              {[
-                { color: CATEGORY_COLORS.PAYLOAD.css,     label: 'Active Satellites', count: objectCounts.payloads },
-                { color: CATEGORY_COLORS.DEBRIS.css,      label: 'Debris Objects',    count: objectCounts.debris },
-                { color: CATEGORY_COLORS.ROCKET_BODY.css, label: 'Rocket Bodies',     count: objectCounts.rocketBodies },
-                { color: CATEGORY_COLORS.COLLISION.css,    label: 'Collision Risks',   count: objectCounts.collisions },
-              ].map(item => (
-                <div key={item.label} className="flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="w-3 h-3 rounded-full"
-                      style={{ backgroundColor: item.color, boxShadow: `0 0 8px ${item.color}60` }}
-                    />
-                    <span className="font-technical-data text-[11px] text-on-surface-variant">{item.label}</span>
+            <div className="bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[200px] shadow-[0_0_30px_rgba(0,0,0,0.6)]">
+              <div className="flex justify-between items-center mb-3">
+                <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">ORBITAL LEGEND</span>
+                <button onClick={() => setShowLegend(false)} className="text-on-surface-variant/60 hover:text-on-surface cursor-pointer">
+                  <MaterialIcon name="close" className="text-xs" />
+                </button>
+              </div>
+              <div className="space-y-2">
+                {[
+                  { color: CATEGORY_COLORS.PAYLOAD.css, label: 'Active Satellites', count: objectCounts.payloads },
+                  { color: CATEGORY_COLORS.DEBRIS.css, label: 'Debris Objects', count: objectCounts.debris },
+                  { color: CATEGORY_COLORS.ROCKET_BODY.css, label: 'Rocket Bodies', count: objectCounts.rocketBodies },
+                  { color: CATEGORY_COLORS.COLLISION.css, label: 'Collision Risks', count: objectCounts.collisions },
+                ].map(item => (
+                  <div key={item.label} className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="w-3 h-3 rounded-full"
+                        style={{ backgroundColor: item.color, boxShadow: `0 0 8px ${item.color}60` }}
+                      />
+                      <span className="font-technical-data text-[11px] text-on-surface-variant">{item.label}</span>
+                    </div>
+                    <span className="font-technical-data text-[11px] font-bold text-on-surface">{item.count.toLocaleString()}</span>
                   </div>
-                  <span className="font-technical-data text-[11px] font-bold text-on-surface">{item.count.toLocaleString()}</span>
-                </div>
-              ))}
+                ))}
+              </div>
+              <div className="mt-3 pt-2 border-t border-border-panel/40 text-[9px] text-on-surface-variant/50 font-technical-data">
+                All positions from real orbital elements
+              </div>
             </div>
-            <div className="mt-3 pt-2 border-t border-border-panel/40 text-[9px] text-on-surface-variant/50 font-technical-data">
-              All positions from real orbital elements
-            </div>
-          </div>
-          ) : (<LegendCardSkeleton />) }
+          ) : (<LegendCardSkeleton />)}
         </div>
+      )}
+
+      {/* Bookmark create/edit dialog */}
+      {isBookmarkModalOpen && (
+        <BookmarkModal
+          onClose={() => setIsBookmarkModalOpen(false)}
+          onSubmit={handleBookmarkSubmit}
+        />
+      )}
+
+
+      {/* Bookmark sidebar */}
+      {isBookmarkSidebarOpen && (
+        <BookmarkSidebar
+          bookmarks={bookmarks}
+          filteredBookmarks={filteredBookmarks}
+          favoriteBookmarks={favoriteBookmarks}
+          recentBookmarks={recentBookmarks}
+          categories={categories}
+          searchQuery={searchQuery}
+          selectedCategory={selectedCategory}
+          onSearchChange={setSearchQuery}
+          onCategoryChange={setSelectedCategory}
+          onOpenBookmark={restoreBookmark}
+          onCreateBookmark={() => {
+            setEditingBookmark(null);
+            setIsBookmarkModalOpen(true);
+          }}
+          onShareBookmark={handleShareBookmark}
+          onEditBookmark={(bookmark) => {
+            setEditingBookmark(bookmark);
+            setIsBookmarkModalOpen(true);
+          }}
+          onDeleteBookmark={deleteBookmark}
+          onToggleFavorite={(bookmarkId) =>
+            toggleFavorite(bookmarkId)
+          }
+          onExportBookmarks={exportBookmarks}
+          onImportBookmarks={importBookmarks}
+          onClose={() => setIsBookmarkSidebarOpen(false)}
+        />
+      )}
+
+      {isBookmarkModalOpen && (
+        <BookmarkModal
+          key={editingBookmark?.id ?? 'create-bookmark'}
+          initialBookmark={editingBookmark}
+          onClose={() => {
+            setEditingBookmark(null);
+            setIsBookmarkModalOpen(false);
+          }}
+          onSubmit={handleBookmarkSubmit}
+        />
       )}
       {/* ── Inline Styles for Animations ──────────────────────── */}
       <style>{`

--- a/frontend/src/hooks/useSpeechRecognition.ts
+++ b/frontend/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface SpeechRecognitionEventLike {
+    results: {
+        [index: number]: {
+            [index: number]: {
+                transcript: string;
+                confidence: number;
+            };
+        };
+    };
+}
+
+interface SpeechRecognitionErrorEventLike {
+    error: string;
+}
+
+interface SpeechRecognitionInstance {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    start: () => void;
+    stop: () => void;
+    abort: () => void;
+    onstart: (() => void) | null;
+    onend: (() => void) | null;
+    onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+    onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+}
+
+interface SpeechRecognitionConstructor {
+    new(): SpeechRecognitionInstance;
+}
+
+declare global {
+    interface Window {
+        SpeechRecognition?: SpeechRecognitionConstructor;
+        webkitSpeechRecognition?: SpeechRecognitionConstructor;
+    }
+}
+
+interface UseSpeechRecognitionOptions {
+    onCommand: (transcript: string) => void;
+}
+
+export function useSpeechRecognition({
+    onCommand,
+}: UseSpeechRecognitionOptions) {
+    const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+
+    const [isListening, setIsListening] = useState(false);
+    const [transcript, setTranscript] = useState("");
+    const [error, setError] = useState<string | null>(null);
+
+    const isSupported =
+        typeof window !== "undefined" &&
+        Boolean(
+            window.SpeechRecognition || window.webkitSpeechRecognition
+        );
+
+    useEffect(() => {
+        if (!isSupported) {
+            return;
+        }
+
+        const SpeechRecognition =
+            window.SpeechRecognition || window.webkitSpeechRecognition;
+
+        if (!SpeechRecognition) {
+            return;
+        }
+
+        const recognition = new SpeechRecognition();
+
+        recognition.continuous = false;
+        recognition.interimResults = false;
+        recognition.lang = "en-US";
+
+        recognition.onstart = () => {
+            setIsListening(true);
+            setError(null);
+            setTranscript("");
+        };
+
+        recognition.onresult = (event) => {
+            const result = event.results[0]?.[0];
+
+            if (!result) {
+                return;
+            }
+            setTimeout(() => {
+                setTranscript("");
+            }, 1500);
+
+            const spokenText = result.transcript.trim();
+
+            setTranscript(spokenText);
+            onCommand(spokenText);
+        };
+
+        recognition.onerror = (event) => {
+            setError(event.error);
+            setIsListening(false);
+        };
+
+        recognition.onend = () => {
+            setIsListening(false);
+        };
+
+        recognitionRef.current = recognition;
+
+        return () => {
+            recognition.abort();
+            recognitionRef.current = null;
+        };
+    }, [isSupported, onCommand]);
+
+    const startListening = useCallback(() => {
+        if (!recognitionRef.current || isListening) {
+            return;
+        }
+
+        setError(null);
+        recognitionRef.current.start();
+    }, [isListening]);
+
+    const stopListening = useCallback(() => {
+        if (!recognitionRef.current || !isListening) {
+            return;
+        }
+
+        recognitionRef.current.stop();
+    }, [isListening]);
+
+    return {
+        isSupported,
+        isListening,
+        transcript,
+        error,
+        startListening,
+        stopListening,
+    };
+}

--- a/frontend/src/lib/voiceCommands.ts
+++ b/frontend/src/lib/voiceCommands.ts
@@ -1,0 +1,86 @@
+export interface VoiceActions {
+  trackISS: () => void;
+  showDebris: () => void;
+  openCollisionCenter: () => void;
+  zoomToIndia: () => void;
+  toggleSpaceWeather: () => void;
+}
+
+export interface VoiceCommandResult {
+  success: boolean;
+  message: string;
+}
+
+export function executeVoiceCommand(
+  transcript: string,
+  actions: VoiceActions
+): VoiceCommandResult {
+  const command = transcript.toLowerCase().trim();
+
+  if (
+    command.includes("track iss") ||
+    command.includes("track the iss")
+  ) {
+    actions.trackISS();
+
+    return {
+      success: true,
+      message: "Tracking ISS",
+    };
+  }
+
+  if (
+    command.includes("show debris") ||
+    command.includes("show the debris") ||
+    command.includes("display debris")
+  ) {
+    actions.showDebris();
+
+    return {
+      success: true,
+      message: "Showing debris",
+    };
+  }
+
+  if (
+    command.includes("collision center") ||
+    command.includes("open collision center")
+  ) {
+    actions.openCollisionCenter();
+
+    return {
+      success: true,
+      message: "Opening Collision Center",
+    };
+  }
+
+  if (
+    command.includes("zoom to india") ||
+    command.includes("zoom into india") ||
+    command.includes("show india")
+  ) {
+    actions.zoomToIndia();
+
+    return {
+      success: true,
+      message: "Zooming to India",
+    };
+  }
+
+  if (
+    command.includes("space weather") ||
+    command.includes("toggle space weather")
+  ) {
+    actions.toggleSpaceWeather();
+
+    return {
+      success: true,
+      message: "Toggling space weather",
+    };
+  }
+
+  return {
+    success: false,
+    message: `Command not recognized: "${transcript}"`,
+  };
+}

--- a/frontend/src/lib/voiceCommands.ts
+++ b/frontend/src/lib/voiceCommands.ts
@@ -18,8 +18,8 @@ export function executeVoiceCommand(
   const command = transcript.toLowerCase().trim();
 
   if (
-    command.includes("track iss") ||
-    command.includes("track the iss")
+    command.includes("view iss") ||
+    command.includes("show iss")
   ) {
     actions.trackISS();
 
@@ -85,7 +85,7 @@ export function executeVoiceCommand(
   };
 }
 
-//For tracking ISS , use the command "track ISS" or "track the ISS"
+//For viewing ISS , use the command "view iss" or "show iss"
 //For showing debris , use the command "show debris", "show the debris" or "display debris"
 //For opening collision center , use the command "collision center" or "open collision center"
 //For zooming to India , use the command "zoom to India", "zoom into India" or "show India"

--- a/frontend/src/lib/voiceCommands.ts
+++ b/frontend/src/lib/voiceCommands.ts
@@ -84,3 +84,9 @@ export function executeVoiceCommand(
     message: `Command not recognized: "${transcript}"`,
   };
 }
+
+//For tracking ISS , use the command "track ISS" or "track the ISS"
+//For showing debris , use the command "show debris", "show the debris" or "display debris"
+//For opening collision center , use the command "collision center" or "open collision center"
+//For zooming to India , use the command "zoom to India", "zoom into India" or "show India"
+//For toggling space weather , use the command "space weather" or "toggle space weather"


### PR DESCRIPTION
## **User description**
## Summary

This PR adds voice command support to the globe dashboard, allowing users to control key navigation and globe actions using spoken commands.

### Changes
- Added browser-based speech recognition through a reusable `useSpeechRecognition` hook.
- Added a central voice command handler to recognise supported spoken commands.
- Added voice commands for:
  - Opening the ISS view
  - Showing the debris catalog
  - Opening the Collision Center
  - Zooming to India
  - Toggling Space Weather
- Connected voice commands to the existing React Router navigation and Cesium globe controls.
- Added command execution feedback and automatically clears the displayed transcript after successful command execution.

This improves accessibility and provides a more intuitive hands-free way to interact with the strategic globe dashboard.

## Related Issue

Fixes #139 

## Type of Change

<!-- Select all that apply. -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🚀 Performance improvement
- [x] 🎨 UI/UX enhancement
- [ ] 🔧 Refactoring
- [ ] 🧹 Chore / Maintenance
- [ ] 🔒 Security improvement

## Screenshots / Screen Recordings


https://github.com/user-attachments/assets/1bc2a74f-63bb-4cf8-adec-3b1abe22b497


## Testing Performed

<!-- Describe the tests you performed to verify your changes. -->

- [x] Tested locally
- [x] Tested relevant functionality
- [x] Checked for linting errors
- [x] Checked for TypeScript/build errors
- [x] Tested responsive behaviour (if applicable)

## Breaking Changes

N/A

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] My code follows the project's coding standards and guidelines.
- [x] I have completed testing of my changes.
- [x] I have updated documentation where applicable.
- [x] I have checked that my changes do not introduce unintended regressions.

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [x] `ECSoC26-L1` – Beginner
- [ ] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added speech-driven voice commands (track ISS, view debris, open collision center, zoom to India, toggle space weather) with listening/transcript/error feedback.
  * Enabled URL-based shared bookmark navigation for camera positioning.
  * Improved globe interactions with direct hover tooltips and click-to-select camera navigation.
  * Refreshed the HUD overlay: collision status updates after data loads, refreshed metrics, and a closeable legend panel.

* **Bug Fixes**
  * Improved visualization rebuilding and interaction cleanup for more reliable hover/click behavior and smoother navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds browser speech recognition and connects spoken phrases to dashboard navigation and Cesium camera actions.
- Adds a reusable speech-recognition hook with listening, transcript, and error state.
- Adds phrase matching for ISS, debris, collision center, India, and space-weather commands.
- Expands EarthTwin with voice controls, bookmark UI, shared views, direct object picking, and day/night visualization.

<h3>Confidence Score: 2/5</h3>

This PR is not safe to merge until the stacked bookmark dialogs, false ISS-tracking behavior, and removed keyboard globe controls are fixed.

The current code still mounts two bookmark dialogs under one state flag, labels a flight to fixed zero coordinates as ISS tracking, and replaces the accessible globe interaction system with mouse-only handlers.

**Files Needing Attention:** frontend/src/components/EarthTwin.tsx, frontend/src/lib/voiceCommands.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/EarthTwin.tsx | Integrates voice actions, bookmarks, shared views, direct Cesium picking, and lighting into the globe dashboard. |
| frontend/src/hooks/useSpeechRecognition.ts | Adds lifecycle and state management around the browser SpeechRecognition API. |
| frontend/src/lib/voiceCommands.ts | Maps supported transcript phrases to injected dashboard actions. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User
  participant UI as EarthTwin
  participant Speech as useSpeechRecognition
  participant Commands as executeVoiceCommand
  participant Action as Router / Cesium
  User->>UI: Start voice command
  UI->>Speech: startListening()
  Speech-->>Commands: recognized transcript
  Commands->>Action: invoke matched action
  Action-->>User: navigate or move camera
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix iss command"](https://github.com/7-blocks/kepler/commit/ff59be886a0bc02bcf1b8f81fd1e3fafd6540f68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47668051)</sub>

<!-- /greptile_comment -->


___

## **CodeAnt-AI Description**
Add voice controls and saved views to the orbital globe

### What Changed
- Users can control key globe actions by voice, including viewing the ISS, showing debris, opening the Collision Center, zooming to India, and opening Space Weather.
- The globe now provides listening, transcript, and voice-error feedback, with a clear message when a command is not recognized.
- Users can save the current globe position as a bookmark, restore saved views, search and filter bookmarks, mark favorites, edit or delete them, and share or export saved views.
- Orbital objects now reflect day and night conditions, while selecting an object shows its details and moves the camera to it.
- Shared bookmarks open directly at their saved globe position, and automatic rotation pauses when a saved or voice-selected view is opened.

### Impact
`✅ Hands-free globe navigation`
`✅ Reusable saved orbital views`
`✅ Clearer day/night satellite visibility`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
