### PR TITLE
Add reusable MouseParallax component to Hero for layered visual depth

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -5,6 +5,7 @@ import { Globe } from "@/components/ui/globe";
 import { OrbitSatellites } from "@/components/ui/OrbitSatellites";
 import { ShimmerButton } from "@/components/ui/shimmer-button";
 import { Link } from "react-router-dom";
+import { MouseParallax } from "./MouseParallax";
 
 const TELEMETRY = [
   { label: "OBJECTS TRACKED", value: "34,900+" },
@@ -25,16 +26,23 @@ const fadeUp = {
 export function Hero() {
   return (
     <section className="relative flex min-h-screen w-full items-center overflow-hidden bg-[radial-gradient(120%_90%_at_50%_10%,#0B111F_0%,#05070C_60%)] font-[Inter]">
-      <Particles className="absolute inset-0" quantity={220} />
+      <MouseParallax className="absolute inset-0" strength={20}>
+        <Particles  quantity={220} />
+      </MouseParallax>
+
+      
       <div
         className="absolute left-1/2 top-[32%] h-[240px] w-[240px] max-w-[85vw] -translate-x-1/2 -translate-y-1/2 opacity-40
                    sm:left-auto sm:right-[3%] sm:top-1/2 sm:h-[380px] sm:w-[380px] sm:translate-x-0 sm:-translate-y-1/2 sm:opacity-70
                    lg:right-[5%] lg:h-[520px] lg:w-[520px] lg:opacity-90"
       >
-        <OrbitSatellites />
-        <div className="absolute inset-0 flex items-center justify-center">
+        <MouseParallax strength={10}>
+          <OrbitSatellites />
+        </MouseParallax>
+
+        <MouseParallax strength={20} className="absolute inset-0 flex items-center justify-center">
           <Globe className="h-max-[480px] w-max-[480px]" />
-        </div>
+        </MouseParallax>
       </div>
 
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,#05070C_0%,rgba(5,7,12,0.85)_38%,rgba(5,7,12,0.25)_62%,transparent_85%)] sm:bg-[linear-gradient(90deg,#05070C_0%,rgba(5,7,12,0.85)_38%,rgba(5,7,12,0.25)_62%,transparent_85%)]" />

--- a/frontend/src/components/MouseParallax.tsx
+++ b/frontend/src/components/MouseParallax.tsx
@@ -1,0 +1,59 @@
+import {useRef, type ReactNode} from "react";
+import {motion, useMotionValue, useSpring} from "framer-motion"
+
+interface MouseParallaxProps {
+    children: ReactNode;
+    strength?: number;
+    className?: string;
+    springConfig?: {
+      stiffness?: number;
+      damping?: number;
+      mass?: number;
+    };
+  }
+
+export function MouseParallax({
+    children,
+    strength = 20,
+    className="",
+    springConfig = {stiffness: 150, damping: 15, mass: 0.1},
+}: MouseParallaxProps) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    const x = useMotionValue(0);
+    const y = useMotionValue(0);
+
+    const springX = useSpring(x, springConfig);
+    const springY = useSpring(y, springConfig);
+
+    const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+        const rect = ref.current?.getBoundingClientRect();
+        if (!rect) return;
+
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+
+        const offsetX = (e.clientX - centerX) / (rect.width / 2);
+        const offsetY = (e.clientY - centerY) / (rect.height / 2);
+
+        x.set(offsetX * strength);
+        y.set(offsetY * strength);
+    };
+
+    const handleMouseLeave = () => {
+        x.set(0);
+        y.set(0);
+    };
+
+    return (
+        <motion.div
+          ref={ref}
+          className={className}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+          style={{x: springX, y: springY}}
+        >
+            {children}
+        </motion.div>
+    )
+}


### PR DESCRIPTION
## **User description**
## Summary

- Adds a reusable `MouseParallax` component that tracks cursor position relative to its container and applies spring-smoothed X/Y translation via Framer Motion.
- Supports configurable `strength`, `className`, and spring physics (`stiffness`, `damping`, `mass`) so layers can move at different depths.
- Integrates layered parallax into the Hero section: particles (`strength={20}`), orbit satellites (`strength={10}`), and globe (`strength={20}`) for a more immersive orbital feel.
- Resets motion to center on mouse leave for a clean idle state.

## Related Issue

#152 

## Type of Change

<!-- Select all that apply. -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🚀 Performance improvement
- [x] 🎨 UI/UX enhancement
- [ ] 🔧 Refactoring
- [ ] 🧹 Chore / Maintenance
- [ ] 🔒 Security improvement

## Screenshots / Screen Recordings


https://github.com/user-attachments/assets/72c04c24-44a0-457e-9d04-d18536b03390

## Testing Performed

<!-- Describe the tests you performed to verify your changes. -->

- [x] Tested locally
- [x] Tested relevant functionality
- [x] Checked for linting errors
- [x] Checked for TypeScript/build errors
- [x] Tested responsive behavior (if applicable)

Verified that Hero layers follow the cursor with spring easing, different strengths produce distinct depth, and motion resets when the pointer leaves the parallax region.

## Breaking Changes

None.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] My code follows the project's coding standards and guidelines.
- [x] I have completed testing of my changes.
- [ ] I have updated documentation where applicable.
- [x] I have checked that my changes do not introduce unintended regressions.

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [ ] `ECSoC26-L1` – Beginner
- [x] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced


___

## **CodeAnt-AI Description**
Add cursor-driven layered motion to the Hero visual

### What Changed
- Hero background particles, satellites, and globe now shift in response to the cursor
- Each visual layer moves at a different strength to create a depth effect
- Motion eases smoothly and returns to the centered position when the cursor leaves
- The cursor motion behavior is reusable for other visual elements

### Impact
`✅ More immersive Hero visuals`
`✅ Clearer layered depth`
`✅ Smooth reset when leaving the Hero`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth mouse-responsive parallax effects to hero background elements, including particles, satellites, and the globe.
  * Added configurable motion behavior for interactive visual elements.

* **Enhancements**
  * Background layers now move independently and reset smoothly when the pointer leaves the area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->