### PR TITLE
Feat/interactive orbit layer manager

### DIFF
--- a/backend/api/v1/endpoints/catalog.py
+++ b/backend/api/v1/endpoints/catalog.py
@@ -31,9 +31,46 @@ def _validate_group(group: str) -> None:
         )
 
 
+def _angles_from_tle(tle_line2: Optional[str]) -> tuple[Optional[float], Optional[float], Optional[float]]:
+    """Extract RAAN, arg of perigee, and mean anomaly (degrees) from TLE line 2.
+
+    Satellite / Debris rows often store TLEs but leave the dedicated angle
+    columns empty, and the globe placer needs those angles to plot points.
+    """
+    if not tle_line2:
+        return None, None, None
+    try:
+        line = tle_line2.rstrip("\n\r")
+        # NORAD fixed-width columns (0-indexed): RAAN 17:25, ArgP 34:42, MA 43:51
+        if len(line) >= 51 and line[17:25].strip() and line[34:42].strip() and line[43:51].strip():
+            return float(line[17:25]), float(line[34:42]), float(line[43:51])
+        parts = line.split()
+        # 2 <satnum> <incl> <raan> <ecc> <argp> <ma> <n> ...
+        if len(parts) >= 7:
+            return float(parts[3]), float(parts[5]), float(parts[6])
+    except (ValueError, IndexError):
+        pass
+    return None, None, None
+
+
+def _orbital_angles(
+    tle_line2: Optional[str],
+    space_object=None,
+) -> tuple[Optional[float], Optional[float], Optional[float]]:
+    if space_object is not None:
+        if (
+            space_object.raan is not None
+            and space_object.arg_of_perigee is not None
+            and space_object.mean_anomaly is not None
+        ):
+            return space_object.raan, space_object.arg_of_perigee, space_object.mean_anomaly
+    return _angles_from_tle(tle_line2)
+
+
 def _serialize_sat(sat: Satellite) -> Dict[str, Any]:
     epoch   = sat.epoch
     updated = sat.updatedAt
