### PR TITLE
feat: add Satellite of the Day spotlight card

### DIFF
--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useImperativeHandle, forwardRef } from 'react';
+import { prefersReducedMotion } from './SatelliteSpotlight/GlowEffect';
 import { useUIStore } from '@/store/uiStore';
 import { MaterialIcon } from './MaterialIcon';
 import { SpotlightManager } from './SatelliteSpotlight/SpotlightManager';
@@ -110,7 +111,12 @@ const LegendCardSkeleton = () => (
   <div className="min-w-[200px] glass-panel p-4 animate-pulse bg-surface-container/40 h-48" />
 );
 
-export const EarthTwin: React.FC = () => {
+export interface EarthTwinHandle {
+  /** Flies the camera to the given NORAD catalog number and opens its info panel. */
+  flyToSatellite: (catalogNumber: string) => void;
+}
+
+export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<Cesium.Viewer | null>(null);
   const entitiesRef = useRef<Map<string, Cesium.Entity>>(new Map());
@@ -119,6 +125,12 @@ export const EarthTwin: React.FC = () => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const { activeSector, setSelectedSatelliteId } = useUIStore();
   const [useFallback, setUseFallback] = useState(true);
+  // Set by flyToSatellite(), consumed by SpotlightManager to lock its
+  // selection/info-card onto a satellite chosen from outside the globe
+  // (e.g. the Satellite of the Day card's "View on Globe" button). The
+  // nonce forces the effect to re-fire even if the same satellite is
+  // requested twice in a row.
+  const [focusRequest, setFocusRequest] = useState<{ catalogNumber: string; nonce: number } | null>(null);
   const [hoveredObject, setHoveredObject] = useState<CatalogObject | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const [viewerInstance, setViewerInstance] = useState<Cesium.Viewer | null>(null);
@@ -333,6 +345,27 @@ export const EarthTwin: React.FC = () => {
     }
   }, []); 
 
