### PR TITLE
Add Dark/Light theme toggle with persistent user preference (#127)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,8 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/Logo.svg" />
+    <script>
+      (function () {
+        try {
+          var stored = JSON.parse(localStorage.getItem('kepler-theme'));
+          if (stored && stored.state && stored.state.theme === 'light') {
+            document.documentElement.classList.add('light');
+          }
+        } catch (e) {}
+      })();
+    </script>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />    <link rel="apple-touch-icon" href="/Logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KEPLER | AI STRATEGIC COMMAND</title>
     <!-- Google Fonts & Material Icons -->

--- a/frontend/src/components/layouts/MainLayout.tsx
+++ b/frontend/src/components/layouts/MainLayout.tsx
@@ -6,7 +6,7 @@ import { DynamicBackground } from '@/components/DynamicBackground/DynamicBackgro
 import { LogbookPanel } from '@/components/Logbook/LogbookPanel';
 import { PerformanceOverlay } from '@/components/PerformanceOverlay/PerformanceOverlay';
 import { PerformanceToggleButton } from '@/components/PerformanceOverlay/PerformanceToggleButton';
-import { NotificationCenter } from '@/components/ui/NotificationCenter';
+import { ThemeToggle } from '@/components/ui/ThemeToggle';import { NotificationCenter } from '@/components/ui/NotificationCenter';
 import { CameraControls } from '@/components/ui/CameraControls';
 import { MaterialIcon } from '@/components/MaterialIcon';
 
@@ -246,8 +246,8 @@ export const MainLayout: React.FC = () => {
                 {utcTime}
               </div>
               <PerformanceToggleButton />
-              <div className="flex items-center gap-4">
-                <button
+              <ThemeToggle />
+              <div className="flex items-center gap-4">                <button
                   onClick={toggleRightDrawer}
                   className={`relative transition-ui cursor-pointer p-2 min-w-[44px] min-h-[44px] flex items-center justify-center ${rightDrawerOpen ? 'text-primary-container drop-shadow-[0_0_8px_rgba(0,229,255,0.6)]' : 'text-primary hover:text-primary-fixed'}`}
                 >

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useThemeStore } from '@/store/themeStore';
+import { MaterialIcon } from '@/components/MaterialIcon';
+
+export const ThemeToggle: React.FC = () => {
+  const theme = useThemeStore((s) => s.theme);
+  const toggleTheme = useThemeStore((s) => s.toggleTheme);
+  const isLight = theme === 'light';
+
+  return (
+    <button
+      onClick={toggleTheme}
+      title={`Switch to ${isLight ? 'dark' : 'light'} theme`}
+      aria-label={`Switch to ${isLight ? 'dark' : 'light'} theme`}
+      className="relative p-2 min-w-[44px] min-h-[44px] flex items-center justify-center text-primary hover:text-primary-fixed transition-ui cursor-pointer"
+    >
+      <MaterialIcon name={isLight ? 'dark_mode' : 'light_mode'} className="text-xl" />
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -7,14 +7,14 @@ import { useLayerStore } from './layerStore';
 import { useLogbookStore } from './logbookStore';
 import { useUIStore } from './uiStore';
 import { useOrbitalStore } from './orbitalStore';
-
+import { useThemeStore } from './themeStore';
 export { useAuthStore } from './authStore';
 export { useDataStore, type DataFilters, type RiskLevel, type TimeRangeOption } from './dataStore';
 export { useLayerStore, type ObjectCategory } from './layerStore';
 export { useLogbookStore, logEvent } from './logbookStore';
 export { useUIStore } from './uiStore';
 export { useOrbitalStore } from './orbitalStore';
-
+export { useThemeStore, type Theme } from './themeStore';
 // Fine-grained atomic selector hooks to prevent unnecessary React re-renders
 
 // Orbital Selectors
@@ -77,6 +77,9 @@ export function useGlobalSearchOpen(): boolean {
   return useUIStore((state) => state.globalSearchOpen);
 }
 
+export function useTheme(): Theme {
+  return useThemeStore((state) => state.theme);
+}
 // Layer Selectors
 export function useCategoryVisibility() {
   return useLayerStore((state) => state.categoryVisibility);

--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type Theme = 'dark' | 'light';
+
+const applyThemeClass = (theme: Theme) => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle('light', theme === 'light');
+};
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      theme: 'dark',
+      setTheme: (theme) => {
+        applyThemeClass(theme);
+        set({ theme });
+      },
+      toggleTheme: () => {
+        const next: Theme = get().theme === 'dark' ? 'light' : 'dark';
+        applyThemeClass(next);
+        set({ theme: next });
+      },
+    }),
+    {
+      name: 'kepler-theme',
+      onRehydrateStorage: () => (state) => {
+        if (state) applyThemeClass(state.theme);
+      },
+    }
+  )
+);

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -20,60 +20,59 @@ a{
 @theme {
   --color-on-primary: #00363d;
   --color-status-emergency: #FF3B30;
-  --color-inverse-surface: #dfe2eb;
+  --color-inverse-surface: var(--kepler-inverse-surface);
   --color-error: #ffb4ab;
   --color-inverse-primary: #006875;
   --color-on-primary-fixed-variant: #004f58;
-  --color-surface: #10141a;
+  --color-surface: var(--kepler-surface);
   --color-on-tertiary-fixed-variant: #594400;
   --color-on-primary-container: #00626e;
   --color-error-container: #93000a;
   --color-on-primary-fixed: #001f24;
-  --color-surface-bright: #353940;
-  --color-surface-variant: #31353c;
+  --color-surface-bright: var(--kepler-surface-bright);
+  --color-surface-variant: var(--kepler-surface-variant);
   --color-on-error: #690005;
   --color-secondary-container: #0044eb;
-  --color-background: #0C1220;
-  --color-outline-variant: #3b494c;
+  --color-background: var(--kepler-background);
+  --color-outline-variant: var(--kepler-outline-variant);
   --color-surface-tint: #00daf3;
-  --color-inverse-on-surface: #2d3137;
+  --color-inverse-on-surface: var(--kepler-inverse-on-surface);
   --color-tertiary-fixed: #ffdf96;
   --color-text-satellite: #F9FAFB;
   --color-primary-fixed: #9cf0ff;
   --color-tertiary: #ffeac0;
   --color-on-secondary: #002387;
   --color-on-tertiary-fixed: #251a00;
-  --color-on-surface: #dfe2eb;
+  --color-on-surface: var(--kepler-on-surface);
   --color-on-secondary-fixed: #001355;
   --color-tertiary-fixed-dim: #f3bf26;
   --color-on-tertiary: #3e2e00;
   --color-secondary-fixed: #dde1ff;
-  --color-on-background: #dfe2eb;
+  --color-on-background: var(--kepler-on-background);
   --color-secondary: #b8c3ff;
-  --color-surface-dim: #10141a;
+  --color-surface-dim: var(--kepler-surface-dim);
   --color-status-warning: #FF9500;
   --color-on-error-container: #ffdad6;
   --color-secondary-fixed-dim: #b8c3ff;
   --color-tertiary-container: #fec931;
-  --color-surface-container-lowest: #0a0e14;
-  --color-surface-container-highest: #31353c;
-  --color-outline: #849396;
-  --color-surface-container-low: #181c22;
+  --color-surface-container-lowest: var(--kepler-surface-container-lowest);
+  --color-surface-container-highest: var(--kepler-surface-container-highest);
+  --color-outline: var(--kepler-outline);
+  --color-surface-container-low: var(--kepler-surface-container-low);
   --color-primary: #c3f5ff;
-  --color-surface-container-high: #262a31;
-  --color-on-surface-variant: #bac9cc;
-  --color-bg-graphite: #05070A;
-  --color-text-muted: #9CA3AF;
+  --color-surface-container-high: var(--kepler-surface-container-high);
+  --color-on-surface-variant: var(--kepler-on-surface-variant);
+  --color-bg-graphite: var(--kepler-bg-graphite);
+  --color-text-muted: var(--kepler-text-muted);
   --color-primary-container: #00e5ff;
   --color-on-secondary-fixed-variant: #0035bd;
-  --color-surface-container: #1c2026;
-  --color-bg-deep-space: #0C1220;
+  --color-surface-container: var(--kepler-surface-container);
+  --color-bg-deep-space: var(--kepler-bg-deep-space);
   --color-status-success: #34C759;
   --color-primary-fixed-dim: #00daf3;
   --color-on-tertiary-container: #6f5500;
   --color-on-secondary-container: #c6cfff;
-  --color-border-panel: #1F2937;
-
+  --color-border-panel: var(--kepler-border-panel);
   --font-body-ui: "Inter", sans-serif;
   --font-label-caps: "IBM Plex Sans", sans-serif;
   --font-technical-data: "IBM Plex Sans", monospace;
@@ -97,14 +96,63 @@ a{
   }
 }
 
+/* Default (dark) theme — matches the app's original look */
+:root {
+  --kepler-background: #0C1220;
+  --kepler-surface: #10141a;
+  --kepler-surface-bright: #353940;
+  --kepler-surface-variant: #31353c;
+  --kepler-outline-variant: #3b494c;
+  --kepler-inverse-surface: #dfe2eb;
+  --kepler-inverse-on-surface: #2d3137;
+  --kepler-on-surface: #dfe2eb;
+  --kepler-on-background: #dfe2eb;
+  --kepler-surface-dim: #10141a;
+  --kepler-surface-container-lowest: #0a0e14;
+  --kepler-surface-container-highest: #31353c;
+  --kepler-outline: #849396;
+  --kepler-surface-container-low: #181c22;
+  --kepler-surface-container-high: #262a31;
+  --kepler-on-surface-variant: #bac9cc;
+  --kepler-bg-graphite: #05070A;
+  --kepler-text-muted: #9CA3AF;
+  --kepler-surface-container: #1c2026;
+  --kepler-bg-deep-space: #0C1220;
+  --kepler-border-panel: #1F2937;
+}
+
+/* Light theme — applied when <html> has class="light" */
+.light {
+  --kepler-background: #F4F6FA;
+  --kepler-surface: #FFFFFF;
+  --kepler-surface-bright: #FFFFFF;
+  --kepler-surface-variant: #E3E8ED;
+  --kepler-outline-variant: #C6CDD1;
+  --kepler-inverse-surface: #10141a;
+  --kepler-inverse-on-surface: #dfe2eb;
+  --kepler-on-surface: #171C22;
+  --kepler-on-background: #171C22;
+  --kepler-surface-dim: #DDE3EA;
+  --kepler-surface-container-lowest: #FFFFFF;
+  --kepler-surface-container-highest: #DEE2E8;
+  --kepler-outline: #6B7478;
+  --kepler-surface-container-low: #F6F8FB;
+  --kepler-surface-container-high: #E6E9EE;
+  --kepler-on-surface-variant: #495056;
+  --kepler-bg-graphite: #E9ECF1;
+  --kepler-text-muted: #6B7280;
+  --kepler-surface-container: #EEF1F5;
+  --kepler-bg-deep-space: #F4F6FA;
+  --kepler-border-panel: #D7DCE2;
+}
+
 @layer base {
   body {
-    background-color: #0C1220;
-    color: #dfe2eb;
+    background-color: var(--color-background);
+    color: var(--color-on-background);
     overflow: hidden;
   }
 }
-
 body {
   cursor: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSIjMDAwMDAwIiBzdHJva2U9IiMwMEU1RkYiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTUuNSAzLjIxVjIwLjhjMCAuNDUuNTQuNjcuODUuMzVsNC44Ni00Ljg2YS41LjUgMCAwIDEgLjM1LS4xNWg2Ljg3YS41LjUgMCAwIDAgLjM1LS44NUw2LjM1IDIuODVhLjUuNSAwIDAgMC0uODUuMzVaIj48L3BhdGg+PC9zdmc+"), auto;
 }
@@ -112,6 +160,17 @@ body {
   @apply transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)];
 }
 