+    raan, arg_of_perigee, mean_anomaly = _orbital_angles(sat.tle_line2, sat.space_object_rel)
     return {
         "id":             str(sat.id),
         "name":           sat.objectName or "",
@@ -44,9 +81,9 @@ def _serialize_sat(sat: Satellite) -> Dict[str, Any]:
         "inclination":    sat.inclination,
         "eccentricity":   sat.eccentricity,
         "semimajor_axis": sat.semimajor_axis,
-        "raan":           None,
-        "arg_of_perigee": None,
-        "mean_anomaly":   None,
+        "raan":           raan,
+        "arg_of_perigee": arg_of_perigee,
+        "mean_anomaly":   mean_anomaly,
         "mean_motion":    sat.meanMotion,
         "period":         sat.period,
         "has_tle":        bool(sat.tle_line1 and sat.tle_line2),
@@ -56,6 +93,7 @@ def _serialize_sat(sat: Satellite) -> Dict[str, Any]:
 
 def _serialize_debris(deb: Debris) -> Dict[str, Any]:
     epoch = deb.epoch
+    raan, arg_of_perigee, mean_anomaly = _orbital_angles(deb.tle_line2, deb.space_object_rel)
     return {
         "id":             str(deb.id),
         "name":           deb.objectName or "",
@@ -66,9 +104,9 @@ def _serialize_debris(deb: Debris) -> Dict[str, Any]:
         "inclination":    deb.inclination,
         "eccentricity":   deb.eccentricity,
         "semimajor_axis": deb.semimajor_axis,
-        "raan":           None,
-        "arg_of_perigee": None,
-        "mean_anomaly":   None,
+        "raan":           raan,
+        "arg_of_perigee": arg_of_perigee,
+        "mean_anomaly":   mean_anomaly,
         "mean_motion":    deb.meanMotion,
         "period":         deb.period,
         "has_tle":        bool(deb.tle_line1 and deb.tle_line2),

--- a/frontend/src/components/EarthTwin.tsx
+++ b/frontend/src/components/EarthTwin.tsx
@@ -17,6 +17,16 @@ import {
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 import { executeVoiceCommand } from '../lib/voiceCommands';
 import { SpotlightManager } from './SatelliteSpotlight/SpotlightManager';
+import { deriveOrbitRegime, type OrbitRegime } from '@/types/orbitLayers';
+import {
+  deriveObjectCategory,
+  getObjectCategoryCss,
+  isObjectCategoryVisible,
+  OBJECT_CATEGORY_INFO,
+  type ObjectCategory,
+} from '@/types/objectCategories';
+import { useLayerStore } from '@/store/layerStore';
+import { LayerManagerPanel } from './OrbitLayers/LayerManagerPanel';
 
 interface CatalogObject {
   id: number;
@@ -101,6 +111,16 @@ const CATEGORY_COLORS = {
   SELECTED: { css: '#00E5FF', cesium: Cesium.Color.fromCssColorString('#00E5FF'), label: 'Selected', icon: 'gps_fixed' },
 } as const;
 
+/** Cesium colors aligned with Layer Manager toggle accents. */
+const OBJECT_CATEGORY_CESIUM: Record<ObjectCategory, Cesium.Color> = {
+  NAVIGATION: Cesium.Color.fromCssColorString(OBJECT_CATEGORY_INFO.NAVIGATION.css),
+  WEATHER: Cesium.Color.fromCssColorString(OBJECT_CATEGORY_INFO.WEATHER.css),
+  MILITARY: Cesium.Color.fromCssColorString(OBJECT_CATEGORY_INFO.MILITARY.css),
+  SPACE_DEBRIS: Cesium.Color.fromCssColorString(OBJECT_CATEGORY_INFO.SPACE_DEBRIS.css),
+  ROCKET_BODY: Cesium.Color.fromCssColorString(OBJECT_CATEGORY_INFO.ROCKET_BODY.css),
+  OTHER: Cesium.Color.fromCssColorString(OBJECT_CATEGORY_INFO.OTHER.css),
+};
+
 function getPointSize(classification: string): number {
   switch (classification) {
     case 'PAYLOAD': return 5;
@@ -150,6 +170,9 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
   const entitiesRef = useRef<Map<string, Cesium.Entity>>(new Map());
   const catalogMapRef = useRef<Map<string, CatalogObject>>(new Map());
   const collisionSetRef = useRef<Set<string>>(new Set());
+  const regimeMapRef = useRef<Map<string, OrbitRegime>>(new Map());
+  const categoryMapRef = useRef<Map<string, ObjectCategory>>(new Map());
+  const collisionLinesRef = useRef<{ entity: Cesium.Entity; objectA: string; objectB: string }[]>([]);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [viewerInstance, setViewerInstance] = useState<Cesium.Viewer | null>(null);
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
@@ -167,7 +190,12 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
   const [showLegend, setShowLegend] = useState(true);
   const [showDensity, setShowDensity] = useState(false);
   const [showRiskOverlay, setShowRiskOverlay] = useState(false);
-  const [objectCounts, setObjectCounts] = useState({ payloads: 0, debris: 0, rocketBodies: 0, total: 0, collisions: 0 });
+  const [showLayerManager, setShowLayerManager] = useState(false);
+  const [objectCounts, setObjectCounts] = useState({
+    navigation: 0, weather: 0, military: 0, debris: 0, rocketBodies: 0, other: 0,
+    total: 0, collisions: 0,
+    leo: 0, meo: 0, geo: 0, heo: 0,
+  });
   const [dataLoaded, setDataLoaded] = useState(false);
   const [isBookmarkModalOpen, setIsBookmarkModalOpen] = useState(false);
   const [isBookmarkSidebarOpen, setIsBookmarkSidebarOpen] = useState(false);
@@ -254,9 +282,13 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
         if (c.object_b?.catalog_number) collisionCatNums.add(c.object_b.catalog_number);
       });
 
-      let payloads = 0, debris = 0, rocketBodies = 0;
+      let navigation = 0, weather = 0, military = 0, debris = 0, rocketBodies = 0, other = 0;
+      let leo = 0, meo = 0, geo = 0, heo = 0;
       const entityMap = new Map<string, Cesium.Entity>();
       const catalogMap = new Map<string, CatalogObject>();
+      const regimeMap = new Map<string, OrbitRegime>();
+      const categoryMap = new Map<string, ObjectCategory>();
+      const collisionLines: { entity: Cesium.Entity; objectA: string; objectB: string }[] = [];
 
 
       if (!viewer || viewer.isDestroyed()) return;
@@ -264,20 +296,30 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
 
       viewer.entities.removeAll();
       const nowJulian = Cesium.JulianDate.now();
+      const { categoryVisibility: catVis, regimeVisibility: regVis } = useLayerStore.getState();
       objects.forEach(obj => {
         const pos = keplerToLatLonAlt(obj);
         if (!pos) return;
 
+        const objectCategory = deriveObjectCategory(obj);
+        if (objectCategory === 'NAVIGATION') navigation++;
+        else if (objectCategory === 'WEATHER') weather++;
+        else if (objectCategory === 'MILITARY') military++;
+        else if (objectCategory === 'SPACE_DEBRIS') debris++;
+        else if (objectCategory === 'ROCKET_BODY') rocketBodies++;
+        else other++;
 
-        if (obj.classification === 'PAYLOAD') payloads++;
-        else if (obj.classification === 'DEBRIS') debris++;
-        else if (obj.classification === 'ROCKET_BODY') rocketBodies++;
+        const regime = deriveOrbitRegime(obj);
+        if (regime === 'LEO') leo++;
+        else if (regime === 'MEO') meo++;
+        else if (regime === 'GEO') geo++;
+        else if (regime === 'HEO') heo++;
 
 
         const isCollisionRisk = collisionCatNums.has(obj.catalog_number);
-        const colorConfig = isCollisionRisk
-          ? CATEGORY_COLORS.COLLISION
-          : CATEGORY_COLORS[obj.classification] ?? CATEGORY_COLORS.UNKNOWN;
+        const markerColor = isCollisionRisk
+          ? CATEGORY_COLORS.COLLISION.cesium
+          : OBJECT_CATEGORY_CESIUM[objectCategory];
 
         const pixelSize = isCollisionRisk ? 8 : getPointSize(obj.classification);
         const outlineWidth = isCollisionRisk ? 3 : getOutlineWidth(obj.classification);
@@ -285,12 +327,16 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
         const cartPos = Cesium.Cartesian3.fromDegrees(pos.lon, pos.lat, pos.alt * 1000);
         const sunlit = isSatelliteSunlit(cartPos, nowJulian, viewer.scene.globe);
 
+        const initiallyVisible =
+          isObjectCategoryVisible(objectCategory, catVis) && (regVis[regime] ?? true);
+
         const entity = viewer.entities.add({
           position: cartPos,
+          show: initiallyVisible,
           point: {
             pixelSize,
-            color: sunlit ? colorConfig.cesium.withAlpha(0.85) : colorConfig.cesium.withAlpha(0.3),
-            outlineColor: sunlit ? colorConfig.cesium.withAlpha(0.4) : colorConfig.cesium.withAlpha(0.1),
+            color: sunlit ? markerColor.withAlpha(0.85) : markerColor.withAlpha(0.3),
+            outlineColor: sunlit ? markerColor.withAlpha(0.4) : markerColor.withAlpha(0.1),
             outlineWidth,
             disableDepthTestDistance: Number.POSITIVE_INFINITY,
             scaleByDistance: new Cesium.NearFarScalar(1e6, 1.5, 5e7, 0.4),
@@ -298,7 +344,9 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
           properties: new Cesium.PropertyBag({
             catalogData: JSON.stringify(obj),
             objectType: obj.classification,
+            objectCategory,
             isCollisionRisk,
+            orbitRegime: regime,
           }),
           label: {
             text: '',
@@ -308,6 +356,8 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
 
         entityMap.set(obj.catalog_number, entity);
         catalogMap.set(obj.catalog_number, obj);
+        regimeMap.set(obj.catalog_number, regime);
+        categoryMap.set(obj.catalog_number, objectCategory);
       });
 
 
@@ -321,7 +371,7 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
         const posB = entityB.position.getValue(Cesium.JulianDate.now());
         if (!posA || !posB) return;
 
-        viewer.entities.add({
+        const lineEntity = viewer.entities.add({
           polyline: {
             positions: [posA, posB],
             width: 2,
@@ -331,18 +381,29 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
             }),
           },
         });
+        collisionLines.push({ entity: lineEntity, objectA: conj.object_a.catalog_number, objectB: conj.object_b.catalog_number });
       });
 
       entitiesRef.current = entityMap;
       catalogMapRef.current = catalogMap;
       collisionSetRef.current = collisionCatNums;
+      regimeMapRef.current = regimeMap;
+      categoryMapRef.current = categoryMap;
+      collisionLinesRef.current = collisionLines;
       setDatasetVersion(v => v + 1);
       setObjectCounts({
-        payloads,
+        navigation,
+        weather,
+        military,
         debris,
         rocketBodies,
+        other,
         total: objects.length,
         collisions: collisions.length,
+        leo,
+        meo,
+        geo,
+        heo,
       });
       setStats({
         totalObjects: objects.length,
@@ -563,8 +624,16 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
     let handler: Cesium.ScreenSpaceEventHandler | null = null;
 
     try {
+      // Use Cesium's bundled Natural Earth II tiles so the globe works
+      // without a Cesium ion access token (avoids api.cesium.com 401s).
       const viewer = new Cesium.Viewer(containerRef.current, {
         animation: false,
+        baseLayer: Cesium.ImageryLayer.fromProviderAsync(
+          Cesium.TileMapServiceImageryProvider.fromUrl(
+            Cesium.buildModuleUrl('Assets/Textures/NaturalEarthII')
+          ),
+          {}
+        ),
         baseLayerPicker: false,
         fullscreenButton: false,
         vrButton: false,
@@ -712,6 +781,34 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const categoryVisibility = useLayerStore((s) => s.categoryVisibility);
+  const regimeVisibility = useLayerStore((s) => s.regimeVisibility);
+
+  // Applies the current layer-manager toggle state to entities Cesium has
+  // already created. Mutating `.show` here (instead of refetching/re-running
+  // populateEntities) keeps toggling instant and network-free. Re-runs on
+  // datasetVersion so toggle state survives the periodic 5-minute refetch,
+  // which recreates every entity from scratch.
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    if (!viewer || viewer.isDestroyed()) return;
+
+    const visibleIds = new Set<string>();
+    entitiesRef.current.forEach((entity, catNum) => {
+      const regime = regimeMapRef.current.get(catNum) ?? 'LEO';
+      const objectCategory = categoryMapRef.current.get(catNum) ?? 'OTHER';
+      const visible =
+        isObjectCategoryVisible(objectCategory, categoryVisibility) &&
+        (regimeVisibility[regime] ?? true);
+      entity.show = visible;
+      if (visible) visibleIds.add(catNum);
+    });
+    collisionLinesRef.current.forEach(({ entity, objectA, objectB }) => {
+      entity.show = visibleIds.has(objectA) && visibleIds.has(objectB);
+    });
+    viewer.scene.requestRender();
+  }, [categoryVisibility, regimeVisibility, datasetVersion]);
+
   // Mirrors the double-click fly-to in useSatelliteSelection.ts, but
   // triggerable from outside the globe (e.g. a dashboard card) instead of
   // from a Cesium pick event.
@@ -732,6 +829,9 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
   }, []);
 
   useImperativeHandle(ref, () => ({ flyToSatellite }), [flyToSatellite]);
+
+  const hoveredCategory = hoveredObject ? deriveObjectCategory(hoveredObject) : 'OTHER';
+  const hoveredCategoryLabel = OBJECT_CATEGORY_INFO[hoveredCategory].label;
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-bg-deep-space border-b border-border-panel">
@@ -785,7 +885,7 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
             <div className="flex items-center gap-2 mb-2">
               <span
                 className="w-2.5 h-2.5 rounded-full animate-pulse"
-                style={{ backgroundColor: CATEGORY_COLORS[hoveredObject.classification]?.css ?? '#888' }}
+                style={{ backgroundColor: getObjectCategoryCss(hoveredCategory) }}
               />
               <span className="font-technical-data text-xs font-bold text-primary-container">
                 {hoveredObject.name}
@@ -794,7 +894,7 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
             <div className="grid grid-cols-2 gap-x-4 gap-y-1 font-technical-data text-[10px]">
               {[
                 ['NORAD ID', hoveredObject.catalog_number],
-                ['TYPE', hoveredObject.classification],
+                ['TYPE', hoveredCategoryLabel],
                 ['ALTITUDE', hoveredObject.semimajor_axis ? `${Math.round(hoveredObject.semimajor_axis - 6371).toLocaleString()} km` : '—'],
                 ['INCLINATION', hoveredObject.inclination != null ? `${hoveredObject.inclination.toFixed(2)}°` : '—'],
                 ['MEAN MOTION', hoveredObject.mean_motion != null ? `${hoveredObject.mean_motion.toFixed(4)} rev/d` : '—'],
@@ -977,6 +1077,14 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
             >
               RISK
             </button>
+            <button
+              onClick={() => setShowLayerManager(v => !v)}
+              aria-pressed={showLayerManager}
+              className={`px-2.5 md:px-4 py-2 md:py-2.5 font-bold text-[10px] md:text-xs transition-ui active:scale-95 cursor-pointer border ${showLayerManager ? 'bg-primary-container text-bg-deep-space border-primary-container' : 'border-primary-container text-primary-container hover:bg-primary-container/10'
+                }`}
+            >
+              LAYERS
+            </button>
           </div>
         </div>
       </div>
@@ -994,9 +1102,12 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
               </div>
               <div className="space-y-2">
                 {[
-                  { color: CATEGORY_COLORS.PAYLOAD.css, label: 'Active Satellites', count: objectCounts.payloads },
-                  { color: CATEGORY_COLORS.DEBRIS.css, label: 'Debris Objects', count: objectCounts.debris },
-                  { color: CATEGORY_COLORS.ROCKET_BODY.css, label: 'Rocket Bodies', count: objectCounts.rocketBodies },
+                  { color: OBJECT_CATEGORY_INFO.NAVIGATION.css, label: OBJECT_CATEGORY_INFO.NAVIGATION.label, count: objectCounts.navigation },
+                  { color: OBJECT_CATEGORY_INFO.WEATHER.css, label: OBJECT_CATEGORY_INFO.WEATHER.label, count: objectCounts.weather },
+                  { color: OBJECT_CATEGORY_INFO.MILITARY.css, label: OBJECT_CATEGORY_INFO.MILITARY.label, count: objectCounts.military },
+                  { color: OBJECT_CATEGORY_INFO.SPACE_DEBRIS.css, label: OBJECT_CATEGORY_INFO.SPACE_DEBRIS.label, count: objectCounts.debris },
+                  { color: OBJECT_CATEGORY_INFO.ROCKET_BODY.css, label: OBJECT_CATEGORY_INFO.ROCKET_BODY.label, count: objectCounts.rocketBodies },
+                  { color: OBJECT_CATEGORY_INFO.OTHER.css, label: OBJECT_CATEGORY_INFO.OTHER.label, count: objectCounts.other },
                   { color: CATEGORY_COLORS.COLLISION.css, label: 'Collision Risks', count: objectCounts.collisions },
                 ].map(item => (
                   <div key={item.label} className="flex items-center justify-between gap-3">
@@ -1016,6 +1127,26 @@ export const EarthTwin = forwardRef<EarthTwinHandle>((_props, ref) => {
               </div>
             </div>
           ) : (<LegendCardSkeleton />)}
+        </div>
+      )}
+
+      {/* ── Orbit Layer Manager Panel ──────────────────────────── */}
+      {/* Bounded by the HUD's top status row and bottom button row so the
+          panel can never overflow the globe section and be clipped. */}
+      {showLayerManager && (
+        <div className="absolute top-14 sm:top-20 bottom-16 md:bottom-24 right-3 md:right-6 z-20 flex items-start justify-end pointer-events-none animate-[slideUp_0.3s_ease-out]">
+          <LayerManagerPanel
+            onClose={() => setShowLayerManager(false)}
+            regimeCounts={{ LEO: objectCounts.leo, MEO: objectCounts.meo, GEO: objectCounts.geo, HEO: objectCounts.heo }}
+            categoryCounts={{
+              NAVIGATION: objectCounts.navigation,
+              WEATHER: objectCounts.weather,
+              MILITARY: objectCounts.military,
+              SPACE_DEBRIS: objectCounts.debris,
+              ROCKET_BODY: objectCounts.rocketBodies,
+              OTHER: objectCounts.other,
+            }}
+          />
         </div>
       )}
 

--- a/frontend/src/components/OrbitLayers/LayerManagerPanel.tsx
+++ b/frontend/src/components/OrbitLayers/LayerManagerPanel.tsx
@@ -1,0 +1,105 @@
+import { MaterialIcon } from '../MaterialIcon';
+import { ToggleSwitch } from '../ui/ToggleSwitch';
+import { useLayerStore } from '@/store/layerStore';
+import { ORBIT_REGIMES, type OrbitRegime } from '@/types/orbitLayers';
+import {
+  OBJECT_CATEGORIES,
+  OBJECT_CATEGORY_INFO,
+  type ObjectCategory,
+} from '@/types/objectCategories';
+
+interface LayerManagerPanelProps {
+  onClose: () => void;
+  regimeCounts: Record<OrbitRegime, number>;
+  categoryCounts: Record<ObjectCategory, number>;
+}
+
+export function LayerManagerPanel({ onClose, regimeCounts, categoryCounts }: LayerManagerPanelProps) {
+  const categoryVisibility = useLayerStore((s) => s.categoryVisibility);
+  const regimeVisibility = useLayerStore((s) => s.regimeVisibility);
+  const toggleCategory = useLayerStore((s) => s.toggleCategory);
+  const toggleRegime = useLayerStore((s) => s.toggleRegime);
+
+  return (
+    <section
+      role="region"
+      aria-label="Orbit layer visibility controls"
+      className="pointer-events-auto flex max-h-full min-h-0 flex-col bg-bg-deep-space/90 backdrop-blur-xl border border-border-panel p-4 min-w-[220px] shadow-[0_0_30px_rgba(0,0,0,0.6)]"
+    >
+      <div className="flex justify-between items-center mb-3 shrink-0">
+        <span className="font-label-caps text-[10px] text-primary-container font-bold tracking-widest">
+          ORBIT LAYERS
+        </span>
+        <button
+          onClick={onClose}
+          aria-label="Close layer manager"
+          className="text-on-surface-variant/60 hover:text-on-surface cursor-pointer"
+        >
+          <MaterialIcon name="close" className="text-xs" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto custom-scrollbar pr-1">
+        <div role="group" aria-labelledby="orbit-region-heading" className="mb-4">
+          <div id="orbit-region-heading" className="font-label-caps text-[9px] text-on-surface-variant/60 tracking-widest mb-2">
+            ORBIT REGION
+          </div>
+          <div className="space-y-2">
+            {ORBIT_REGIMES.map((regime) => (
+              <div key={regime} className="flex items-center justify-between gap-3">
+                <span className="font-technical-data text-[11px] text-on-surface-variant">{regime}</span>
+                <div className="flex items-center gap-2">
+                  <span className="font-technical-data text-[11px] font-bold text-on-surface">
+                    {regimeCounts[regime].toLocaleString()}
+                  </span>
+                  <ToggleSwitch
+                    checked={regimeVisibility[regime]}
+                    onChange={() => toggleRegime(regime)}
+                    label={`Toggle ${regime} visibility`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div role="group" aria-labelledby="object-category-heading">
+          <div id="object-category-heading" className="font-label-caps text-[9px] text-on-surface-variant/60 tracking-widest mb-2">
+            OBJECT CATEGORY
+          </div>
+          <div className="space-y-2">
+            {OBJECT_CATEGORIES.map((category) => {
+              const info = OBJECT_CATEGORY_INFO[category];
+              return (
+                <div key={category} className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="w-3 h-3 rounded-full shrink-0"
+                      style={{ backgroundColor: info.css, boxShadow: `0 0 8px ${info.css}60` }}
+                    />
+                    <span className="font-technical-data text-[11px] text-on-surface-variant">{info.label}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-technical-data text-[11px] font-bold text-on-surface">
+                      {categoryCounts[category].toLocaleString()}
+                    </span>
+                    <ToggleSwitch
+                      checked={categoryVisibility[category]}
+                      onChange={() => toggleCategory(category)}
+                      label={`Toggle ${info.label} visibility`}
+                      accentColor={info.css}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 pt-2 shrink-0 border-t border-border-panel/40 text-[9px] text-on-surface-variant/50 font-technical-data">
+        Filters apply instantly · Saved for this session
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/ui/ToggleSwitch.tsx
+++ b/frontend/src/components/ui/ToggleSwitch.tsx
@@ -1,0 +1,30 @@
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+  accentColor?: string;
+  disabled?: boolean;
+}
+
+export function ToggleSwitch({ checked, onChange, label, accentColor, disabled }: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-ui focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-container focus-visible:ring-offset-2 focus-visible:ring-offset-bg-deep-space ${
+        disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
+      } ${checked ? 'border-transparent' : 'bg-surface-container-high border-border-panel'}`}
+      style={checked ? { backgroundColor: accentColor ?? 'var(--color-primary-container)' } : undefined}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-on-surface transition-ui ${
+          checked ? 'translate-x-[18px]' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  );
+}

--- a/frontend/src/constants/objectCategories.ts
+++ b/frontend/src/constants/objectCategories.ts
@@ -1,0 +1,12 @@
+/**
+ * Re-exports layer-manager category constants from the shared types module
+ * so existing `@/constants/objectCategories` imports keep working.
+ */
+export {
+  OBJECT_CATEGORIES,
+  OBJECT_CATEGORY_INFO,
+  deriveObjectCategory,
+  getObjectCategoryCss,
+  isObjectCategoryVisible,
+  type ObjectCategory,
+} from '@/types/objectCategories';

--- a/frontend/src/hooks/useSpotlightEffect.ts
+++ b/frontend/src/hooks/useSpotlightEffect.ts
@@ -4,6 +4,7 @@ import type { CatalogObject } from '@/types/satellite';
 import { applyBaseline, applyDim, applyHighlight, type PointBaseline } from '@/components/SatelliteSpotlight/GlowEffect';
 import { setOrbitHighlight, clearOrbitHighlight } from '@/components/SatelliteSpotlight/OrbitHighlight';
 import { CATEGORY_COLORS, getOutlineWidth, getPointSize } from '@/lib/satelliteVisuals';
+import { deriveObjectCategory, getObjectCategoryCss } from '@/types/objectCategories';
 
 interface UseSpotlightEffectArgs {
   viewer: Cesium.Viewer | null;
@@ -20,11 +21,13 @@ function baselineFor(id: string, catalogMap: Map<string, CatalogObject>, collisi
   const obj = catalogMap.get(id);
   if (!obj) return null;
   const isCollisionRisk = collisionSet.has(id);
-  const colorConfig = isCollisionRisk ? CATEGORY_COLORS.COLLISION : CATEGORY_COLORS[obj.classification] ?? CATEGORY_COLORS.UNKNOWN;
+  const markerColor = isCollisionRisk
+    ? CATEGORY_COLORS.COLLISION.cesium
+    : Cesium.Color.fromCssColorString(getObjectCategoryCss(deriveObjectCategory(obj)));
   return {
-    color: colorConfig.cesium,
+    color: markerColor,
     pixelSize: isCollisionRisk ? 8 : getPointSize(obj.classification),
-    outlineColor: colorConfig.cesium,
+    outlineColor: markerColor,
     outlineWidth: isCollisionRisk ? 3 : getOutlineWidth(obj.classification),
   };
 }

--- a/frontend/src/store/layerStore.ts
+++ b/frontend/src/store/layerStore.ts
@@ -1,0 +1,73 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { OrbitRegime } from '@/types/orbitLayers';
+import type { ObjectCategory } from '@/types/objectCategories';
+import { OBJECT_CATEGORIES } from '@/types/objectCategories';
+
+export type { ObjectCategory };
+
+interface LayerState {
+  categoryVisibility: Record<ObjectCategory, boolean>;
+  regimeVisibility: Record<OrbitRegime, boolean>;
+  toggleCategory: (key: ObjectCategory) => void;
+  toggleRegime: (key: OrbitRegime) => void;
+  resetLayers: () => void;
+}
+
+const defaultCategoryVisibility: Record<ObjectCategory, boolean> = {
+  NAVIGATION: true,
+  WEATHER: true,
+  MILITARY: true,
+  SPACE_DEBRIS: true,
+  ROCKET_BODY: true,
+  OTHER: true,
+};
+
+const defaultRegimeVisibility: Record<OrbitRegime, boolean> = {
+  LEO: true,
+  MEO: true,
+  GEO: true,
+  HEO: true,
+};
+
+export const useLayerStore = create<LayerState>()(
+  persist(
+    (set) => ({
+      categoryVisibility: defaultCategoryVisibility,
+      regimeVisibility: defaultRegimeVisibility,
+      toggleCategory: (key) =>
+        set((state) => ({
+          categoryVisibility: { ...state.categoryVisibility, [key]: !state.categoryVisibility[key] },
+        })),
+      toggleRegime: (key) =>
+        set((state) => ({
+          regimeVisibility: { ...state.regimeVisibility, [key]: !state.regimeVisibility[key] },
+        })),
+      resetLayers: () =>
+        set({ categoryVisibility: defaultCategoryVisibility, regimeVisibility: defaultRegimeVisibility }),
+    }),
+    {
+      // v2: ObjectCategory keys changed from catalog classifications to mission layers
+      name: 'kepler-orbit-layers-v2',
+      storage: createJSONStorage(() => sessionStorage),
+      merge: (persisted, current) => {
+        const p = persisted as Partial<LayerState> | undefined;
+        const categoryVisibility = { ...defaultCategoryVisibility };
+        for (const key of OBJECT_CATEGORIES) {
+          if (p?.categoryVisibility && typeof p.categoryVisibility[key] === 'boolean') {
+            categoryVisibility[key] = p.categoryVisibility[key];
+          }
+        }
+        return {
+          ...current,
+          ...p,
+          categoryVisibility,
+          regimeVisibility: {
+            ...defaultRegimeVisibility,
+            ...(p?.regimeVisibility ?? {}),
+          },
+        };
+      },
+    }
+  )
+);

--- a/frontend/src/stories/LayerManagerPanel.stories.tsx
+++ b/frontend/src/stories/LayerManagerPanel.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LayerManagerPanel } from "@/components/OrbitLayers/LayerManagerPanel";
+
+const meta: Meta<typeof LayerManagerPanel> = {
+  title: "Globe/Layer Manager Panel",
+  component: LayerManagerPanel,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Floating panel docked over the 3D globe, letting users toggle orbit-region and object-category visibility layers in real time.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LayerManagerPanel>;
+
+const Wrapper = (args: React.ComponentProps<typeof LayerManagerPanel>) => (
+  <div className="relative h-[420px] w-[320px] bg-[#05070C] flex items-end justify-end p-4">
+    <LayerManagerPanel {...args} />
+  </div>
+);
+
+export const Default: Story = {
+  render: Wrapper,
+  args: {
+    onClose: () => {},
+    regimeCounts: { LEO: 4200, MEO: 180, GEO: 560, HEO: 40 },
+    categoryCounts: {
+      NAVIGATION: 420,
+      WEATHER: 180,
+      MILITARY: 260,
+      SPACE_DEBRIS: 1200,
+      ROCKET_BODY: 340,
+      OTHER: 2140,
+    },
+  },
+};

--- a/frontend/src/stories/ToggleSwitch.stories.tsx
+++ b/frontend/src/stories/ToggleSwitch.stories.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ToggleSwitch } from "@/components/ui/ToggleSwitch";
+
+const meta: Meta<typeof ToggleSwitch> = {
+  title: "UI/Toggle Switch",
+  component: ToggleSwitch,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Accessible on/off switch used by the Orbit Layer Manager panel to toggle globe visibility layers.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToggleSwitch>;
+
+const Interactive = (args: React.ComponentProps<typeof ToggleSwitch>) => {
+  const [checked, setChecked] = useState(args.checked);
+  return (
+    <div className="bg-bg-deep-space p-6">
+      <ToggleSwitch {...args} checked={checked} onChange={setChecked} />
+    </div>
+  );
+};
+
+export const On: Story = {
+  render: Interactive,
+  args: {
+    checked: true,
+    label: "Active Satellites",
+  },
+};
+
+export const Off: Story = {
+  render: Interactive,
+  args: {
+    checked: false,
+    label: "Active Satellites",
+  },
+};
+
+export const Disabled: Story = {
+  render: Interactive,
+  args: {
+    checked: true,
+    label: "Active Satellites",
+    disabled: true,
+  },
+};

--- a/frontend/src/types/objectCategories.ts
+++ b/frontend/src/types/objectCategories.ts
@@ -1,0 +1,135 @@
+/**
+ * Layer-manager object categories from the Orbit Layer Manager feature.
+ * These are UI/filter buckets — not the raw catalog `classification` field.
+ */
+export type ObjectCategory =
+  | 'NAVIGATION'
+  | 'WEATHER'
+  | 'MILITARY'
+  | 'SPACE_DEBRIS'
+  | 'ROCKET_BODY'
+  | 'OTHER';
+
+export const OBJECT_CATEGORIES: ObjectCategory[] = [
+  'NAVIGATION',
+  'WEATHER',
+  'MILITARY',
+  'SPACE_DEBRIS',
+  'ROCKET_BODY',
+  'OTHER',
+];
+
+export const OBJECT_CATEGORY_INFO: Record<ObjectCategory, { css: string; label: string }> = {
+  NAVIGATION: { css: '#4CD6F0', label: 'Navigation Satellites' },
+  WEATHER: { css: '#34C759', label: 'Weather Satellites' },
+  MILITARY: { css: '#9D7BFF', label: 'Military Satellites' },
+  SPACE_DEBRIS: { css: '#FFAA00', label: 'Space Debris' },
+  ROCKET_BODY: { css: '#FF4444', label: 'Rocket Bodies' },
+  OTHER: { css: '#8793AC', label: 'Other Objects' },
+};
+
+/** CSS hex used for globe markers / toggles for a derived category. */
+export function getObjectCategoryCss(category: ObjectCategory): string {
+  return OBJECT_CATEGORY_INFO[category].css;
+}
+
+const NAVIGATION_PATTERNS = [
+  /\bgps\b/i,
+  /\bnavstar\b/i,
+  /\bglonass\b/i,
+  /\bgalileo\b/i,
+  /\bbeidou\b/i,
+  /\bcompass\b/i,
+  /\bqzss\b/i,
+  /\bmichibiki\b/i,
+  /\birnss\b/i,
+  /\bnavic\b/i,
+  /\bwaas\b/i,
+  /\begnos\b/i,
+  /\bmsas\b/i,
+  /\bgagan\b/i,
+];
+
+const WEATHER_PATTERNS = [
+  /\bgoes\b/i,
+  /\bnoaa\b/i,
+  /\bmetop\b/i,
+  /\bmeteo\b/i,
+  /\bhimawari\b/i,
+  /\bfengyun\b/i,
+  /\bfy[- ]?\d/i,
+  /\bmsg[- ]?\d/i,
+  /\bmeteosat\b/i,
+  /\binsat\b/i,
+  /\belectro[- ]?l\b/i,
+  /\bsuomi\b/i,
+  /\bnpp\b/i,
+  /\bjpss\b/i,
+  /\bdmsp\b/i,
+  /\bterra\b/i,
+  /\baqua\b/i,
+  /\bgpm\b/i,
+  /\bcloudsat\b/i,
+  /\bcalipso\b/i,
+];
+
+const MILITARY_PATTERNS = [
+  /\busa[- ]?\d/i,
+  /\bnrol\b/i,
+  /\bno[- ]?ss\b/i,
+  /\blacrosse\b/i,
+  /\bonyx\b/i,
+  /\bmentor\b/i,
+  /\borion\b/i,
+  /\bsbss\b/i,
+  /\bdds\b/i,
+  /\bmilstar\b/i,
+  /\baehf\b/i,
+  /\bwgs\b/i,
+  /\bmuos\b/i,
+  /\bskynet\b/i,
+  /\bsyracuse\b/i,
+  /\bsicral\b/i,
+  /\bcosmos[- ]?\d/i, // many Russian military; imperfect but commonly used
+  /\bkh[- ]?\d/i,
+  /\bkeyhole\b/i,
+  /\bintruder\b/i,
+  /\bgapfiller\b/i,
+  /\bsbirs\b/i,
+  /\bgssap\b/i,
+];
+
+function matchesAny(name: string, patterns: RegExp[]): boolean {
+  return patterns.some((re) => re.test(name));
+}
+
+/**
+ * Maps a catalog object onto a layer-manager category.
+ * Debris / rocket bodies come from classification; payload mission type is
+ * inferred from the object name because the API does not expose mission role.
+ *
+ * Payloads that match no mission pattern fall into 'OTHER' so every tracked
+ * object belongs to exactly one toggleable layer.
+ */
+export function deriveObjectCategory(obj: {
+  name: string;
+  classification: 'PAYLOAD' | 'DEBRIS' | 'ROCKET_BODY' | 'UNKNOWN';
+}): ObjectCategory {
+  if (obj.classification === 'DEBRIS') return 'SPACE_DEBRIS';
+  if (obj.classification === 'ROCKET_BODY') return 'ROCKET_BODY';
+
+  const name = obj.name ?? '';
+  if (matchesAny(name, NAVIGATION_PATTERNS)) return 'NAVIGATION';
+  if (matchesAny(name, WEATHER_PATTERNS)) return 'WEATHER';
+  if (matchesAny(name, MILITARY_PATTERNS)) return 'MILITARY';
+
+  return 'OTHER';
+}
+
+/** Visibility rule for a derived category. */
+export function isObjectCategoryVisible(
+  category: ObjectCategory,
+  visibility: Record<ObjectCategory, boolean>
+): boolean {
+  return visibility[category] ?? true;
+}

--- a/frontend/src/types/orbitLayers.ts
+++ b/frontend/src/types/orbitLayers.ts
@@ -1,0 +1,37 @@
+export type OrbitRegime = 'LEO' | 'MEO' | 'GEO' | 'HEO';
+
+export const ORBIT_REGIMES: OrbitRegime[] = ['LEO', 'MEO', 'GEO', 'HEO'];
+
+export const ORBIT_REGIME_LABELS: Record<OrbitRegime, string> = {
+  LEO: 'Low Earth Orbit',
+  MEO: 'Medium Earth Orbit',
+  GEO: 'Geostationary Orbit',
+  HEO: 'Highly Elliptical Orbit',
+};
+
+const EARTH_RADIUS_KM = 6371;
+const HEO_ECCENTRICITY_THRESHOLD = 0.25;
+const GEO_ALTITUDE_MIN_KM = 35586;
+const MEO_ALTITUDE_MIN_KM = 2000;
+
+/**
+ * Orbit regime isn't a field the backend provides, so it's derived from the
+ * same Keplerian elements EarthTwin already uses to place objects on the
+ * globe. Eccentricity is checked first so a highly elliptical orbit is
+ * classified as HEO regardless of which altitude band its semimajor axis
+ * falls into (a Molniya-type orbit's SMA can land in the MEO band).
+ */
+export function deriveOrbitRegime(obj: {
+  semimajor_axis: number | null;
+  eccentricity: number | null;
+}): OrbitRegime {
+  if (obj.semimajor_axis == null) return 'LEO';
+
+  const altitude = obj.semimajor_axis - EARTH_RADIUS_KM;
+  const eccentricity = obj.eccentricity ?? 0;
+
+  if (eccentricity > HEO_ECCENTRICITY_THRESHOLD) return 'HEO';
+  if (altitude >= GEO_ALTITUDE_MIN_KM) return 'GEO';
+  if (altitude >= MEO_ALTITUDE_MIN_KM) return 'MEO';
+  return 'LEO';
+}


### PR DESCRIPTION
## **User description**
## Summary

Adds an interactive **Orbit Layer Manager** to the 3D globe (`EarthTwin`), letting users control which categories of space objects are rendered in real time.

**Layer manager UI** — A floating glass panel opened from a new `LAYERS` button in the globe HUD, with accessible `role="switch"` toggles (`ToggleSwitch`) and per-layer object counts:

- **Orbit regions:** LEO, MEO, GEO, HEO
- **Object categories:** Navigation Satellites, Weather Satellites, Military Satellites, Space Debris, Rocket Bodies, Other Objects

**Instant, network-free updates** — Toggling mutates `entity.show` on already-created Cesium entities rather than refetching or rebuilding the scene, so switching layers stays smooth across the full catalog. Newly created entities read current toggle state up front, so the periodic 5-minute catalog refresh doesn't flash hidden objects back on. Conjunction lines hide unless both endpoints are visible.

**Layer derivation** — Orbit regime is derived from Keplerian elements (`deriveOrbitRegime`, eccentricity-first so Molniya-type orbits classify as HEO). The API exposes no mission role, so Navigation/Weather/Military are inferred from object-name patterns (`deriveObjectCategory`), with debris and rocket bodies taken directly from `classification`. Every object resolves to exactly one layer, so category counts reconcile with the tracked total.

**Session persistence** — Visibility preferences live in a Zustand store persisted to `sessionStorage`, with a `merge` step so newly added layers default to visible instead of `undefined`.

**Visual consistency** — Globe markers, hover tooltips, spotlight highlight, and the orbital legend all draw from one `OBJECT_CATEGORY_INFO` palette, so a toggle's accent color matches its points on the globe.

Two supporting fixes were required to make the feature usable:

- **Backend (`catalog.py`):** `raan`, `arg_of_perigee`, and `mean_anomaly` were hardcoded to `null`, so objects storing only TLEs could not be placed on the globe. These are now parsed from TLE line 2 (fixed-width NORAD columns, with a whitespace-split fallback) when the dedicated columns are empty.
- **Cesium imagery:** The viewer defaulted to Cesium Ion World Imagery and failed with `401 INVALID_TOKEN`, leaving the globe blank. It now uses the bundled Natural Earth II tiles, so no Ion account or token is needed to run the project locally.

Storybook stories are included for `LayerManagerPanel` and `ToggleSwitch`.

## Related Issue

Fixes #<!-- issue number -->

## Type of Change

<!-- Select all that apply. -->

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🚀 Performance improvement
- [x] 🎨 UI/UX enhancement
- [ ] 🔧 Refactoring
- [ ] 🧹 Chore / Maintenance
- [ ] 🔒 Security improvement

## Screenshots / Screen Recordings

<!-- Add a short recording showing layers toggling on/off with the globe updating live. -->

## Testing Performed

<!-- Describe the tests you performed to verify your changes. -->

https://github.com/user-attachments/assets/bb6d5f2a-d4f7-4230-8035-740d880a62e0



- [x] Tested locally
- [x] Tested relevant functionality
- [x] Checked for linting errors
- [x] Checked for TypeScript/build errors
- [x] Tested responsive behavior (if applicable)

Verified against a running frontend and backend:

- Each of the four orbit-region and six object-category toggles hides and shows the matching objects immediately, with no page refresh or network request.
- Multiple layers stay active at once; region and category filters combine correctly.
- Panel counts match the legend, and the category counts sum to the tracked total.
- Preferences survive navigating away from and back to the dashboard within a session, and reset on a new session.
- Globe markers render with the same colors as their toggles; conjunction lines disappear when either endpoint is filtered out.
- Panel stays fully within the globe section at mobile and desktop widths, scrolling internally rather than being clipped by the header.
- `tsc -b` passes clean; no new lint warnings introduced.

## Breaking Changes

None for end users. Note for reviewers: the session-storage key changed to `kepler-orbit-layers-v2` because the category keys changed shape, so any preferences saved during earlier testing are discarded and fall back to all-visible defaults.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] My code follows the project's coding standards and guidelines.
- [x] I have completed testing of my changes.
- [ ] I have updated documentation where applicable.
- [x] I have checked that my changes do not introduce unintended regressions.

---

## ECSoC26 Submission

> **ECSoC26 contributors only** — select your difficulty level by checking exactly **one** box below.
> Leaving all boxes unchecked, or checking more than one, will cause the automation to fail.

- [ ] `ECSoC26-L1` – Beginner
- [x] `ECSoC26-L2` – Intermediate
- [ ] `ECSoC26-L3` – Advanced


___

## **CodeAnt-AI Description**
Add interactive orbit layer filters to the 3D globe

### What Changed
- Added a `LAYERS` control with instant toggles for LEO, MEO, GEO, and HEO regions plus navigation, weather, military, debris, rocket body, and other objects.
- Globe markers and collision lines now hide or appear according to the selected filters, without reloading data; collision lines remain visible only when both objects are shown.
- Updated marker colors, hover details, legends, and counts to use the new object categories and orbit regions.
- Visibility choices are retained for the current session and newly loaded objects follow the active filters.
- Orbital angles are now recovered from TLE data when catalog fields are empty, allowing affected objects to be positioned on the globe.
- The globe uses bundled map imagery, avoiding dependence on a Cesium access token for its base map.

### Impact
`✅ Instant globe layer filtering`
`✅ Clearer satellite and debris categories`
`✅ Fewer objects missing from the globe`
`✅ Layer choices preserved during the session`
`✅ Globe map loads without Cesium token errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Layers control for filtering objects by orbit region and category.
  * Added visibility counts, legends, category-based colors, and updated hover details.
  * Layer preferences persist during the session and can be reset.
  * Added accessible toggle controls and a scrollable Layer Manager panel.
  * Satellite orbital angles now display when available or derivable from TLE data.
  * Updated globe imagery with Natural Earth II styling.

* **Documentation**
  * Added Storybook examples for the Layer Manager and toggle controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->