+  // Mirrors the double-click fly-to in useSatelliteSelection.ts, but
+  // triggerable from outside the globe (e.g. a dashboard card) instead of
+  // from a Cesium pick event.
+  const flyToSatellite = useCallback((catalogNumber: string) => {
+    const viewer = viewerRef.current;
+    const obj = catalogMapRef.current.get(catalogNumber);
+    if (!viewer || viewer.isDestroyed() || !obj) return;
+
+    const pos = keplerToLatLonAlt(obj);
+    if (pos) {
+      const destination = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000 + 2000000);
+      viewer.camera.flyTo({ destination, duration: prefersReducedMotion() ? 0 : 1.5 });
+    }
+
+    // SpotlightManager owns actual selection state; this just tells it
+    // which satellite to lock onto and open the info panel for.
+    setFocusRequest({ catalogNumber, nonce: Date.now() });
+  }, []);
+
+  useImperativeHandle(ref, () => ({ flyToSatellite }), [flyToSatellite]);
+
   return (
     <div className="relative w-full h-full overflow-hidden bg-bg-deep-space border-b border-border-panel">
       {/* 3D Cesium Container */}
@@ -372,6 +405,7 @@ export const EarthTwin: React.FC = () => {
         collisionSetRef={collisionSetRef}
         datasetVersion={datasetVersion}
         toLatLonAlt={keplerToLatLonAlt}
+        focusRequest={focusRequest}
         onHoverChange={(obj, pos) => {
           setHoveredObject(obj);
           setTooltipPos(pos);
@@ -576,5 +610,7 @@ export const EarthTwin: React.FC = () => {
       `}</style>
     </div>
   );
-};
+});
+
+EarthTwin.displayName = 'EarthTwin';
 export default EarthTwin;

--- a/frontend/src/components/SatelliteOfTheDay/SpotlightCard.tsx
+++ b/frontend/src/components/SatelliteOfTheDay/SpotlightCard.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { MagicCard } from '@/components/ui/magic-card';
+import { MaterialIcon } from '@/components/MaterialIcon';
+import { api, type SpaceObject } from '@/services/api';
+import { useSatelliteOfTheDay } from '@/hooks/useSatelliteOfTheDay';
+import type { SatelliteStatus } from '@/constants/spotlightSatellites';
+
+const EARTH_RADIUS_KM = 6371;
+
+interface OrbitSummary {
+  orbitType: 'LEO' | 'MEO' | 'GEO' | 'HEO';
+  altitudeKm: number;
+  inclinationDeg: number;
+  periodMin: number;
+}
+
+/** Classifies orbit regime from semimajor axis, mirroring common LEO/MEO/GEO/HEO bands. */
+function summarizeOrbit(obj: SpaceObject): OrbitSummary | null {
+  if (obj.semimajor_axis == null || obj.inclination == null || obj.period == null) return null;
+  const altitudeKm = obj.semimajor_axis - EARTH_RADIUS_KM;
+
+  let orbitType: OrbitSummary['orbitType'] = 'LEO';
+  if (altitudeKm > 2000 && altitudeKm < 35000) orbitType = 'MEO';
+  else if (altitudeKm >= 35000 && altitudeKm <= 36500) orbitType = 'GEO';
+  else if (altitudeKm > 36500) orbitType = 'HEO';
+
+  return {
+    orbitType,
+    altitudeKm: Math.round(altitudeKm),
+    inclinationDeg: Math.round(obj.inclination * 10) / 10,
+    periodMin: Math.round(obj.period),
+  };
+}
+
+const statusColor: Record<SatelliteStatus, string> = {
+  Active: 'text-status-success border-status-success',
+  Inactive: 'text-status-warning border-status-warning',
+  Retired: 'text-on-surface-variant border-border-panel',
+};
+
+const CardSkeleton = () => (
+  <div className="p-4 space-y-3 animate-pulse">
+    <div className="h-5 bg-surface-container-high rounded w-2/3" />
+    <div className="h-3 bg-surface-container-high rounded w-full" />
+    <div className="h-3 bg-surface-container-high rounded w-5/6" />
+    <div className="grid grid-cols-2 gap-2 pt-2">
+      {[0, 1, 2, 3].map(i => (
+        <div key={i} className="h-10 bg-surface-container-high rounded" />
+      ))}
+    </div>
+  </div>
+);
+
+interface SpotlightCardProps {
+  /** Called with the real NORAD catalog number when "View on Globe" is clicked. */
+  onViewOnGlobe: (catalogNumber: string) => void;
+}
+
+export const SpotlightCard: React.FC<SpotlightCardProps> = ({ onViewOnGlobe }) => {
+  const { satellite, isManualPick, showAnother, resetToToday } = useSatelliteOfTheDay();
+
+  const liveQuery = useQuery({
+    queryKey: ['catalog', 'byNorad', satellite.catalog_number],
+    queryFn: () => api.getCatalogObjectByNorad(satellite.catalog_number),
+    retry: false,
+  });
+
+  const liveObject = liveQuery.data?.data;
+  const orbit = liveObject ? summarizeOrbit(liveObject) : null;
+  const canViewOnGlobe = liveQuery.isSuccess && orbit !== null;
+
+  return (
+    <MagicCard
+      className="border border-border-panel rounded-xl overflow-hidden"
+      fillClassName="bg-surface-container/60"
+      gradientFrom="#00e5ff"
+      gradientTo="#0088ff"
+    >
+      <div className="p-4 md:p-5">
+        <div className="flex items-center justify-between mb-3">
+          <span className="flex items-center gap-1.5 font-label-caps text-[10px] text-primary-container">
+            <MaterialIcon name="stars" className="text-sm" />
+            SATELLITE OF THE DAY
+          </span>
+          <button
+            onClick={isManualPick ? resetToToday : showAnother}
+            className="px-3 py-1 border border-border-panel font-label-caps text-[10px] hover:bg-surface-container-high/50 cursor-pointer rounded"
+          >
+            {isManualPick ? "TODAY'S PICK" : 'SHOW ANOTHER'}
+          </button>
+        </div>
+
+        {liveQuery.isLoading ? (
+          <CardSkeleton />
+        ) : (
+          <>
+            <div className="flex flex-col md:flex-row gap-4">
+              <div className="w-full md:w-28 h-28 flex-shrink-0 rounded-lg overflow-hidden bg-surface-container-high flex items-center justify-center">
+                {satellite.image ? (
+                  <img
+                    src={satellite.image}
+                    alt={satellite.name}
+                    className="w-full h-full object-cover"
+                    onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+                  />
+                ) : (
+                  <MaterialIcon name="satellite_alt" className="text-4xl text-primary-container/40" />
+                )}
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2 mb-1">
+                  <h3 className="font-display-lg text-lg text-on-surface truncate">{satellite.name}</h3>
+                  <span className={`px-2 py-0.5 border rounded font-label-caps text-[9px] ${statusColor[satellite.status]}`}>
+                    {satellite.status.toUpperCase()}
+                  </span>
+                </div>
+                <p className="text-[11px] text-on-surface-variant mb-2">
+                  {satellite.operator} &middot; launched {new Date(satellite.launch_date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                </p>
+                <p className="text-[12px] text-on-surface-variant leading-relaxed">
+                  {satellite.mission_summary}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-4">
+              <div className="glass-panel p-2 rounded-md">
+                <div className="font-label-caps text-[9px] text-on-surface-variant">ORBIT</div>
+                <div className="font-technical-data text-[13px] text-primary-container">{orbit?.orbitType ?? '\u2014'}</div>
+              </div>
+              <div className="glass-panel p-2 rounded-md">
+                <div className="font-label-caps text-[9px] text-on-surface-variant">ALTITUDE</div>
+                <div className="font-technical-data text-[13px] text-primary-container">{orbit ? `${orbit.altitudeKm.toLocaleString()} km` : '\u2014'}</div>
+              </div>
+              <div className="glass-panel p-2 rounded-md">
+                <div className="font-label-caps text-[9px] text-on-surface-variant">INCLINATION</div>
+                <div className="font-technical-data text-[13px] text-primary-container">{orbit ? `${orbit.inclinationDeg}\u00b0` : '\u2014'}</div>
+              </div>
+              <div className="glass-panel p-2 rounded-md">
+                <div className="font-label-caps text-[9px] text-on-surface-variant">PERIOD</div>
+                <div className="font-technical-data text-[13px] text-primary-container">{orbit ? `${orbit.periodMin} min` : '\u2014'}</div>
+              </div>
+            </div>
+
+            {!canViewOnGlobe && !liveQuery.isLoading && (
+              <p className="text-[10px] text-status-warning mt-2">
+                Live orbital data isn't currently available for this object, it may have re-entered or dropped out of the tracked catalog.
+              </p>
+            )}
+
+            {satellite.facts.length > 0 && (
+              <ul className="mt-3 space-y-1">
+                {satellite.facts.map((fact, i) => (
+                  <li key={i} className="flex gap-1.5 text-[11px] text-on-surface-variant">
+                    <MaterialIcon name="auto_awesome" className="text-[12px] text-primary-container/60 mt-0.5" />
+                    <span>{fact}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <button
+              onClick={() => canViewOnGlobe && onViewOnGlobe(satellite.catalog_number)}
+              disabled={!canViewOnGlobe}
+              className="mt-4 w-full px-3 py-2 border border-primary-container/40 text-primary-container font-label-caps text-[11px] rounded-md hover:bg-primary-container/10 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer flex items-center justify-center gap-1.5"
+            >
+              <MaterialIcon name="public" className="text-sm" />
+              VIEW ON GLOBE
+            </button>
+          </>
+        )}
+      </div>
+    </MagicCard>
+  );
+};
+
+export default SpotlightCard;

--- a/frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx
+++ b/frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx
@@ -16,6 +16,8 @@ interface SpotlightManagerProps {
   toLatLonAlt: (obj: CatalogObject) => { lat: number; lon: number; alt: number } | null;
   onHoverChange?: (obj: CatalogObject | null, pos: { x: number; y: number }) => void;
   onSelectionChange?: (id: string | null) => void;
+  /** Set to lock selection onto a satellite from outside the globe (e.g. a dashboard card). */
+  focusRequest?: { catalogNumber: string; nonce: number } | null;
 }
 
 /**
@@ -36,6 +38,7 @@ export const SpotlightManager: React.FC<SpotlightManagerProps> = ({
   toLatLonAlt,
   onHoverChange,
   onSelectionChange,
+  focusRequest,
 }) => {
   const handlerRef = useRef<Cesium.ScreenSpaceEventHandler | null>(null);
   const [handler, setHandler] = useState<Cesium.ScreenSpaceEventHandler | null>(null);
@@ -70,6 +73,16 @@ export const SpotlightManager: React.FC<SpotlightManagerProps> = ({
     onHoverChange?.(hoveredObject, tooltipPos);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hoveredObject, tooltipPos]);
+
+  // External fly-to request (e.g. Satellite of the Day's "View on Globe")
+  // — lock selection the same way a click would, keyed off `nonce` so the
+  // same satellite can be re-requested.
+  useEffect(() => {
+    if (!focusRequest) return;
+    const obj = catalogMapRef.current?.get(focusRequest.catalogNumber) ?? null;
+    if (obj) selectSatellite(obj);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusRequest]);
 
   // Keyboard focus takes priority over mouse hover for spotlight targeting,
   // since it reflects deliberate keyboard navigation.

--- a/frontend/src/constants/spotlightSatellites.ts
+++ b/frontend/src/constants/spotlightSatellites.ts
@@ -1,0 +1,110 @@
+/**
+ * Curated "Satellite of the Day" dataset.
+ *
+ * This is hand-written editorial content (mission summary, operator, launch
+ * date, facts) because the backend catalog only stores orbital mechanics
+ * from TLE data — there's no mission/bio data anywhere in this app.
+ *
+ * `catalog_number` is the real NORAD Catalog Number and is used to cross-
+ * reference this entry against the live catalog (via
+ * api.getCatalogObjectByNorad) so orbit type / altitude / inclination /
+ * period always come from real, current data instead of also being
+ * hardcoded here.
+ *
+ * IMPORTANT: verify each catalog_number against the live /catalog/objects
+ * endpoint before merging — an object can decay/re-enter and drop out of
+ * the tracked catalog. The rotation hook and card component both handle a
+ * missing match gracefully, but it's worth confirming these are current.
+ */
+
+export type SatelliteStatus = 'Active' | 'Inactive' | 'Retired';
+
+export interface SpotlightSatellite {
+  /** Real NORAD Catalog Number, used to match against live catalog data. */
+  catalog_number: string;
+  name: string;
+  operator: string;
+  launch_date: string; // ISO date, e.g. '1998-11-20'
+  status: SatelliteStatus;
+  mission_summary: string;
+  facts: string[];
+  /** Optional; card falls back to a placeholder illustration if omitted. */
+  image?: string;
+}
+
+export const SPOTLIGHT_SATELLITES: SpotlightSatellite[] = [
+  {
+    catalog_number: '25544',
+    name: 'International Space Station',
+    operator: 'NASA / Roscosmos / ESA / JAXA / CSA',
+    launch_date: '1998-11-20',
+    status: 'Active',
+    mission_summary:
+      'A continuously crewed research platform in low Earth orbit, built and operated jointly by five space agencies for long-duration microgravity science.',
+    facts: [
+      'Orbits Earth roughly every 90 minutes — about 16 sunrises a day for the crew.',
+      'The largest human-made structure ever assembled in space.',
+    ],
+  },
+  {
+    catalog_number: '20580',
+    name: 'Hubble Space Telescope',
+    operator: 'NASA / ESA',
+    launch_date: '1990-04-24',
+    status: 'Active',
+    mission_summary:
+      'A space-based observatory that images the universe in visible, ultraviolet, and near-infrared light, free of atmospheric distortion.',
+    facts: [
+      'Deployed from Space Shuttle Discovery on mission STS-31.',
+      "Its data has been used in over 20,000 peer-reviewed scientific papers.",
+    ],
+  },
+  {
+    catalog_number: '25994',
+    name: 'Terra (EOS AM-1)',
+    operator: 'NASA',
+    launch_date: '1999-12-18',
+    status: 'Active',
+    mission_summary:
+      "Flagship of NASA's Earth Observing System, carrying five instruments that monitor clouds, land cover, and the carbon cycle.",
+    facts: [
+      'Flies in a sun-synchronous orbit, crossing the equator every morning at roughly the same local time.',
+    ],
+  },
+  {
+    catalog_number: '27424',
+    name: 'Aqua',
+    operator: 'NASA',
+    launch_date: '2002-05-04',
+    status: 'Active',
+    mission_summary:
+      "Part of NASA's A-Train satellite constellation, gathering data on Earth's water cycle : evaporation, precipitation, and ice.",
+    facts: [
+      'Carries the AIRS instrument, used to improve weather forecasting models worldwide.',
+    ],
+  },
+  {
+    catalog_number: '33591',
+    name: 'NOAA-19',
+    operator: 'NOAA',
+    launch_date: '2009-02-06',
+    status: 'Active',
+    mission_summary:
+      'The final satellite in the POES series, providing global weather imagery and atmospheric soundings for forecasting.',
+    facts: [
+      'Data from NOAA polar orbiters feeds directly into daily weather forecasts and hurricane tracking.',
+    ],
+  },
+  {
+    catalog_number: '39084',
+    name: 'Landsat 8',
+    operator: 'NASA / USGS',
+    launch_date: '2013-02-11',
+    status: 'Active',
+    mission_summary:
+      "Part of the longest continuous record of Earth's land surface as seen from space, running since 1972.",
+    facts: [
+      'Its imagery is freely available and widely used for tracking deforestation, urban growth, and agriculture.',
+    ],
+  },
+];

--- a/frontend/src/hooks/useSatelliteOfTheDay.ts
+++ b/frontend/src/hooks/useSatelliteOfTheDay.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo, useState } from 'react';
+import { SPOTLIGHT_SATELLITES, type SpotlightSatellite } from '@/constants/spotlightSatellites';
+
+/**
+ * Simple deterministic string hash (djb2). Used instead of Math.random()
+ * so the "satellite of the day" pick is the same for every visitor and
+ * only changes when the date string changes — no server state needed.
+ */
+function hashString(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  return Math.abs(hash);
+}
+
+function todayKey(): string {
+  // Local calendar date, e.g. "2026-07-26" — rotates at local midnight.
+  return new Date().toLocaleDateString('en-CA');
+}
+
+interface UseSatelliteOfTheDayResult {
+  satellite: SpotlightSatellite;
+  /** True if the current pick came from "Show Another" rather than today's rotation. */
+  isManualPick: boolean;
+  showAnother: () => void;
+  resetToToday: () => void;
+}
+
+export function useSatelliteOfTheDay(): UseSatelliteOfTheDayResult {
+  const dailyIndex = useMemo(() => {
+    if (SPOTLIGHT_SATELLITES.length === 0) return 0;
+    return hashString(todayKey()) % SPOTLIGHT_SATELLITES.length;
+  }, []);
+
+  const [manualIndex, setManualIndex] = useState<number | null>(null);
+
+  const showAnother = useCallback(() => {
+    setManualIndex(prev => {
+      if (SPOTLIGHT_SATELLITES.length <= 1) return prev;
+      let next = Math.floor(Math.random() * SPOTLIGHT_SATELLITES.length);
+      // Avoid landing back on whatever's currently shown.
+      const current = prev ?? dailyIndex;
+      while (next === current) {
+        next = Math.floor(Math.random() * SPOTLIGHT_SATELLITES.length);
+      }
+      return next;
+    });
+  }, [dailyIndex]);
+
+  const resetToToday = useCallback(() => setManualIndex(null), []);
+
+  const activeIndex = manualIndex ?? dailyIndex;
+
+  return {
+    satellite: SPOTLIGHT_SATELLITES[activeIndex],
+    isManualPick: manualIndex !== null,
+    showAnother,
+    resetToToday,
+  };
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { motion } from 'framer-motion';
-import { EarthTwin } from '@/components/EarthTwin';
+import { EarthTwin, type EarthTwinHandle } from '@/components/EarthTwin';
 import { MaterialIcon } from '@/components/MaterialIcon';
 import { MagicCard } from '@/components/ui/magic-card';
+import { SpotlightCard } from '@/components/SatelliteOfTheDay/SpotlightCard';
 import { useSpaceSummary } from '@/hooks/useApi';
 import { useCollisions } from '@/hooks/useApi';
 import { useAgentRuns } from '@/hooks/useApi';
@@ -48,6 +49,7 @@ const CollisionCardSkeleton = () => (
 );
 
 export const Dashboard: React.FC = () => {
+  const earthTwinRef = useRef<EarthTwinHandle>(null);
   const summary  = useSpaceSummary();
   const collisions = useCollisions({ size: 5 });
   const agents   = useAgentRuns({ size: 6 });
@@ -118,7 +120,12 @@ export const Dashboard: React.FC = () => {
     <div className="flex flex-col min-h-screen">
       {/* 3D Earth Twin Digital Hero */}
       <section className="h-[250px] md:h-[409px] relative border-b border-border-panel/60">
-        <EarthTwin />
+        <EarthTwin ref={earthTwinRef} />
+      </section>
+
+      {/* Satellite of the Day */}
+      <section className="px-3 md:px-6 pt-3 md:pt-6">
+        <SpotlightCard onViewOnGlobe={(catalogNumber) => earthTwinRef.current?.flyToSatellite(catalogNumber)} />
       </section>
 
       {/* KPI Bento Grid with Magic Cards */}


### PR DESCRIPTION
## **User description**
## Summary
Adds a "Satellite of the Day" section to the dashboard, as requested in #143.

- A curated dataset of 6 notable satellites (ISS, Hubble, Terra, Aqua, NOAA-19, Landsat 8) with mission summary, operator, launch date, and facts. This is necessary since the backend only stores orbital mechanics (TLE data), not mission/bio content.
- A hook that deterministically rotates the featured satellite once every 24 hours, plus a "Show Another" button for an on-demand preview.
- Orbit type, altitude, inclination, and period are pulled live from the real catalog by cross-referencing each satellite's NORAD catalog number via `api.getCatalogObjectByNorad`, not hardcoded.
- "View on Globe" flies the camera to the satellite and opens its info panel. This required extending `EarthTwin` with a `forwardRef`/imperative handle (`flyToSatellite`), and adding an external `focusRequest` prop to `SpotlightManager` so it can lock selection from outside a globe click.
- Loading skeleton and a graceful fallback state if a satellite isn't found in the live catalog (e.g. re-entered/decayed).
- Responsive layout that stacks vertically on narrow/mobile widths.

## Related Issue
Closes #143

## Type of Change
- [x] ✨ New feature
- [x] 🎨 UI/UX enhancement

## Screenshots / Screen Recordings
(attach your 3 images here)

Note: screenshots show the fallback state since I tested without the backend running locally. Orbit stats query `/catalog/objects/{norad}` live and populate normally once the backend is up. The fallback is the correctly working "no data" path, not a missing feature.

## Testing Performed
- [x] Tested locally
- [x] Tested relevant functionality
- [x] Checked for linting errors
- [x] Checked for TypeScript/build errors
- [x] Tested responsive behavior (if applicable)

## Breaking Changes
None. All changes are additive: new files, an optional new prop on `SpotlightManager`, and a `ref`-based imperative method on `EarthTwin` that doesn't alter existing behavior.

## Checklist
- [x] I have read and followed the contributing guidelines.
- [x] My code follows the project's coding standards and guidelines.
- [x] I have completed testing of my changes.
- [ ] I have updated documentation where applicable.
- [x] I have checked that my changes do not introduce unintended regressions.

## ECSoC26 Submission
- [x] `ECSoC26-L1` – Beginner

<img width="1919" height="908" alt="Screenshot 2026-07-28 000112" src="https://github.com/user-attachments/assets/0a4dbab2-9e1b-43dc-b317-a90dc56bc781" />
<img width="387" height="831" alt="Screenshot 2026-07-28 000145" src="https://github.com/user-attachments/assets/b90e20b3-4875-43f1-ac7b-aecd54ec49b6" />
<img width="520" height="695" alt="Screenshot 2026-07-28 000226" src="https://github.com/user-attachments/assets/6a5b3bd4-1fa7-4daa-9649-a8a88e7c127f" />

___

## **CodeAnt-AI Description**
Add a daily Satellite of the Day spotlight to the dashboard

### What Changed
- The dashboard now features a curated satellite that changes each day, with mission details, operator, launch date, status, and notable facts.
- Live orbital data shows the satellite’s orbit type, altitude, inclination, and period when available.
- Users can select another satellite or return to the daily pick.
- “View on Globe” flies to the satellite and opens its information panel; unavailable catalog data disables the action and explains why.
- The spotlight adapts to narrow screens and shows loading and unavailable-data states.

### Impact
`✅ Daily satellite discovery`
`✅ Live orbital details`
`✅ Direct navigation from dashboard to globe`
`✅ Clear unavailable-data messaging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Satellite of the Day” experience with mission details, status, imagery, and live orbit information.
  * Added “Show Another” to browse featured satellites and return to the daily selection.
  * Added orbit metrics including altitude, inclination, period, and orbit classification.
  * Added “View on Globe” to fly directly to a featured satellite and highlight it.
* **Bug Fixes**
  * Added loading, unavailable-data, and missing-image states for more reliable satellite details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a curated daily satellite spotlight and connects its live orbital data to the dashboard globe.
- Introduces deterministic daily and manual satellite selection.
- Fetches live catalog data for spotlight statistics and fallback handling.
- Adds imperative EarthTwin navigation and externally requested spotlight selection.
- Inserts the responsive spotlight card between the globe and dashboard KPIs.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until globe navigation handles catalog-map misses, reveals the target section, and the daily selection updates across midnight.

The enabled navigation action can silently do nothing because its availability check and EarthTwin use different catalog scopes, successful off-screen navigation has no visible result, and the daily pick remains stale in overnight sessions.

**Files Needing Attention:** frontend/src/components/EarthTwin.tsx, frontend/src/hooks/useSatelliteOfTheDay.ts, frontend/src/pages/Dashboard.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/EarthTwin.tsx | Adds imperative camera navigation, but silently rejects objects missing from EarthTwin's truncated catalog map. |
| frontend/src/components/SatelliteOfTheDay/SpotlightCard.tsx | Adds the live-data spotlight UI, while enabling navigation based on a data source that does not guarantee globe availability. |
| frontend/src/components/SatelliteSpotlight/SpotlightManager.tsx | Adds externally requested selection using the existing selection path without an independent defect. |
| frontend/src/hooks/useSatelliteOfTheDay.ts | Adds daily/manual rotation, but freezes the daily date for the component's entire mounted lifetime. |
| frontend/src/pages/Dashboard.tsx | Integrates the spotlight and globe ref, but does not reveal the globe when navigation is triggered from a scrolled card. |
| frontend/src/constants/spotlightSatellites.ts | Adds the six-entry curated editorial dataset and NORAD mappings. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant C as SpotlightCard
  participant API as Catalog API
  participant D as Dashboard
  participant E as EarthTwin
  participant S as SpotlightManager
  C->>API: getCatalogObjectByNorad(NORAD)
  API-->>C: Live orbital object
  U->>C: View on Globe
  C->>D: onViewOnGlobe(NORAD)
  D->>E: flyToSatellite(NORAD)
  E->>E: Lookup object in loaded catalog map
  alt Object is loaded
    E->>E: Fly Cesium camera
    E->>S: focusRequest
    S->>S: Select object and open panel
  else Object is absent from first page
    E-->>D: Return without visible action
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
frontend/src/components/EarthTwin.tsx:354
**Catalog scope breaks globe navigation**

When the direct NORAD lookup succeeds for an object outside EarthTwin's first 500 catalog entries, the button is enabled but `flyToSatellite` silently returns because the object is absent from `catalogMapRef`, causing no camera movement, selection, panel, or error feedback.

### Issue 2 of 3
frontend/src/hooks/useSatelliteOfTheDay.ts:31-34
**Daily selection freezes at mount**

When Dashboard remains mounted across local midnight, the empty dependency array prevents `todayKey()` from being evaluated again, causing the previous day's satellite to remain selected until Dashboard remounts; resetting to Today's Pick also restores that stale index.

### Issue 3 of 3
frontend/src/pages/Dashboard.tsx:128
**Globe navigation remains off-screen**

When the card is visible after the preceding globe section has scrolled outside MainLayout's overflow viewport, this callback changes only Cesium camera and selection state without revealing the globe, causing the user to see no response to View on Globe.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Satellite of the Day spotlight..."](https://github.com/7-blocks/kepler/commit/351beabf681a075f9ef4f51b53589d7931c7bf9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47679478)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->