+/* Smooth color/background transitions when the theme is toggled */
+body,
+header,
+aside,
+main,
+button,
+input,
+textarea,
+.glass-panel {
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
 .table-head {
   @apply p-4 font-label-caps text-on-surface-variant;
 }


### PR DESCRIPTION
## **User description**
## Summary
Closes #127

Adds a Dark/Light theme toggle to the top command bar, backed by CSS
variables so every page, panel, form, card, and modal that already
uses the app's semantic color tokens (bg-surface, text-on-surface,
border-border-panel, etc.) switches automatically — no per-component
changes needed.

## Changes
- `src/styles/index.css`: neutral color tokens (surface/background/
  outline/on-surface variants) now resolve from CSS custom properties
  defined once for `:root` (dark, default — identical to the current
  look) and once for `.light` (new light palette). Brand colors,
  status colors, and the Material "fixed" roles stay the same in both
  themes so the Kepler cyan accent is consistent either way. Added a
  short transition on common surfaces so switching themes fades
  instead of snapping.
- `src/store/themeStore.ts` (new): a Zustand store (matching the
  existing store pattern) that holds `theme: 'dark' | 'light'`,
  toggles the `light` class on `<html>`, and persists the choice to
  `localStorage` under `kepler-theme`.
- `src/store/index.ts`: wires up the new store and exports a
  `useTheme()` selector alongside the existing ones.
