### PR TITLE
Add rocket launch countdown widget to dashboard

### DIFF
--- a/frontend/src/components/RocketLaunchCountdown/RocketLaunchCountdown.tsx
+++ b/frontend/src/components/RocketLaunchCountdown/RocketLaunchCountdown.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from "react";
+import { MagicCard } from "@/components/ui/magic-card";
+import { MaterialIcon } from "@/components/MaterialIcon";
+import { rocketLaunches } from "@/constants/rocketLaunches";
+
+const getTimeRemaining = (launchTime: string) => {
+  const diff = new Date(launchTime).getTime() - Date.now();
+
+  if (diff <= 0) {
+    return "LIFTOFF 🚀";
+  }
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((diff / (1000 * 60)) % 60);
+  const seconds = Math.floor((diff / 1000) % 60);
+
+  return `T-${days}d ${hours}h ${minutes}m ${seconds}s`;
+};
+
+const statusBadge = (status: string) => {
+  switch (status) {
+    case "Upcoming":
+      return "bg-green-500/20 text-green-400";
+    case "Delayed":
+      return "bg-yellow-500/20 text-yellow-400";
+    case "Scrubbed":
+      return "bg-red-500/20 text-red-400";
+    case "Completed":
+      return "bg-blue-500/20 text-blue-400";
+    default:
+      return "bg-primary/20 text-primary";
+  }
+};
+
+const RocketLaunchCountdown: React.FC = () => {
+    const [, setTick] = useState<number>(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTick((v) => v + 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <MagicCard
+      mode="orb"
+      glowFrom="#FF6B35"
+      glowTo="#FFD166"
+      glowOpacity={0.25}
+      className="rounded-xl border border-white/10"
+      fillClassName="bg-[#0A0F1A]"
+    >
+      <div className="p-5">
+        <div className="flex items-center gap-2 mb-5">
+          <MaterialIcon
+            name="rocket_launch"
+            className="text-primary-container text-lg"
+          />
+
+          <h2 className="font-label-caps text-primary uppercase tracking-wider">
+            Upcoming Rocket Launches
+          </h2>
+        </div>
+
+        <div className="space-y-4">
+          {rocketLaunches.map((launch) => (
+            <div
+              key={launch.id}
+              className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 border-b border-white/10 pb-4 last:border-none"
+            >
+              {/* Left */}
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-xl">{launch.missionPatch}</span>
+
+                  <p className="font-semibold text-white">
+                    {launch.mission}
+                  </p>
+                </div>
+
+                <p className="text-xs text-primary/60">
+                  {launch.provider} • {launch.vehicle}
+                </p>
+
+                <p className="text-xs text-primary/40">
+                  {launch.launchSite}
+                </p>
+
+                <p className="text-xs text-primary/50">
+                  Target Orbit: {launch.targetOrbit}
+                </p>
+              </div>
+
+              {/* Right */}
+              <div className="text-right space-y-2 md:min-w-[220px]">
+                <p className="font-mono text-primary-container text-lg font-bold">
+                  {getTimeRemaining(launch.launchTime)}
+                </p>
+
+                <p className="text-xs text-primary/50">
+                  {new Date(launch.launchTime).toLocaleString("en-US", {
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    timeZone: "UTC",
+                    timeZoneName: "short",
+                  })}
+                </p>
+
+                <span
+                  className={`inline-block rounded-full px-2 py-1 text-[10px] font-semibold ${statusBadge(
+                    launch.status
+                  )}`}
+                >
+                  {launch.status}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </MagicCard>
+  );
+};
+
+export default RocketLaunchCountdown;

--- a/frontend/src/constants/rocketLaunches.ts
+++ b/frontend/src/constants/rocketLaunches.ts
@@ -1,0 +1,47 @@
+export interface RocketLaunch {
+  id: number;
+  mission: string;
+  vehicle: string;
+  provider: string;
+  launchSite: string;
+  targetOrbit: string;
+  launchTime: string;
+  status: "Upcoming" | "Delayed" | "Scrubbed" | "Completed";
+  missionPatch: string;
+}
+
+export const rocketLaunches: RocketLaunch[] = [
+  {
+    id: 1,
+    mission: "Artemis II",
+    vehicle: "SLS Block 1",
+    provider: "NASA",
+    launchSite: "Kennedy Space Center LC-39B",
+    targetOrbit: "Lunar Flyby",
+    launchTime: "2026-12-15T14:30:00Z",
+    status: "Upcoming",
+    missionPatch: "🚀",
+  },
+  {
+    id: 2,
+    mission: "Starlink Group 18-5",
+    vehicle: "Falcon 9",
+    provider: "SpaceX",
+    launchSite: "Cape Canaveral SLC-40",
+    targetOrbit: "Low Earth Orbit",
+    launchTime: "2026-09-12T09:45:00Z",
+    status: "Upcoming",
+    missionPatch: "🛰️",
+  },
+  {
+    id: 3,
+    mission: "New Glenn Demo",
+    vehicle: "New Glenn",
+    provider: "Blue Origin",
+    launchSite: "Cape Canaveral LC-36",
+    targetOrbit: "Geostationary Transfer Orbit",
+    launchTime: "2026-10-01T18:00:00Z",
+    status: "Delayed",
+    missionPatch: "🌍",
+  },
+];

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { MaterialIcon } from '@/components/MaterialIcon';
 import { MagicCard } from '@/components/ui/magic-card';
 import { SpotlightCard } from '@/components/SatelliteOfTheDay/SpotlightCard';
 import { useSpaceSummary } from '@/hooks/useApi';
+import RocketLaunchCountdown from "@/components/RocketLaunchCountdown/RocketLaunchCountdown";
 import { useCollisions } from '@/hooks/useApi';
 import { useAgentRuns } from '@/hooks/useApi';
 import { useWeatherStatus } from '@/hooks/useApi';
@@ -173,6 +174,10 @@ export const Dashboard: React.FC = () => {
             </motion.div>
           ))
         }
+      </section>
+
+      <section className="px-3 md:px-6 pb-6">
+        <RocketLaunchCountdown />
       </section>
 
       {/* Bottom Timeline & Reasoning Stream */}


### PR DESCRIPTION
## **User description**
## Fixes #155 
<img width="1600" height="866" alt="ss1" src="https://github.com/user-attachments/assets/896018e8-79a8-42e5-be32-e098601cde26" />
<img width="1600" height="866" alt="ss2" src="https://github.com/user-attachments/assets/358e7ce9-3fea-4759-8d93-96d5dfa514c4" />

## Summary

This PR adds a **Rocket Launch Countdown Widget** to the dashboard, providing users with a real-time overview of upcoming space missions and their countdowns.

## What was needed

The dashboard did not include a dedicated widget for tracking upcoming rocket launches. The issue requested a responsive countdown widget that displays essential mission information while updating countdown timers in real time.

## What I implemented

- Added a reusable **RocketLaunchCountdown** component.
- Created a separate **rocketLaunches.ts** file to store launch data.
- Integrated the widget into the Dashboard below the KPI section.
- Implemented a live countdown timer that updates every second.
- Displayed:
  - Mission patch
  - Mission name
  - Launch provider
  - Launch vehicle
  - Launch site
  - Target orbit
  - Scheduled launch date & time (UTC)
  - Launch status with colored badges
- Designed the widget using the existing **MagicCard** component to match the current dashboard UI.
- Ensured the layout is responsive for different screen sizes.

## Testing

- ✅ Verified live countdown updates.
- ✅ Verified dashboard integration.
- ✅ Verified responsive layout.
- ✅ `npm run build` passes successfully.

## Screenshots

*(Attached below as requested.)*





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard section displaying upcoming rocket launches.
  * View mission details, launch providers, locations, orbits, scheduled UTC times, and status badges.
  * Follow a live countdown that updates every second and displays “LIFTOFF 🚀” after launch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->