- `src/components/ui/ThemeToggle.tsx` (new): icon button (sun/moon)
  for switching themes.
- `src/components/layouts/MainLayout.tsx`: adds `<ThemeToggle />` to
  the top command bar next to the performance toggle.
- `index.html`: small inline script that applies the saved theme
  before first paint, so there's no flash of the wrong theme on
  reload.

## Notes for reviewers
- Default theme is still Dark, so existing users see zero visual
  change until they opt into Light.
- The light palette (in `index.css`) is a first pass, chosen for
  reasonable contrast — happy to adjust exact hex values if you'd
  like a different look.
- Not changed: the 3D globe/canvas visuals and status colors, which
  intentionally stay the same in both themes.

## Testing
- Manually toggled theme across Dashboard, Satellites, Settings,
  Sign In, and the AI Assistant drawer/modals; verified the choice
  survives a page reload.

Closes #127 

Please add the **ECSoC26** label before merging this PR so that my points are calculated correctly.
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.


___

## **CodeAnt-AI Description**
Add a persistent dark and light theme switcher

### What Changed
- Users can switch between dark and light themes from the top command bar
- The selected theme updates app backgrounds, panels, forms, borders, and text with a smooth transition
- The theme preference is saved and restored on later visits
- Saved light themes are applied before the page appears, avoiding a flash of dark styling

### Impact
`✅ User-controlled light and dark display`
`✅ Consistent colors across app screens`
`✅ No theme flash on reload`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dark/light theme toggle to the command bar.
  * Added persistent theme selection across sessions.
  * Applied the saved theme immediately when the app starts.
  * Updated colors and shared interface elements to transition smoothly between themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->